### PR TITLE
Upgrade whisper-rs to 0.15

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6491,9 +6491,9 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "whisper-rs"
-version = "0.14.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2eac0a371f8ae667a5ee15ae4130553ea3004e7572544d1ce546c81ea8874b"
+checksum = "4d4a5eb3a2a84d3adfb2e84b3ae783ee73428676582b2c91cb66c3091e737256"
 dependencies = [
  "libc",
  "log",
@@ -6502,9 +6502,9 @@ dependencies = [
 
 [[package]]
 name = "whisper-rs-sys"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c86f1b993f216594b1ad9a9bb00a26014fb7c512e12664a2d401c7897d2ef7d"
+checksum = "3d0927ebac46387e6f3f705cc007c9ea40885f6d924071a918f1ee8b829cf5cd"
 dependencies = [
  "bindgen",
  "cfg-if",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -63,13 +63,13 @@ natural = "0.5.0"
 version = "=2.0.0-rc.9"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-whisper-rs = { version = "0.14.4", features = ["metal", "log_backend"] }
+whisper-rs = { version = "0.15.0", features = ["metal", "log_backend"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-whisper-rs = { version = "0.14.4", features = ["vulkan", "log_backend"] }
+whisper-rs = { version = "0.15.0", features = ["vulkan", "log_backend"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-whisper-rs = { version = "0.14.4", features = ["vulkan", "log_backend"] }
+whisper-rs = { version = "0.15.0", features = ["vulkan", "log_backend"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-autostart = "2"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -42,7 +42,7 @@
     "macOS": {
       "files": {},
       "hardenedRuntime": true,
-      "minimumSystemVersion": "10.13",
+      "minimumSystemVersion": "10.15",
       "signingIdentity": "-",
       "entitlements": "Entitlements.plist"
     },


### PR DESCRIPTION
This just upgrades to the latest version of whisper-rs. However, this fails to build on macOS for me, and doesn't seem to support older versions of macOS. So this is a tentative upgrade, but it won't be pulled in until these issues are fixed.