### PR TITLE
feat(tray): add menu items to cancel recording/transcribing

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -122,6 +122,25 @@ pub fn run() {
                     "check_updates" => {
                         let _ = app.emit("check-for-updates", ());
                     }
+                    "cancel_listening" => {
+                        use crate::utils::{change_tray_icon, TrayIconState};
+                        use crate::managers::audio::AudioRecordingManager;
+                        use std::sync::Arc;
+                        
+                        // Cancel the recording without transcribing
+                        let rm = app.state::<Arc<AudioRecordingManager>>();
+                        rm.cancel_recording();
+                        
+                        // Return to idle state
+                        change_tray_icon(app, TrayIconState::Idle);
+                    }
+                    "cancel_transcribing" => {
+                        use crate::utils::{change_tray_icon, TrayIconState};
+                        
+                        // For now, just return to idle state
+                        // TODO: In a future version, we could add actual request cancellation
+                        change_tray_icon(app, TrayIconState::Idle);
+                    }
                     "quit" => {
                         app.exit(0);
                     }


### PR DESCRIPTION
Users can now stop recording or cancel transcription directly from the system tray menu instead of having to wait for them to finish. Useful when you need to quickly cancel an operation, e.g. having it recording for hours accidentally :-).