### PR TITLE
Support mac Fn shortcut handling

### DIFF
--- a/src-tauri/src/fn_monitor.rs
+++ b/src-tauri/src/fn_monitor.rs
@@ -1,0 +1,141 @@
+use once_cell::sync::Lazy;
+use rdev::{listen, Event, EventType, Key};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use tauri::AppHandle;
+use tauri_plugin_global_shortcut::ShortcutState;
+
+use crate::settings::ShortcutBinding;
+use crate::shortcut::dispatch_binding_event;
+
+pub(crate) fn register_fn_binding(app: &AppHandle, binding: ShortcutBinding) -> Result<(), String> {
+    ensure_listener_started();
+
+    let mut state = MONITOR_STATE
+        .lock()
+        .map_err(|_| "Failed to lock Fn monitor state".to_string())?;
+
+    state.bindings.insert(
+        binding.id.clone(),
+        FnBindingEntry {
+            app_handle: app.clone(),
+            binding_id: binding.id,
+            shortcut_string: binding.current_binding,
+        },
+    );
+
+    Ok(())
+}
+
+pub(crate) fn unregister_fn_binding(_app: &AppHandle, binding_id: &str) -> Result<(), String> {
+    let mut state = MONITOR_STATE
+        .lock()
+        .map_err(|_| "Failed to lock Fn monitor state".to_string())?;
+
+    if state.bindings.remove(binding_id).is_some() && state.bindings.is_empty() {
+        state.fn_pressed = false;
+    }
+
+    Ok(())
+}
+
+fn ensure_listener_started() {
+    if MONITOR_STARTED.load(Ordering::SeqCst) {
+        return;
+    }
+
+    if MONITOR_STARTED
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_ok()
+    {
+        let state = Arc::clone(&MONITOR_STATE);
+        thread::spawn(move || {
+            let result = listen(move |event| handle_event(&state, event));
+            if let Err(err) = result {
+                eprintln!("Fn monitor failed: {:?}", err);
+                MONITOR_STARTED.store(false, Ordering::SeqCst);
+            }
+        });
+    }
+}
+
+fn handle_event(state: &Arc<Mutex<FnMonitorState>>, event: Event) {
+    let maybe_state = match event.event_type {
+        EventType::KeyPress(Key::Function) | EventType::KeyPress(Key::Unknown(63)) => {
+            Some(ShortcutState::Pressed)
+        }
+        EventType::KeyRelease(Key::Function)
+        | EventType::KeyRelease(Key::Unknown(63)) => Some(ShortcutState::Released),
+        _ => None,
+    };
+
+    if let Some(shortcut_state) = maybe_state {
+        broadcast_event(state, shortcut_state);
+    }
+}
+
+fn broadcast_event(state: &Arc<Mutex<FnMonitorState>>, shortcut_state: ShortcutState) {
+    let bindings: Vec<FnBindingEntry> = {
+        let mut guard = match state.lock() {
+            Ok(guard) => guard,
+            Err(_) => {
+                eprintln!("Fn monitor state poisoned");
+                return;
+            }
+        };
+
+        if guard.bindings.is_empty() {
+            return;
+        }
+
+        match shortcut_state {
+            ShortcutState::Pressed => {
+                if guard.fn_pressed {
+                    return;
+                }
+                guard.fn_pressed = true;
+            }
+            ShortcutState::Released => {
+                if !guard.fn_pressed {
+                    return;
+                }
+                guard.fn_pressed = false;
+            }
+        }
+
+        guard.bindings.values().cloned().collect()
+    };
+
+    if bindings.is_empty() {
+        return;
+    }
+
+    for binding in bindings {
+        dispatch_binding_event(
+            &binding.app_handle,
+            &binding.binding_id,
+            &binding.shortcut_string,
+            shortcut_state,
+        );
+    }
+}
+
+#[derive(Clone)]
+struct FnBindingEntry {
+    app_handle: AppHandle,
+    binding_id: String,
+    shortcut_string: String,
+}
+
+#[derive(Default)]
+struct FnMonitorState {
+    bindings: HashMap<String, FnBindingEntry>,
+    fn_pressed: bool,
+}
+
+static MONITOR_STATE: Lazy<Arc<Mutex<FnMonitorState>>> =
+    Lazy::new(|| Arc::new(Mutex::new(FnMonitorState::default())));
+
+static MONITOR_STARTED: AtomicBool = AtomicBool::new(false);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,9 @@ mod shortcut;
 mod tray;
 mod utils;
 
+#[cfg(target_os = "macos")]
+mod fn_monitor;
+
 use managers::audio::AudioRecordingManager;
 use managers::history::HistoryManager;
 use managers::model::ModelManager;

--- a/src/components/settings/HandyShortcut.tsx
+++ b/src/components/settings/HandyShortcut.tsx
@@ -33,6 +33,7 @@ export const HandyShortcut: React.FC<HandyShortcutProps> = ({
   const shortcutRefs = useRef<Map<string, HTMLDivElement | null>>(new Map());
 
   const bindings = getSetting("bindings") || {};
+  const isMac = osType === "macos";
 
   // Detect and store OS type
   useEffect(() => {
@@ -239,6 +240,15 @@ export const HandyShortcut: React.FC<HandyShortcutProps> = ({
     shortcutRefs.current.set(id, ref);
   };
 
+  const applyFnShortcut = async (id: string) => {
+    try {
+      await updateBinding(id, "fn");
+    } catch (error) {
+      console.error("Failed to set Fn shortcut:", error);
+      toast.error("Failed to set Fn shortcut");
+    }
+  };
+
   // If still loading, show loading state
   if (isLoading) {
     return (
@@ -284,6 +294,9 @@ export const HandyShortcut: React.FC<HandyShortcutProps> = ({
           );
         }
 
+        const isFnActive =
+          primaryBinding.current_binding.toLowerCase() === "fn";
+
         return (
           <div className="flex items-center space-x-1">
             {editingShortcutId === primaryId ? (
@@ -301,10 +314,22 @@ export const HandyShortcut: React.FC<HandyShortcutProps> = ({
                 {formatKeyCombination(primaryBinding.current_binding, osType)}
               </div>
             )}
+            {isMac && editingShortcutId !== primaryId && (
+              <button
+                className="px-2 py-1 text-xs font-semibold border border-mid-gray/80 rounded hover:border-logo-primary hover:text-logo-primary disabled:opacity-50 disabled:cursor-not-allowed"
+                onClick={() => applyFnShortcut(primaryId)}
+                disabled={isUpdating(`binding_${primaryId}`) || isFnActive}
+              >
+                {isFnActive ? "Fn Active" : "Use Fn"}
+              </button>
+            )}
             <ResetButton
               onClick={() => resetBinding(primaryId)}
               disabled={isUpdating(`binding_${primaryId}`)}
             />
+            {isFnActive && isMac && (
+              <span className="text-xs text-mid-gray">macOS-only shortcut</span>
+            )}
           </div>
         );
       })()}

--- a/src/lib/utils/keyboard.ts
+++ b/src/lib/utils/keyboard.ts
@@ -162,9 +162,46 @@ export const formatKeyCombination = (
   combination: string,
   osType: OSType,
 ): string => {
-  // Simply return the combination as-is since getKeyName already provides
-  // the correct platform-specific key names
-  return combination;
+  if (!combination) return "";
+
+  const formatSegment = (segment: string): string => {
+    const key = segment.trim().toLowerCase();
+
+    const atlas: Record<string, string> = {
+      fn: "Fn",
+      command: osType === "macos" ? "⌘" : osType === "windows" ? "Win" : "Super",
+      super: osType === "macos" ? "⌘" : "Super",
+      option: "Option",
+      alt: osType === "macos" ? "Option" : "Alt",
+      ctrl: "Ctrl",
+      control: "Ctrl",
+      shift: "Shift",
+      space: "Space",
+      enter: "Enter",
+      esc: "Esc",
+      escape: "Esc",
+      tab: "Tab",
+      "page up": "Page Up",
+      "page down": "Page Down",
+      "caps lock": "Caps Lock",
+      commandorcontrol: osType === "macos" ? "⌘" : "Ctrl",
+    };
+
+    if (atlas[key]) {
+      return atlas[key];
+    }
+
+    if (key.startsWith("f") && key.length > 1 && !Number.isNaN(Number(key.substring(1)))) {
+      return key.toUpperCase();
+    }
+
+    return key.length === 1 ? key.toUpperCase() : key.replace(/\b\w/g, (m) => m.toUpperCase());
+  };
+
+  return combination
+    .split("+")
+    .map((segment) => formatSegment(segment))
+    .join(" + ");
 };
 
 /**


### PR DESCRIPTION
- special-case "fn" bindings via rdev listener so mac users can use Fn
- reuse shortcut dispatcher to drive existing push-to-talk/toggle flow
- expose Use Fn button on mac settings and keep Cmd glyph formatting