### PR TITLE
drop libsamplerate feature to fix macos build

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1075,15 +1075,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dasp_frame"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a3937f5fe2135702897535c8d4a5553f8b116f76c1529088797f2eee7c5cd6"
-dependencies = [
- "dasp_sample",
-]
-
-[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,18 +1286,6 @@ name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
-
-[[package]]
-name = "ebur128"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e227cc62d64d6fe01abbef48134b9c1f17d470cef1e7a56337ad05b1f81df7f9"
-dependencies = [
- "bitflags 1.3.2",
- "dasp_frame",
- "dasp_sample",
- "smallvec 1.13.2",
-]
 
 [[package]]
 name = "either"
@@ -2983,15 +2962,6 @@ dependencies = [
  "bitflags 2.8.0",
  "libc",
  "redox_syscall",
-]
-
-[[package]]
-name = "libsamplerate-sys"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28853b399f78f8281cd88d333b54a63170c4275f6faea66726a2bea5cca72e0d"
-dependencies = [
- "cmake",
 ]
 
 [[package]]
@@ -4931,15 +4901,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "samplerate"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e032b2b24715c4f982f483ea3abdb3c9ba444d9f63e87b2843d6f998f5ba2698"
-dependencies = [
- "libsamplerate-sys",
 ]
 
 [[package]]
@@ -6985,12 +6946,10 @@ name = "vad-rs"
 version = "0.1.5"
 source = "git+https://github.com/cjpais/vad-rs#88b3a01f72f83a5d80d0e7ea9bacfc0d897fd03f"
 dependencies = [
- "ebur128",
  "eyre",
  "ndarray",
  "ort",
  "ringbuffer",
- "samplerate",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,7 +47,7 @@ hound = "3.5.1"
 env_logger = "0.11.6"
 log = "0.4.25"
 tokio = "1.43.0"
-vad-rs = { git = "https://github.com/cjpais/vad-rs" }
+vad-rs = { git = "https://github.com/cjpais/vad-rs", default-features = false }
 tauri-plugin-store = "2"
 tauri-plugin-os = "2"
 enigo = "0.5.0"


### PR DESCRIPTION
## Summary
- disable `vad-rs` default features so the helpers module (and libsamplerate-sys) stay out of our dependency tree
- refresh Cargo.lock; the git dependency now pulls only pure-Rust crates

## Why
Modern macOS installs ship CMake ≥3.30, which refuses to configure the vendored libsamplerate sources pulled in by the `samplerate` helper. The build blows up with:
```
error: failed to run custom build command for libsamplerate-sys v0.1.12

--- stderr
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
Compatibility with CMake < 3.5 has been removed from CMake.
```

Dropping the helper removes that dependency entirely, so the build succeeds again.

  ## Testing
  - cargo check
  - bun run tauri dev