### PR TITLE
Add VRAM Inactivity Timer

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod audio;
 pub mod models;
+pub mod transcription;
 
 use crate::utils::cancel_current_operation;
 use tauri::{AppHandle, Manager};

--- a/src-tauri/src/commands/transcription.rs
+++ b/src-tauri/src/commands/transcription.rs
@@ -1,0 +1,32 @@
+use crate::managers::transcription::TranscriptionManager;
+use crate::settings::{get_settings, write_settings, ModelUnloadTimeout};
+use tauri::{AppHandle, State};
+
+#[tauri::command]
+pub fn set_model_unload_timeout(app: AppHandle, timeout: ModelUnloadTimeout) {
+    let mut settings = get_settings(&app);
+    settings.model_unload_timeout = timeout;
+    write_settings(&app, settings);
+}
+
+#[tauri::command]
+pub fn get_model_load_status(
+    transcription_manager: State<TranscriptionManager>,
+) -> Result<serde_json::Value, String> {
+    let is_loaded = transcription_manager.is_model_loaded();
+    let current_model = transcription_manager.get_current_model();
+
+    Ok(serde_json::json!({
+        "is_loaded": is_loaded,
+        "current_model": current_model
+    }))
+}
+
+#[tauri::command]
+pub fn unload_model_manually(
+    transcription_manager: State<TranscriptionManager>,
+) -> Result<(), String> {
+    transcription_manager
+        .unload_model()
+        .map_err(|e| format!("Failed to unload model: {}", e))
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -213,7 +213,10 @@ pub fn run() {
             commands::audio::get_selected_microphone,
             commands::audio::get_available_output_devices,
             commands::audio::set_selected_output_device,
-            commands::audio::get_selected_output_device
+            commands::audio::get_selected_output_device,
+            commands::transcription::set_model_unload_timeout,
+            commands::transcription::get_model_load_status,
+            commands::transcription::unload_model_manually
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -3,7 +3,10 @@ use crate::settings::get_settings;
 use anyhow::Result;
 use natural::phonetics::soundex;
 use serde::Serialize;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, SystemTime};
 use strsim::levenshtein;
 use tauri::{App, AppHandle, Emitter, Manager};
 use whisper_rs::install_whisper_log_trampoline;
@@ -19,12 +22,15 @@ pub struct ModelStateEvent {
     pub error: Option<String>,
 }
 
+#[derive(Clone)]
 pub struct TranscriptionManager {
-    state: Mutex<Option<WhisperState>>,
-    context: Mutex<Option<WhisperContext>>,
+    state: Arc<Mutex<Option<WhisperState>>>,
+    context: Arc<Mutex<Option<WhisperContext>>>,
     model_manager: Arc<ModelManager>,
     app_handle: AppHandle,
-    current_model_id: Mutex<Option<String>>,
+    current_model_id: Arc<Mutex<Option<String>>>,
+    last_activity: Arc<AtomicU64>,
+    _watcher_handle: Arc<Mutex<Option<thread::JoinHandle<()>>>>,
 }
 
 fn apply_custom_words(text: &str, custom_words: &[String], threshold: f64) -> String {
@@ -140,18 +146,100 @@ impl TranscriptionManager {
         let app_handle = app.app_handle().clone();
 
         let manager = Self {
-            state: Mutex::new(None),
-            context: Mutex::new(None),
+            state: Arc::new(Mutex::new(None)),
+            context: Arc::new(Mutex::new(None)),
             model_manager,
             app_handle: app_handle.clone(),
-            current_model_id: Mutex::new(None),
+            current_model_id: Arc::new(Mutex::new(None)),
+            last_activity: Arc::new(AtomicU64::new(
+                SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis() as u64,
+            )),
+            _watcher_handle: Arc::new(Mutex::new(None)),
         };
+
+        // Start the idle watcher
+        {
+            let app_handle_cloned = app_handle.clone();
+            let manager_cloned = manager.clone();
+            let handle = thread::spawn(move || {
+                loop {
+                    thread::sleep(Duration::from_secs(10)); // Check every 10 seconds
+
+                    let settings = get_settings(&app_handle_cloned);
+                    let timeout_seconds = settings.model_unload_timeout.to_seconds();
+
+                    if let Some(limit_seconds) = timeout_seconds {
+                        let last = manager_cloned.last_activity.load(Ordering::Relaxed);
+                        let now_ms = SystemTime::now()
+                            .duration_since(SystemTime::UNIX_EPOCH)
+                            .unwrap()
+                            .as_millis() as u64;
+
+                        if now_ms.saturating_sub(last) > limit_seconds * 1000 {
+                            // idle -> unload
+                            if manager_cloned.is_model_loaded() {
+                                if let Ok(()) = manager_cloned.unload_model() {
+                                    let _ = app_handle_cloned.emit(
+                                        "model-state-changed",
+                                        ModelStateEvent {
+                                            event_type: "unloaded_due_to_idle".to_string(),
+                                            model_id: None,
+                                            model_name: None,
+                                            error: None,
+                                        },
+                                    );
+                                    println!("Model unloaded due to inactivity");
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+            *manager._watcher_handle.lock().unwrap() = Some(handle);
+        }
 
         // Try to load the default model from settings, but don't fail if no models are available
         let settings = get_settings(&app_handle);
         let _ = manager.load_model(&settings.selected_model);
 
         Ok(manager)
+    }
+
+    pub fn is_model_loaded(&self) -> bool {
+        let state = self.state.lock().unwrap();
+        state.is_some()
+    }
+
+    pub fn unload_model(&self) -> Result<()> {
+        {
+            let mut state = self.state.lock().unwrap();
+            *state = None; // Dropping state frees GPU/CPU memory
+        }
+        {
+            let mut context = self.context.lock().unwrap();
+            *context = None; // Dropping context frees additional memory
+        }
+        {
+            let mut current_model = self.current_model_id.lock().unwrap();
+            *current_model = None;
+        }
+
+        // Emit unloaded event
+        let _ = self.app_handle.emit(
+            "model-state-changed",
+            ModelStateEvent {
+                event_type: "unloaded_manually".to_string(),
+                model_id: None,
+                model_name: None,
+                error: None,
+            },
+        );
+
+        println!("Model unloaded manually");
+        Ok(())
     }
 
     pub fn load_model(&self, model_id: &str) -> Result<()> {
@@ -266,6 +354,15 @@ impl TranscriptionManager {
     }
 
     pub fn transcribe(&self, audio: Vec<f32>) -> Result<String> {
+        // Update last activity timestamp
+        self.last_activity.store(
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as u64,
+            Ordering::Relaxed,
+        );
+
         let st = std::time::Instant::now();
 
         let mut result = String::new();
@@ -276,10 +373,34 @@ impl TranscriptionManager {
             return Ok(result);
         }
 
+        // Check if model is loaded, if not try to load it
+        {
+            let state_guard = self.state.lock().unwrap();
+            if state_guard.is_none() {
+                // Model not loaded, try to load the selected model from settings
+                let settings = get_settings(&self.app_handle);
+                println!(
+                    "Model not loaded, attempting to load: {}",
+                    settings.selected_model
+                );
+
+                // Drop the guard before calling load_model to avoid deadlock
+                drop(state_guard);
+
+                // Try to load the model
+                if let Err(e) = self.load_model(&settings.selected_model) {
+                    return Err(anyhow::anyhow!(
+                        "Failed to auto-load model '{}': {}. Please check that the model is downloaded and try again.",
+                        settings.selected_model, e
+                    ));
+                }
+            }
+        }
+
         let mut state_guard = self.state.lock().unwrap();
         let state = state_guard.as_mut().ok_or_else(|| {
             anyhow::anyhow!(
-                "No model loaded. Please download and select a model from settings first."
+                "Model failed to load after auto-load attempt. Please check your model settings."
             )
         })?;
 

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -20,6 +20,46 @@ pub enum OverlayPosition {
     Bottom,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelUnloadTimeout {
+    Never,
+    Min2,
+    Min5,
+    Min10,
+    Min15,
+    Hour1,
+    Sec5, // Debug mode only
+}
+
+impl Default for ModelUnloadTimeout {
+    fn default() -> Self {
+        ModelUnloadTimeout::Never
+    }
+}
+
+impl ModelUnloadTimeout {
+    pub fn to_minutes(self) -> Option<u64> {
+        match self {
+            ModelUnloadTimeout::Never => None,
+            ModelUnloadTimeout::Min2 => Some(2),
+            ModelUnloadTimeout::Min5 => Some(5),
+            ModelUnloadTimeout::Min10 => Some(10),
+            ModelUnloadTimeout::Min15 => Some(15),
+            ModelUnloadTimeout::Hour1 => Some(60),
+            ModelUnloadTimeout::Sec5 => Some(0), // Special case for debug - handled separately
+        }
+    }
+
+    pub fn to_seconds(self) -> Option<u64> {
+        match self {
+            ModelUnloadTimeout::Never => None,
+            ModelUnloadTimeout::Sec5 => Some(5),
+            _ => self.to_minutes().map(|m| m * 60),
+        }
+    }
+}
+
 /* still handy for composing the initial JSON in the store ------------- */
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct AppSettings {
@@ -44,6 +84,8 @@ pub struct AppSettings {
     pub debug_mode: bool,
     #[serde(default)]
     pub custom_words: Vec<String>,
+    #[serde(default)]
+    pub model_unload_timeout: ModelUnloadTimeout,
     #[serde(default = "default_word_correction_threshold")]
     pub word_correction_threshold: f64,
 }
@@ -113,6 +155,7 @@ pub fn get_default_settings() -> AppSettings {
         overlay_position: OverlayPosition::Bottom,
         debug_mode: false,
         custom_words: Vec::new(),
+        model_unload_timeout: ModelUnloadTimeout::Never,
         word_correction_threshold: default_word_correction_threshold(),
     }
 }

--- a/src-tauri/src/shortcut.rs
+++ b/src-tauri/src/shortcut.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use tauri::{App, AppHandle, Manager};
+use tauri::{App, AppHandle, Emitter, Manager};
 use tauri_plugin_global_shortcut::GlobalShortcutExt;
 use tauri_plugin_global_shortcut::{Shortcut, ShortcutState};
 
@@ -160,6 +160,16 @@ pub fn change_debug_mode_setting(app: AppHandle, enabled: bool) -> Result<(), St
     let mut settings = settings::get_settings(&app);
     settings.debug_mode = enabled;
     settings::write_settings(&app, settings);
+
+    // Emit event to notify frontend of debug mode change
+    let _ = app.emit(
+        "settings-changed",
+        serde_json::json!({
+            "setting": "debug_mode",
+            "value": enabled
+        }),
+    );
+
     Ok(())
 }
 

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -3,6 +3,7 @@ import { getVersion } from "@tauri-apps/api/app";
 
 import ModelSelector from "../model-selector";
 import UpdateChecker from "../update-checker";
+import ModelStatus from "./ModelStatus";
 
 const Footer: React.FC = () => {
   const [version, setVersion] = useState("");
@@ -26,6 +27,7 @@ const Footer: React.FC = () => {
       <div className="flex justify-between items-center text-xs px-4 pb-3 text-text/60">
         <div className="flex items-center gap-4">
           <ModelSelector />
+          <ModelStatus />
         </div>
 
         {/* Update Status */}

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -3,7 +3,6 @@ import { getVersion } from "@tauri-apps/api/app";
 
 import ModelSelector from "../model-selector";
 import UpdateChecker from "../update-checker";
-import ModelStatus from "./ModelStatus";
 
 const Footer: React.FC = () => {
   const [version, setVersion] = useState("");
@@ -27,7 +26,6 @@ const Footer: React.FC = () => {
       <div className="flex justify-between items-center text-xs px-4 pb-3 text-text/60">
         <div className="flex items-center gap-4">
           <ModelSelector />
-          <ModelStatus />
         </div>
 
         {/* Update Status */}

--- a/src/components/settings/ModelUnloadTimeout.tsx
+++ b/src/components/settings/ModelUnloadTimeout.tsx
@@ -1,0 +1,69 @@
+import React, { useMemo } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useSettings } from "../../hooks/useSettings";
+import { ModelUnloadTimeout } from "../../lib/types";
+import { Dropdown } from "../ui/Dropdown";
+import { SettingContainer } from "../ui/SettingContainer";
+
+interface ModelUnloadTimeoutProps {
+  descriptionMode?: "tooltip" | "inline";
+  grouped?: boolean;
+}
+
+const timeoutOptions = [
+  { value: "never" as ModelUnloadTimeout, label: "Never" },
+  { value: "min2" as ModelUnloadTimeout, label: "After 2 minutes" },
+  { value: "min5" as ModelUnloadTimeout, label: "After 5 minutes" },
+  { value: "min10" as ModelUnloadTimeout, label: "After 10 minutes" },
+  { value: "min15" as ModelUnloadTimeout, label: "After 15 minutes" },
+  { value: "hour1" as ModelUnloadTimeout, label: "After 1 hour" },
+];
+
+const debugTimeoutOptions = [
+  ...timeoutOptions,
+  { value: "sec5" as ModelUnloadTimeout, label: "After 5 seconds (Debug)" },
+];
+
+export const ModelUnloadTimeoutSetting: React.FC<ModelUnloadTimeoutProps> = ({
+  descriptionMode = "inline",
+  grouped = false,
+}) => {
+  const { settings, getSetting, updateSetting } = useSettings();
+
+  const handleChange = async (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const newTimeout = event.target.value as ModelUnloadTimeout;
+
+    try {
+      await invoke("set_model_unload_timeout", { timeout: newTimeout });
+      updateSetting("model_unload_timeout", newTimeout);
+    } catch (error) {
+      console.error("Failed to update model unload timeout:", error);
+    }
+  };
+
+  const currentValue = getSetting("model_unload_timeout") ?? "never";
+
+  const options = useMemo(() => {
+    return settings?.debug_mode === true ? debugTimeoutOptions : timeoutOptions;
+  }, [settings]);
+
+  return (
+    <SettingContainer
+      title="Auto-unload model when idle"
+      description="Automatically free GPU/CPU memory when the model hasn't been used for the specified time"
+      descriptionMode={descriptionMode}
+      grouped={grouped}
+    >
+      <Dropdown
+        options={options}
+        selectedValue={currentValue}
+        onSelect={(value) =>
+          handleChange({
+            target: { value },
+          } as React.ChangeEvent<HTMLSelectElement>)
+        }
+        disabled={false}
+      />
+    </SettingContainer>
+  );
+};

--- a/src/components/settings/ModelUnloadTimeout.tsx
+++ b/src/components/settings/ModelUnloadTimeout.tsx
@@ -49,7 +49,7 @@ export const ModelUnloadTimeoutSetting: React.FC<ModelUnloadTimeoutProps> = ({
 
   return (
     <SettingContainer
-      title="Auto-unload model when idle"
+      title="Unload Model"
       description="Automatically free GPU/CPU memory when the model hasn't been used for the specified time"
       descriptionMode={descriptionMode}
       grouped={grouped}

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -9,6 +9,7 @@ import { HandyShortcut } from "./HandyShortcut";
 import { TranslateToEnglish } from "./TranslateToEnglish";
 import { LanguageSelector } from "./LanguageSelector";
 import { CustomWords } from "./CustomWords";
+import { ModelUnloadTimeoutSetting } from "./ModelUnloadTimeout";
 import { SettingsGroup } from "../ui/SettingsGroup";
 import { WordCorrectionThreshold } from "./debug/WordCorrectionThreshold";
 import { AppDataDirectory } from "./AppDataDirectory";
@@ -56,6 +57,7 @@ export const Settings: React.FC = () => {
         <OutputDeviceSelector descriptionMode="tooltip" grouped={true} />
         <ShowOverlay descriptionMode="tooltip" grouped={true} />
         <TranslateToEnglish descriptionMode="tooltip" grouped={true} />
+        <ModelUnloadTimeoutSetting descriptionMode="tooltip" grouped={true} />
         <CustomWords descriptionMode="tooltip" grouped />
         <AlwaysOnMicrophone descriptionMode="tooltip" grouped={true} />
       </SettingsGroup>

--- a/src/components/settings/debug/DebugPaths.tsx
+++ b/src/components/settings/debug/DebugPaths.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { SettingContainer } from "../../ui/SettingContainer";
+
+interface DebugPathsProps {
+  descriptionMode?: "tooltip" | "inline";
+  grouped?: boolean;
+}
+
+export const DebugPaths: React.FC<DebugPathsProps> = ({
+  descriptionMode = "inline",
+  grouped = false,
+}) => {
+  return (
+    <SettingContainer
+      title="Debug Paths"
+      description="Display internal file paths and directories for debugging purposes"
+      descriptionMode={descriptionMode}
+      grouped={grouped}
+    >
+      <div className="text-sm text-gray-600 space-y-2">
+        <div>
+          <span className="font-medium">App Data:</span>{" "}
+          <span className="font-mono text-xs">%APPDATA%/handy</span>
+        </div>
+        <div>
+          <span className="font-medium">Models:</span>{" "}
+          <span className="font-mono text-xs">%APPDATA%/handy/models</span>
+        </div>
+        <div>
+          <span className="font-medium">Settings:</span>{" "}
+          <span className="font-mono text-xs">%APPDATA%/handy/settings_store.json</span>
+        </div>
+      </div>
+    </SettingContainer>
+  );
+};

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -9,3 +9,4 @@ export { HandyShortcut } from "./HandyShortcut";
 export { TranslateToEnglish } from "./TranslateToEnglish";
 export { CustomWords } from "./CustomWords";
 export { AppDataDirectory } from "./AppDataDirectory";
+export { ModelUnloadTimeoutSetting } from "./ModelUnloadTimeout";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -22,6 +22,17 @@ export const AudioDeviceSchema = z.object({
 export const OverlayPositionSchema = z.enum(["none", "top", "bottom"]);
 export type OverlayPosition = z.infer<typeof OverlayPositionSchema>;
 
+export const ModelUnloadTimeoutSchema = z.enum([
+  "never",
+  "min2",
+  "min5",
+  "min10",
+  "min15",
+  "hour1",
+  "sec5",
+]);
+export type ModelUnloadTimeout = z.infer<typeof ModelUnloadTimeoutSchema>;
+
 export const SettingsSchema = z.object({
   bindings: ShortcutBindingsMapSchema,
   push_to_talk: z.boolean(),
@@ -35,6 +46,7 @@ export const SettingsSchema = z.object({
   overlay_position: OverlayPositionSchema,
   debug_mode: z.boolean(),
   custom_words: z.array(z.string()).optional().default([]),
+  model_unload_timeout: ModelUnloadTimeoutSchema.optional().default("never"),
   word_correction_threshold: z.number().optional().default(0.15),
 });
 


### PR DESCRIPTION
This feature has been requested many times and the main thing is that we want to unload the model when it is not actively being used and this may improve battery life on some devices. Also not using VRAM unless it's absolutely necessary