### PR TITLE
Tweak Sampling Params

### DIFF
--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -441,7 +441,10 @@ impl TranscriptionManager {
         let settings = get_settings(&self.app_handle);
 
         // Initialize parameters
-        let mut params = FullParams::new(SamplingStrategy::default());
+        let mut params = FullParams::new(SamplingStrategy::BeamSearch {
+            beam_size: 3,
+            patience: -1.0,
+        });
         let language = Some(settings.selected_language.as_str());
         params.set_language(language);
         params.set_print_special(false);


### PR DESCRIPTION
In a nutshell, I tweaked the sampling parameters so hopefully that there is a bit more accurate transcriptions with less chance of hallucination overall. We'll kind of have to see how this works. There's a moderate performance impact to this, but it should be negligible for most systems, I suspect.