### PR TITLE
activate the microphone on demand

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -1,13 +1,16 @@
 use crate::managers::audio::AudioRecordingManager;
 use crate::managers::transcription::TranscriptionManager;
+use crate::settings::get_settings;
 use crate::utils;
 use crate::utils::change_tray_icon;
 use crate::utils::play_recording_start_sound;
 use crate::utils::play_recording_stop_sound;
 use crate::utils::TrayIconState;
+use log::debug;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Instant;
 use tauri::AppHandle;
 use tauri::Manager;
 
@@ -22,17 +25,54 @@ struct TranscribeAction;
 
 impl ShortcutAction for TranscribeAction {
     fn start(&self, app: &AppHandle, binding_id: &str, _shortcut_str: &str) {
+        let start_time = Instant::now();
+        debug!("TranscribeAction::start called for binding: {}", binding_id);
+
         let binding_id = binding_id.to_string();
         change_tray_icon(app, TrayIconState::Recording);
 
-        // Play audio feedback for recording start
-        play_recording_start_sound(app);
-
         let rm = app.state::<Arc<AudioRecordingManager>>();
-        rm.try_start_recording(&binding_id);
+
+        // Get the microphone mode to determine audio feedback timing
+        let settings = get_settings(app);
+        let is_always_on = settings.always_on_microphone;
+        debug!("Microphone mode - always_on: {}", is_always_on);
+
+        if is_always_on {
+            // Always-on mode: Play audio feedback immediately
+            debug!("Always-on mode: Playing audio feedback immediately");
+            play_recording_start_sound(app);
+            let recording_started = rm.try_start_recording(&binding_id);
+            debug!("Recording started: {}", recording_started);
+        } else {
+            // On-demand mode: Start recording first, then play audio feedback
+            // This allows the microphone to be activated before playing the sound
+            debug!("On-demand mode: Starting recording first, then audio feedback");
+            let recording_start_time = Instant::now();
+            if rm.try_start_recording(&binding_id) {
+                debug!("Recording started in {:?}", recording_start_time.elapsed());
+                // Small delay to ensure microphone stream is active
+                let app_clone = app.clone();
+                std::thread::spawn(move || {
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                    debug!("Playing delayed audio feedback");
+                    play_recording_start_sound(&app_clone);
+                });
+            } else {
+                debug!("Failed to start recording");
+            }
+        }
+
+        debug!(
+            "TranscribeAction::start completed in {:?}",
+            start_time.elapsed()
+        );
     }
 
     fn stop(&self, app: &AppHandle, binding_id: &str, _shortcut_str: &str) {
+        let stop_time = Instant::now();
+        debug!("TranscribeAction::stop called for binding: {}", binding_id);
+
         let ah = app.clone();
         let rm = Arc::clone(&app.state::<Arc<AudioRecordingManager>>());
         let tm = Arc::clone(&app.state::<Arc<TranscriptionManager>>());
@@ -46,16 +86,37 @@ impl ShortcutAction for TranscribeAction {
 
         tauri::async_runtime::spawn(async move {
             let binding_id = binding_id.clone(); // Clone for the inner async task
+            debug!(
+                "Starting async transcription task for binding: {}",
+                binding_id
+            );
+
+            let stop_recording_time = Instant::now();
             if let Some(samples) = rm.stop_recording(&binding_id) {
+                debug!(
+                    "Recording stopped and samples retrieved in {:?}, sample count: {}",
+                    stop_recording_time.elapsed(),
+                    samples.len()
+                );
+
+                let transcription_time = Instant::now();
                 match tm.transcribe(samples) {
                     Ok(transcription) => {
-                        println!("Transcription Result: {}", transcription);
+                        debug!(
+                            "Transcription completed in {:?}: '{}'",
+                            transcription_time.elapsed(),
+                            transcription
+                        );
                         if !transcription.is_empty() {
                             let transcription_clone = transcription.clone();
                             let ah_clone = ah.clone();
+                            let paste_time = Instant::now();
                             ah.run_on_main_thread(move || {
                                 match utils::paste(transcription_clone, ah_clone) {
-                                    Ok(()) => println!("Text pasted successfully"),
+                                    Ok(()) => debug!(
+                                        "Text pasted successfully in {:?}",
+                                        paste_time.elapsed()
+                                    ),
                                     Err(e) => eprintln!("Failed to paste transcription: {}", e),
                                 }
                             })
@@ -64,10 +125,17 @@ impl ShortcutAction for TranscribeAction {
                             });
                         }
                     }
-                    Err(err) => println!("Global Shortcut Transcription error: {}", err),
+                    Err(err) => debug!("Global Shortcut Transcription error: {}", err),
                 }
+            } else {
+                debug!("No samples retrieved from recording stop");
             }
         });
+
+        debug!(
+            "TranscribeAction::stop completed in {:?}",
+            stop_time.elapsed()
+        );
     }
 }
 

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -1,0 +1,29 @@
+use crate::managers::audio::{AudioRecordingManager, MicrophoneMode};
+use crate::settings::{get_settings, write_settings};
+use std::sync::Arc;
+use tauri::{AppHandle, Manager};
+
+#[tauri::command]
+pub fn update_microphone_mode(app: AppHandle, always_on: bool) -> Result<(), String> {
+    // Update settings
+    let mut settings = get_settings(&app);
+    settings.always_on_microphone = always_on;
+    write_settings(&app, settings);
+
+    // Update the audio manager mode
+    let rm = app.state::<Arc<AudioRecordingManager>>();
+    let new_mode = if always_on {
+        MicrophoneMode::AlwaysOn
+    } else {
+        MicrophoneMode::OnDemand
+    };
+
+    rm.update_mode(new_mode)
+        .map_err(|e| format!("Failed to update microphone mode: {}", e))
+}
+
+#[tauri::command]
+pub fn get_microphone_mode(app: AppHandle) -> Result<bool, String> {
+    let settings = get_settings(&app);
+    Ok(settings.always_on_microphone)
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,1 +1,2 @@
+pub mod audio;
 pub mod models;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -185,7 +185,9 @@ pub fn run() {
             commands::models::is_model_loading,
             commands::models::has_any_models_available,
             commands::models::has_any_models_or_downloads,
-            commands::models::get_recommended_first_model
+            commands::models::get_recommended_first_model,
+            commands::audio::update_microphone_mode,
+            commands::audio::get_microphone_mode
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -20,12 +20,20 @@ pub struct AppSettings {
     pub audio_feedback: bool,
     #[serde(default = "default_model")]
     pub selected_model: String,
+    #[serde(default = "default_always_on_microphone")]
+    pub always_on_microphone: bool,
 }
 
 fn default_model() -> String {
     // Default to empty string if no models are available yet
     // The UI will handle prompting for model download
     "".to_string()
+}
+
+fn default_always_on_microphone() -> bool {
+    // Default to false for better user experience
+    // True would be the old behavior (always-on for low latency)
+    false
 }
 
 pub const SETTINGS_STORE_PATH: &str = "settings_store.json";
@@ -58,6 +66,7 @@ pub fn get_default_settings() -> AppSettings {
         push_to_talk: true,
         audio_feedback: false,
         selected_model: "".to_string(),
+        always_on_microphone: false,
     }
 }
 


### PR DESCRIPTION
This should resolve #5 and I suspect #14 as well.

We only initialize the microphone after the user has clicked the buttons to begin transcribing. The old low latency path still survives and can be enabled by editing the settings file. Specifically setting `"always_on_microphone": true`

On MacOS this is located: `/Users/<user>/Library/Application Support/com.pais.handy/settings_store.json`
