### PR TITLE
Add shortcut to Translate on the fly

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -22,6 +22,9 @@ pub trait ShortcutAction: Send + Sync {
 // Transcribe Action
 struct TranscribeAction;
 
+// Transcribe with Translation Action
+struct TranscribeTranslateAction;
+
 impl ShortcutAction for TranscribeAction {
     fn start(&self, app: &AppHandle, binding_id: &str, _shortcut_str: &str) {
         let start_time = Instant::now();
@@ -154,6 +157,139 @@ impl ShortcutAction for TranscribeAction {
     }
 }
 
+impl ShortcutAction for TranscribeTranslateAction {
+    fn start(&self, app: &AppHandle, binding_id: &str, _shortcut_str: &str) {
+        let start_time = Instant::now();
+        debug!("TranscribeTranslateAction::start called for binding: {}", binding_id);
+
+        let binding_id = binding_id.to_string();
+        change_tray_icon(app, TrayIconState::Recording);
+        show_recording_overlay(app);
+
+        let rm = app.state::<Arc<AudioRecordingManager>>();
+
+        // Get the microphone mode to determine audio feedback timing
+        let settings = get_settings(app);
+        let is_always_on = settings.always_on_microphone;
+        debug!("Microphone mode - always_on: {}", is_always_on);
+
+        if is_always_on {
+            // Always-on mode: Play audio feedback immediately
+            debug!("Always-on mode: Playing audio feedback immediately");
+            play_recording_start_sound(app);
+            let recording_started = rm.try_start_recording(&binding_id);
+            debug!("Recording started: {}", recording_started);
+        } else {
+            // On-demand mode: Start recording first, then play audio feedback
+            // This allows the microphone to be activated before playing the sound
+            debug!("On-demand mode: Starting recording first, then audio feedback");
+            let recording_start_time = Instant::now();
+            if rm.try_start_recording(&binding_id) {
+                debug!("Recording started in {:?}", recording_start_time.elapsed());
+                // Small delay to ensure microphone stream is active
+                let app_clone = app.clone();
+                std::thread::spawn(move || {
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                    debug!("Playing delayed audio feedback");
+                    play_recording_start_sound(&app_clone);
+                });
+            } else {
+                debug!("Failed to start recording");
+            }
+        }
+
+        debug!(
+            "TranscribeTranslateAction::start completed in {:?}",
+            start_time.elapsed()
+        );
+    }
+
+    fn stop(&self, app: &AppHandle, binding_id: &str, _shortcut_str: &str) {
+        let stop_time = Instant::now();
+        debug!("TranscribeTranslateAction::stop called for binding: {}", binding_id);
+
+        let ah = app.clone();
+        let rm = Arc::clone(&app.state::<Arc<AudioRecordingManager>>());
+        let tm = Arc::clone(&app.state::<Arc<TranscriptionManager>>());
+
+        change_tray_icon(app, TrayIconState::Transcribing);
+        show_transcribing_overlay(app);
+
+        // Play audio feedback for recording stop
+        play_recording_stop_sound(app);
+
+        let binding_id = binding_id.to_string(); // Clone binding_id for the async task
+
+        tauri::async_runtime::spawn(async move {
+            let binding_id = binding_id.clone(); // Clone for the inner async task
+            debug!(
+                "Starting async transcription with translation task for binding: {}",
+                binding_id
+            );
+
+            let stop_recording_time = Instant::now();
+            if let Some(samples) = rm.stop_recording(&binding_id) {
+                debug!(
+                    "Recording stopped and samples retrieved in {:?}, sample count: {}",
+                    stop_recording_time.elapsed(),
+                    samples.len()
+                );
+
+                let transcription_time = Instant::now();
+                // Use the translation method instead of regular transcribe
+                match tm.transcribe_with_translation(samples) {
+                    Ok(transcription) => {
+                        debug!(
+                            "Transcription with translation completed in {:?}: '{}'",
+                            transcription_time.elapsed(),
+                            transcription
+                        );
+                        if !transcription.is_empty() {
+                            let transcription_clone = transcription.clone();
+                            let ah_clone = ah.clone();
+                            let paste_time = Instant::now();
+                            ah.run_on_main_thread(move || {
+                                match utils::paste(transcription_clone, ah_clone.clone()) {
+                                    Ok(()) => debug!(
+                                        "Text pasted successfully in {:?}",
+                                        paste_time.elapsed()
+                                    ),
+                                    Err(e) => eprintln!("Failed to paste transcription: {}", e),
+                                }
+                                // Hide the overlay after transcription is complete
+                                utils::hide_recording_overlay(&ah_clone);
+                                change_tray_icon(&ah_clone, TrayIconState::Idle);
+                            })
+                            .unwrap_or_else(|e| {
+                                eprintln!("Failed to run paste on main thread: {:?}", e);
+                                utils::hide_recording_overlay(&ah);
+                                change_tray_icon(&ah, TrayIconState::Idle);
+                            });
+                        } else {
+                            utils::hide_recording_overlay(&ah);
+                            change_tray_icon(&ah, TrayIconState::Idle);
+                        }
+                    }
+                    Err(err) => {
+                        debug!("Global Shortcut Translation Transcription error: {}", err);
+                        utils::hide_recording_overlay(&ah);
+                        change_tray_icon(&ah, TrayIconState::Idle);
+                    }
+                }
+            } else {
+                debug!("No samples retrieved from recording stop");
+                utils::hide_recording_overlay(&ah);
+                change_tray_icon(&ah, TrayIconState::Idle);
+            }
+        });
+
+        debug!(
+            "TranscribeTranslateAction::stop completed in {:?}",
+            stop_time.elapsed()
+        );
+    }
+}
+
 // Test Action
 struct TestAction;
 
@@ -183,6 +319,10 @@ pub static ACTION_MAP: Lazy<HashMap<String, Arc<dyn ShortcutAction>>> = Lazy::ne
     map.insert(
         "transcribe".to_string(),
         Arc::new(TranscribeAction) as Arc<dyn ShortcutAction>,
+    );
+    map.insert(
+        "transcribe_translate".to_string(),
+        Arc::new(TranscribeTranslateAction) as Arc<dyn ShortcutAction>,
     );
     map.insert(
         "test".to_string(),

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -262,6 +262,14 @@ impl TranscriptionManager {
     }
 
     pub fn transcribe(&self, audio: Vec<f32>) -> Result<String> {
+        self.transcribe_with_options(audio, None)
+    }
+
+    pub fn transcribe_with_translation(&self, audio: Vec<f32>) -> Result<String> {
+        self.transcribe_with_options(audio, Some(true))
+    }
+
+    fn transcribe_with_options(&self, audio: Vec<f32>, force_translate: Option<bool>) -> Result<String> {
         let st = std::time::Instant::now();
 
         let mut result = String::new();
@@ -294,8 +302,9 @@ impl TranscriptionManager {
         params.set_suppress_non_speech_tokens(true);
         params.set_no_speech_thold(0.2);
 
-        // Enable translation to English if requested
-        if settings.translate_to_english {
+        // Enable translation to English if requested or forced
+        let should_translate = force_translate.unwrap_or(settings.translate_to_english);
+        if should_translate {
             params.set_translate(true);
         }
 
@@ -326,7 +335,7 @@ impl TranscriptionManager {
         };
 
         let et = std::time::Instant::now();
-        let translation_note = if settings.translate_to_english {
+        let translation_note = if should_translate {
             " (translated)"
         } else {
             ""

--- a/src/components/settings/HandyTranslateShortcut.tsx
+++ b/src/components/settings/HandyTranslateShortcut.tsx
@@ -12,12 +12,12 @@ import { useSettings } from "../../hooks/useSettings";
 import { invoke } from "@tauri-apps/api/core";
 import { toast } from "sonner";
 
-interface HandyShortcutProps {
+interface HandyTranslateShortcutProps {
   descriptionMode?: "inline" | "tooltip";
   grouped?: boolean;
 }
 
-export const HandyShortcut: React.FC<HandyShortcutProps> = ({
+export const HandyTranslateShortcut: React.FC<HandyTranslateShortcutProps> = ({
   descriptionMode = "tooltip",
   grouped = false,
 }) => {
@@ -243,8 +243,8 @@ export const HandyShortcut: React.FC<HandyShortcutProps> = ({
   if (isLoading) {
     return (
       <SettingContainer
-        title="Handy Shortcuts"
-        description="Configure keyboard shortcuts to trigger speech-to-text recording"
+        title="Handy Translate Shortcut"
+        description="Configure keyboard shortcut for speech-to-text recording with translation"
         descriptionMode={descriptionMode}
         grouped={grouped}
       >
@@ -253,55 +253,58 @@ export const HandyShortcut: React.FC<HandyShortcutProps> = ({
     );
   }
 
-  // If no bindings are loaded, show empty state
-  if (Object.keys(bindings).length === 0) {
-    return (
-      <SettingContainer
-        title="Handy Shortcuts"
-        description="Configure keyboard shortcuts to trigger speech-to-text recording"
-        descriptionMode={descriptionMode}
-        grouped={grouped}
-      >
-        <div className="text-sm text-mid-gray">No shortcuts configured</div>
-      </SettingContainer>
-    );
-  }
+  // Get the translate binding for this component, or create default if not present
+  const translateBinding = bindings["transcribe_translate"];
+  
+  // Create default binding if not present
+  const getDefaultTranslateShortcut = () => {
+    switch (osType) {
+      case "macos":
+        return "option+shift+space";
+      case "windows":
+      case "linux":
+        return "ctrl+shift+space";
+      default:
+        return "alt+shift+space";
+    }
+  };
 
-  // Get the transcribe binding for this component
-  const transcribeBinding = bindings["transcribe"];
+  const effectiveBinding = translateBinding || {
+    id: "transcribe_translate",
+    name: "Transcribe & Translate",
+    description: "Converts your speech into text and translates it to English.",
+    default_binding: getDefaultTranslateShortcut(),
+    current_binding: getDefaultTranslateShortcut(),
+  };
 
   return (
     <SettingContainer
-      title="Handy Shortcut"
-      description="Set the keyboard shortcut to start and stop speech-to-text recording"
+      title="Handy Translate Shortcut"
+      description="Set the keyboard shortcut to start speech-to-text recording with translation to English"
       descriptionMode={descriptionMode}
       grouped={grouped}
     >
-      {transcribeBinding ? (
-        <div className="flex items-center space-x-1">
-          {editingShortcutId === "transcribe" ? (
-            <div
-              ref={(ref) => setShortcutRef("transcribe", ref)}
-              className="px-2 py-1 text-sm font-semibold border border-logo-primary bg-logo-primary/30 rounded min-w-[120px] text-center"
-            >
-              {formatCurrentKeys()}
-            </div>
-          ) : (
-            <div
-              className="px-2 py-1 text-sm font-semibold bg-mid-gray/10 border border-mid-gray/80 hover:bg-logo-primary/10 rounded cursor-pointer hover:border-logo-primary"
-              onClick={() => startRecording("transcribe")}
-            >
-              {formatKeyCombination(transcribeBinding.current_binding, osType)}
-            </div>
-          )}
-          <ResetButton
-            onClick={() => resetBinding("transcribe")}
-            disabled={isUpdating("binding_transcribe")}
-          />
-        </div>
-      ) : (
-        <div className="text-sm text-mid-gray">No shortcut configured</div>
-      )}
+      <div className="flex items-center space-x-1">
+        {editingShortcutId === "transcribe_translate" ? (
+          <div
+            ref={(ref) => setShortcutRef("transcribe_translate", ref)}
+            className="px-2 py-1 text-sm font-semibold border border-logo-primary bg-logo-primary/30 rounded min-w-[120px] text-center"
+          >
+            {formatCurrentKeys()}
+          </div>
+        ) : (
+          <div
+            className="px-2 py-1 text-sm font-semibold bg-mid-gray/10 border border-mid-gray/80 hover:bg-logo-primary/10 rounded cursor-pointer hover:border-logo-primary"
+            onClick={() => startRecording("transcribe_translate")}
+          >
+            {formatKeyCombination(effectiveBinding.current_binding, osType)}
+          </div>
+        )}
+        <ResetButton
+          onClick={() => resetBinding("transcribe_translate")}
+          disabled={isUpdating("binding_transcribe_translate")}
+        />
+      </div>
     </SettingContainer>
   );
 };

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -6,6 +6,7 @@ import { AudioFeedback } from "./AudioFeedback";
 import { OutputDeviceSelector } from "./OutputDeviceSelector";
 import { ShowOverlay } from "./ShowOverlay";
 import { HandyShortcut } from "./HandyShortcut";
+import { HandyTranslateShortcut } from "./HandyTranslateShortcut";
 import { TranslateToEnglish } from "./TranslateToEnglish";
 import { LanguageSelector } from "./LanguageSelector";
 import { CustomWords } from "./CustomWords";
@@ -46,6 +47,7 @@ export const Settings: React.FC = () => {
     <div className="max-w-3xl w-full mx-auto space-y-6">
       <SettingsGroup>
         <HandyShortcut descriptionMode="tooltip" grouped={true} />
+        <HandyTranslateShortcut descriptionMode="tooltip" grouped={true} />
         <MicrophoneSelector descriptionMode="tooltip" grouped={true} />
         <LanguageSelector descriptionMode="tooltip" grouped={true} />
       </SettingsGroup>

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -6,6 +6,7 @@ export { PushToTalk } from "./PushToTalk";
 export { AudioFeedback } from "./AudioFeedback";
 export { ShowOverlay } from "./ShowOverlay";
 export { HandyShortcut } from "./HandyShortcut";
+export { HandyTranslateShortcut } from "./HandyTranslateShortcut";
 export { TranslateToEnglish } from "./TranslateToEnglish";
 export { CustomWords } from "./CustomWords";
 export { AppDataDirectory } from "./AppDataDirectory";


### PR DESCRIPTION
<img width="535" height="312" alt="image" src="https://github.com/user-attachments/assets/32bae18d-804c-4669-abf0-a668bf64fb54" />

This PR, mostly AI generated, and tested on my MacOS, adds a shortcut setting to enable the transcribe+translation with push-to-talk, in the same way it already works when the Translate to English flag is activated, so that I can keep the spoken language as well as translate it, just switching the used shortcut