### PR TITLE
Add Translate to English Setting

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -174,6 +174,7 @@ pub fn run() {
             shortcut::reset_binding,
             shortcut::change_ptt_setting,
             shortcut::change_audio_feedback_setting,
+            shortcut::change_translate_to_english_setting,
             trigger_update_check,
             commands::models::get_available_models,
             commands::models::get_model_info,

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -173,6 +173,9 @@ impl TranscriptionManager {
             )
         })?;
 
+        // Get current settings to check translation preference
+        let settings = get_settings(&self.app_handle);
+
         // Initialize parameters
         let mut params = FullParams::new(SamplingStrategy::default());
         params.set_language(Some("auto"));
@@ -182,6 +185,11 @@ impl TranscriptionManager {
         params.set_print_timestamps(false);
         params.set_suppress_blank(true);
         params.set_suppress_non_speech_tokens(true);
+        
+        // Enable translation to English if requested
+        if settings.translate_to_english {
+            params.set_translate(true);
+        }
 
         state
             .full(params, &audio)
@@ -199,7 +207,8 @@ impl TranscriptionManager {
         }
 
         let et = std::time::Instant::now();
-        println!("\ntook {}ms", (et - st).as_millis());
+        let translation_note = if settings.translate_to_english { " (translated)" } else { "" };
+        println!("\ntook {}ms{}", (et - st).as_millis(), translation_note);
 
         Ok(result.trim().to_string())
     }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -22,6 +22,8 @@ pub struct AppSettings {
     pub selected_model: String,
     #[serde(default = "default_always_on_microphone")]
     pub always_on_microphone: bool,
+    #[serde(default = "default_translate_to_english")]
+    pub translate_to_english: bool,
 }
 
 fn default_model() -> String {
@@ -33,6 +35,11 @@ fn default_model() -> String {
 fn default_always_on_microphone() -> bool {
     // Default to false for better user experience
     // True would be the old behavior (always-on for low latency)
+    false
+}
+
+fn default_translate_to_english() -> bool {
+    // Default to false - users need to opt-in to translation
     false
 }
 
@@ -77,6 +84,7 @@ pub fn get_default_settings() -> AppSettings {
         audio_feedback: false,
         selected_model: "".to_string(),
         always_on_microphone: false,
+        translate_to_english: false,
     }
 }
 

--- a/src-tauri/src/shortcut.rs
+++ b/src-tauri/src/shortcut.rs
@@ -111,6 +111,14 @@ pub fn change_audio_feedback_setting(app: AppHandle, enabled: bool) -> Result<()
     Ok(())
 }
 
+#[tauri::command]
+pub fn change_translate_to_english_setting(app: AppHandle, enabled: bool) -> Result<(), String> {
+    let mut settings = settings::get_settings(&app);
+    settings.translate_to_english = enabled;
+    settings::write_settings(&app, settings);
+    Ok(())
+}
+
 fn _register_shortcut(app: &AppHandle, binding: ShortcutBinding) -> Result<(), String> {
     // Parse shortcut and return error if it fails
     let shortcut = match binding.current_binding.parse::<Shortcut>() {

--- a/src/components/AccessibilityPermissions.tsx
+++ b/src/components/AccessibilityPermissions.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import {
-  checkAccessibilityPermissions,
-  requestAccessibilityPermissions,
+  checkAccessibilityPermission,
+  requestAccessibilityPermission,
 } from "tauri-plugin-macos-permissions-api";
 
 // Define permission state type
@@ -20,7 +20,7 @@ const AccessibilityPermissions: React.FC = () => {
 
   // Check permissions without requesting
   const checkPermissions = async (): Promise<boolean> => {
-    const hasPermissions: boolean = await checkAccessibilityPermissions();
+    const hasPermissions: boolean = await checkAccessibilityPermission();
     setHasAccessibility(hasPermissions);
     setPermissionState(hasPermissions ? "granted" : "verify");
     return hasPermissions;
@@ -30,7 +30,7 @@ const AccessibilityPermissions: React.FC = () => {
   const handleButtonClick = async (): Promise<void> => {
     if (permissionState === "request") {
       try {
-        await requestAccessibilityPermissions();
+        await requestAccessibilityPermission();
         // After system prompt, transition to verification state
         setPermissionState("verify");
       } catch (error) {
@@ -46,7 +46,7 @@ const AccessibilityPermissions: React.FC = () => {
   // On app boot - check permissions
   useEffect(() => {
     const initialSetup = async (): Promise<void> => {
-      const hasPermissions: boolean = await checkAccessibilityPermissions();
+      const hasPermissions: boolean = await checkAccessibilityPermission();
       setHasAccessibility(hasPermissions);
       setPermissionState(hasPermissions ? "granted" : "request");
     };

--- a/src/components/settings/KeyboardShortcuts.tsx
+++ b/src/components/settings/KeyboardShortcuts.tsx
@@ -16,6 +16,8 @@ export const KeyboardShortcuts: React.FC = () => {
   const [pttEnabled, setPttEnabled] = React.useState<boolean>(false);
   const [audioFeedbackEnabled, setAudioFeedbackEnabled] =
     React.useState<boolean>(false);
+  const [translateToEnglishEnabled, setTranslateToEnglishEnabled] =
+    React.useState<boolean>(false);
   const [keyPressed, setKeyPressed] = useState<string[]>([]);
   const [recordedKeys, setRecordedKeys] = useState<string[]>([]);
   const [editingShortcutId, setEditingShortcutId] = useState<string | null>(
@@ -80,6 +82,7 @@ export const KeyboardShortcuts: React.FC = () => {
         setBindings(settings.bindings);
         setPttEnabled(settings.push_to_talk);
         setAudioFeedbackEnabled(settings.audio_feedback);
+        setTranslateToEnglishEnabled(settings.translate_to_english);
       });
     });
   }, []);
@@ -252,6 +255,30 @@ export const KeyboardShortcuts: React.FC = () => {
               setAudioFeedbackEnabled(newValue);
 
               invoke("change_audio_feedback_setting", {
+                enabled: newValue,
+              });
+            }}
+          />
+          <div className="relative w-11 h-6 bg-mid-gray/20 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-logo-primary rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-logo-primary"></div>
+        </label>
+      </div>
+      <div className="flex items-center justify-between p-4 rounded-lg border border-mid-gray/20 ">
+        <div className="max-w-2/3">
+          <h3 className="text-sm font-medium ">Translate to English</h3>
+          <p className="text-sm">Automatically translate speech from any language to English</p>
+        </div>
+        <label className="inline-flex items-center cursor-pointer">
+          <input
+            type="checkbox"
+            value=""
+            className="sr-only peer"
+            checked={translateToEnglishEnabled}
+            onChange={(e) => {
+              console.log("change translate to english setting", e.target.checked);
+              const newValue = e.target.checked;
+              setTranslateToEnglishEnabled(newValue);
+
+              invoke("change_translate_to_english_setting", {
                 enabled: newValue,
               });
             }}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -17,6 +17,7 @@ export const SettingsSchema = z.object({
   bindings: ShortcutBindingsMapSchema,
   push_to_talk: z.boolean(),
   audio_feedback: z.boolean(),
+  translate_to_english: z.boolean(),
 });
 
 export const BindingResponseSchema = z.object({


### PR DESCRIPTION
## Summary
- Added a new setting to enable automatic translation of speech to English
- Updated settings UI components to include the translation toggle  
- Integrated translation logic into the transcription process
- Adjusted accessibility permission calls for consistency

## Test plan
- [x] Verify the translation setting appears in the settings UI
- [x] Test that enabling translation works with multilingual Whisper models
- [x] Confirm the setting persists across app restarts
- [x] Validate that translation only works with compatible models (small, medium, large)

🤖 Generated with [Claude Code](https://claude.ai/code)