### PR TITLE
fix: delay releasing modifier key on paste to let slow consumers handle the keystroke

### DIFF
--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -24,13 +24,11 @@ fn send_paste() -> Result<(), String> {
         .key(modifier_key, enigo::Direction::Press)
         .map_err(|e| format!("Failed to press modifier key: {}", e))?;
     enigo
-        .key(v_key_code, enigo::Direction::Press)
+        .key(v_key_code, enigo::Direction::Click)
         .map_err(|e| format!("Failed to press V key: {}", e))?;
 
-    // Release V + modifier (reverse order)
-    enigo
-        .key(v_key_code, enigo::Direction::Release)
-        .map_err(|e| format!("Failed to release V key: {}", e))?;
+    std::thread::sleep(std::time::Duration::from_millis(100));
+
     enigo
         .key(modifier_key, enigo::Direction::Release)
         .map_err(|e| format!("Failed to release modifier key: {}", e))?;

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -25,7 +25,7 @@ fn send_paste() -> Result<(), String> {
         .map_err(|e| format!("Failed to press modifier key: {}", e))?;
     enigo
         .key(v_key_code, enigo::Direction::Click)
-        .map_err(|e| format!("Failed to press V key: {}", e))?;
+        .map_err(|e| format!("Failed to click V key: {}", e))?;
 
     std::thread::sleep(std::time::Duration::from_millis(100));
 


### PR DESCRIPTION
Addresses https://github.com/cjpais/Handy/issues/164.

It both adds a delay between pressing the `v` and replaces press+release `v` with just `click` which is effectively the same thing. 

It works for me in any app now, no matter what layout is set and which text field it is.

Unfortunately, I could not confirm if it's breaking anything for other platforms.