### PR TITLE
feat(settings): add autostart toggle in advanced settings

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -137,10 +137,17 @@ pub fn run() {
             // Initialize tray menu with idle state
             utils::update_tray_menu(&app.handle(), &utils::TrayIconState::Idle);
 
-            // Get the autostart manager
+            // Get the autostart manager and configure based on user setting
             let autostart_manager = app.autolaunch();
-            // Enable autostart
-            let _ = autostart_manager.enable();
+            let settings = settings::get_settings(&app.handle());
+
+            if settings.autostart_enabled {
+                // Enable autostart if user has opted in
+                let _ = autostart_manager.enable();
+            } else {
+                // Disable autostart if user has opted out
+                let _ = autostart_manager.disable();
+            }
 
             // Window is configured to start hidden to avoid flicker.
             // If user didn't choose Start Hidden, show it now.
@@ -205,6 +212,7 @@ pub fn run() {
             shortcut::change_ptt_setting,
             shortcut::change_audio_feedback_setting,
             shortcut::change_start_hidden_setting,
+            shortcut::change_autostart_setting,
             shortcut::change_translate_to_english_setting,
             shortcut::change_selected_language_setting,
             shortcut::change_overlay_position_setting,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -71,6 +71,8 @@ pub struct AppSettings {
     pub audio_feedback: bool,
     #[serde(default = "default_start_hidden")]
     pub start_hidden: bool,
+    #[serde(default = "default_autostart_enabled")]
+    pub autostart_enabled: bool,
     #[serde(default = "default_model")]
     pub selected_model: String,
     #[serde(default = "default_always_on_microphone")]
@@ -108,6 +110,10 @@ fn default_translate_to_english() -> bool {
 }
 
 fn default_start_hidden() -> bool {
+    false
+}
+
+fn default_autostart_enabled() -> bool {
     false
 }
 
@@ -156,6 +162,7 @@ pub fn get_default_settings() -> AppSettings {
         push_to_talk: true,
         audio_feedback: false,
         start_hidden: default_start_hidden(),
+        autostart_enabled: default_autostart_enabled(),
         selected_model: "".to_string(),
         always_on_microphone: false,
         selected_microphone: None,

--- a/src-tauri/src/shortcut.rs
+++ b/src-tauri/src/shortcut.rs
@@ -192,6 +192,27 @@ pub fn change_start_hidden_setting(app: AppHandle, enabled: bool) -> Result<(), 
 }
 
 #[tauri::command]
+pub fn change_autostart_setting(app: AppHandle, enabled: bool) -> Result<(), String> {
+    let mut settings = settings::get_settings(&app);
+    settings.autostart_enabled = enabled;
+    settings::write_settings(&app, settings);
+
+    // Note: Autostart is only managed during app initialization in lib.rs
+    // The setting change will take effect on the next app restart
+
+    // Notify frontend
+    let _ = app.emit(
+        "settings-changed",
+        serde_json::json!({
+            "setting": "autostart_enabled",
+            "value": enabled
+        }),
+    );
+
+    Ok(())
+}
+
+#[tauri::command]
 pub fn update_custom_words(app: AppHandle, words: Vec<String>) -> Result<(), String> {
     let mut settings = settings::get_settings(&app);
     settings.custom_words = words;

--- a/src/components/settings/AdvancedSettings.tsx
+++ b/src/components/settings/AdvancedSettings.tsx
@@ -6,12 +6,14 @@ import { CustomWords } from "./CustomWords";
 import { AlwaysOnMicrophone } from "./AlwaysOnMicrophone";
 import { SettingsGroup } from "../ui/SettingsGroup";
 import { StartHidden } from "./StartHidden";
+import { AutostartToggle } from "./AutostartToggle";
 
 export const AdvancedSettings: React.FC = () => {
   return (
     <div className="max-w-3xl w-full mx-auto space-y-6">
       <SettingsGroup title="Advanced">
         <StartHidden descriptionMode="tooltip" grouped={true} />
+        <AutostartToggle descriptionMode="tooltip" grouped={true} />
         <ShowOverlay descriptionMode="tooltip" grouped={true} />
         <TranslateToEnglish descriptionMode="tooltip" grouped={true} />
         <ModelUnloadTimeoutSetting descriptionMode="tooltip" grouped={true} />

--- a/src/components/settings/AutostartToggle.tsx
+++ b/src/components/settings/AutostartToggle.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { ToggleSwitch } from "../ui/ToggleSwitch";
+import { useSettings } from "../../hooks/useSettings";
+
+interface AutostartToggleProps {
+  descriptionMode?: "inline" | "tooltip";
+  grouped?: boolean;
+}
+
+export const AutostartToggle: React.FC<AutostartToggleProps> = React.memo(({
+  descriptionMode = "tooltip",
+  grouped = false,
+}) => {
+  const { getSetting, updateSetting, isUpdating } = useSettings();
+
+  const autostartEnabled = getSetting("autostart_enabled") ?? false;
+
+  return (
+    <ToggleSwitch
+      checked={autostartEnabled}
+      onChange={(enabled) => updateSetting("autostart_enabled", enabled)}
+      isUpdating={isUpdating("autostart_enabled")}
+      label="Launch on Startup"
+      description="Automatically start Handy when you log in to your computer. Takes effect on next restart."
+      descriptionMode={descriptionMode}
+      grouped={grouped}
+    />
+  );
+});

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -18,3 +18,4 @@ export { CustomWords } from "./CustomWords";
 export { AppDataDirectory } from "./AppDataDirectory";
 export { ModelUnloadTimeoutSetting } from "./ModelUnloadTimeout";
 export { StartHidden } from "./StartHidden";
+export { AutostartToggle } from "./AutostartToggle";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -39,6 +39,7 @@ export const SettingsSchema = z.object({
   push_to_talk: z.boolean(),
   audio_feedback: z.boolean(),
   start_hidden: z.boolean().optional().default(false),
+  autostart_enabled: z.boolean().optional().default(false),
   selected_model: z.string(),
   always_on_microphone: z.boolean(),
   selected_microphone: z.string().nullable().optional(),

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -34,6 +34,7 @@ const DEFAULT_SETTINGS: Partial<Settings> = {
   always_on_microphone: false,
   audio_feedback: true,
   start_hidden: false,
+  autostart_enabled: false,
   push_to_talk: false,
   selected_microphone: "Default",
   selected_output_device: "Default",
@@ -165,6 +166,9 @@ export const useSettingsStore = create<SettingsStore>()(
             break;
           case "start_hidden":
             await invoke("change_start_hidden_setting", { enabled: value });
+            break;
+          case "autostart_enabled":
+            await invoke("change_autostart_setting", { enabled: value });
             break;
           case "push_to_talk":
             await invoke("change_ptt_setting", { enabled: value });


### PR DESCRIPTION
Enable users to configure autostart behavior through a new toggle in the advanced settings UI. The backend now checks user preferences on startup to enable or disable autostart accordingly, with the setting persisted and manageable via a new Tauri command. This provides better control over app initialization without affecting existing functionality.