### PR TITLE
fix clipboard/paste issues on linux/i3wm

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -30,6 +30,15 @@ impl ShortcutAction for TranscribeAction {
         let start_time = Instant::now();
         debug!("TranscribeAction::start called for binding: {}", binding_id);
 
+        // Capture focused window ID BEFORE any UI changes
+        let focused_window_id = crate::utils::get_focused_window_id();
+
+        // Store it in managed state for later use during paste
+        let focused_window_state = app.state::<crate::ManagedFocusedWindow>();
+        if let Ok(mut state) = focused_window_state.try_lock() {
+            *state = focused_window_id;
+        }
+
         let binding_id = binding_id.to_string();
         change_tray_icon(app, TrayIconState::Recording);
         show_recording_overlay(app);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,6 +25,7 @@ struct ShortcutToggleStates {
 }
 
 type ManagedToggleState = Mutex<ShortcutToggleStates>;
+type ManagedFocusedWindow = Mutex<Option<String>>;
 
 fn show_main_window(app: &AppHandle) {
     if let Some(main_window) = app.get_webview_window("main") {
@@ -77,6 +78,7 @@ pub fn run() {
             Some(vec![]),
         ))
         .manage(Mutex::new(ShortcutToggleStates::default()))
+        .manage(Mutex::new(None::<String>))
         .setup(move |app| {
             // Get the current theme to set the appropriate initial icon
             let initial_theme = if let Some(main_window) = app.get_webview_window("main") {
@@ -183,6 +185,7 @@ pub fn run() {
             shortcut::change_selected_language_setting,
             shortcut::change_show_overlay_setting,
             shortcut::change_debug_mode_setting,
+            shortcut::change_input_method_setting,
             shortcut::suspend_binding,
             shortcut::resume_binding,
             trigger_update_check,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -34,6 +34,8 @@ pub struct AppSettings {
     pub show_overlay: bool,
     #[serde(default = "default_debug_mode")]
     pub debug_mode: bool,
+    #[serde(default = "default_input_method")]
+    pub input_method: String,
 }
 
 fn default_model() -> String {
@@ -66,6 +68,11 @@ fn default_show_overlay() -> bool {
 fn default_debug_mode() -> bool {
     // Default to false - debug mode should be opt-in
     false
+}
+
+fn default_input_method() -> String {
+    // Default to "type" - based on the improvements made for Linux compatibility
+    "type".to_string()
 }
 
 pub const SETTINGS_STORE_PATH: &str = "settings_store.json";
@@ -116,6 +123,7 @@ pub fn get_default_settings() -> AppSettings {
         selected_language: "auto".to_string(),
         show_overlay: true,
         debug_mode: false,
+        input_method: "type".to_string(),
     }
 }
 

--- a/src-tauri/src/shortcut.rs
+++ b/src-tauri/src/shortcut.rs
@@ -150,6 +150,20 @@ pub fn change_debug_mode_setting(app: AppHandle, enabled: bool) -> Result<(), St
     Ok(())
 }
 
+#[tauri::command]
+pub fn change_input_method_setting(app: AppHandle, method: String) -> Result<(), String> {
+    let mut settings = settings::get_settings(&app);
+
+    // Validate the input method
+    if method != "paste" && method != "type" {
+        return Err("Invalid input method. Must be 'paste' or 'type'".to_string());
+    }
+
+    settings.input_method = method;
+    settings::write_settings(&app, settings);
+    Ok(())
+}
+
 /// Determine whether a shortcut string contains at least one non-modifier key.
 /// We allow single non-modifier keys (e.g. "f5" or "space") but disallow
 /// modifier-only combos (e.g. "ctrl" or "ctrl+shift").

--- a/src/components/settings/InputMethod.tsx
+++ b/src/components/settings/InputMethod.tsx
@@ -1,0 +1,56 @@
+import { SettingContainer } from "../ui/SettingContainer";
+import { useSettings } from "../../hooks/useSettings";
+
+interface InputMethodProps {
+  descriptionMode?: "tooltip" | "inline";
+  grouped?: boolean;
+}
+
+export function InputMethod({
+  descriptionMode = "tooltip",
+  grouped = false,
+}: InputMethodProps) {
+  const { getSetting, updateSetting, isUpdating } = useSettings();
+
+  const currentMethod = getSetting("input_method") ?? "type";
+
+  const handleMethodChange = async (method: "paste" | "type") => {
+    await updateSetting("input_method", method);
+  };
+
+  return (
+    <SettingContainer
+      title="Input Method"
+      description="Choose how transcribed text is inserted into applications. 'Type' simulates keyboard typing (works better on Linux), 'Paste' uses clipboard (may be faster but less compatible)."
+      descriptionMode={descriptionMode}
+      grouped={grouped}
+    >
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => handleMethodChange("type")}
+          disabled={isUpdating("input_method")}
+          className={`px-4 py-2 rounded-lg text-sm font-medium border transition-colors ${
+            currentMethod === "type"
+              ? "bg-blue-500 text-white border-blue-500"
+              : "bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-600"
+          } disabled:opacity-50 disabled:cursor-not-allowed`}
+        >
+          Type
+        </button>
+        <button
+          type="button"
+          onClick={() => handleMethodChange("paste")}
+          disabled={isUpdating("input_method")}
+          className={`px-4 py-2 rounded-lg text-sm font-medium border transition-colors ${
+            currentMethod === "paste"
+              ? "bg-blue-500 text-white border-blue-500"
+              : "bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-600"
+          } disabled:opacity-50 disabled:cursor-not-allowed`}
+        >
+          Paste
+        </button>
+      </div>
+    </SettingContainer>
+  );
+}

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -8,6 +8,7 @@ import { ShowOverlay } from "./ShowOverlay";
 import { HandyShortcut } from "./HandyShortcut";
 import { TranslateToEnglish } from "./TranslateToEnglish";
 import { LanguageSelector } from "./LanguageSelector";
+import { InputMethod } from "./InputMethod";
 import { SettingsGroup } from "../ui/SettingsGroup";
 import { DebugSettings } from "./debug";
 import { useSettings } from "../../hooks/useSettings";
@@ -54,6 +55,7 @@ export const Settings: React.FC = () => {
         <OutputDeviceSelector descriptionMode="tooltip" grouped={true} />
         <ShowOverlay descriptionMode="tooltip" grouped={true} />
         <TranslateToEnglish descriptionMode="tooltip" grouped={true} />
+        <InputMethod descriptionMode="tooltip" grouped={true} />
         <AlwaysOnMicrophone descriptionMode="tooltip" grouped={true} />
       </SettingsGroup>
 

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -205,6 +205,9 @@ export const useSettings = (): UseSettingsReturn => {
           case "debug_mode":
             await invoke("change_debug_mode_setting", { enabled: value });
             break;
+          case "input_method":
+            await invoke("change_input_method_setting", { method: value });
+            break;
           case "bindings":
             // Handle bindings separately - they use their own invoke methods
             break;
@@ -251,6 +254,7 @@ export const useSettings = (): UseSettingsReturn => {
         selected_language: "auto",
         show_overlay: true,
         debug_mode: false,
+        input_method: "type" as const,
       };
 
       const defaultValue = defaults[key];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -31,6 +31,7 @@ export const SettingsSchema = z.object({
   selected_language: z.string(),
   show_overlay: z.boolean(),
   debug_mode: z.boolean(),
+  input_method: z.enum(["paste", "type"]),
 });
 
 export const BindingResponseSchema = z.object({


### PR DESCRIPTION
When using `i3wm` X windows manager - the recording indicator window catches focus when the recording is started, causing the input to be pasted nowhere afterwards.

Also for Terminal window the standard paste shortcut is not Ctrl+V, so now there's a switch to use "typing" instead of pasting