### PR TITLE
use Ctrl+Shift+V for paste on Linux terminals

### DIFF
--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -19,18 +19,32 @@ fn send_paste() -> Result<(), String> {
     let mut enigo = Enigo::new(&Settings::default())
         .map_err(|e| format!("Failed to initialize Enigo: {}", e))?;
 
-    // Press modifier + V
+    // Press Ctrl (or Cmd on macOS)
     enigo
         .key(modifier_key, enigo::Direction::Press)
         .map_err(|e| format!("Failed to press modifier key: {}", e))?;
+
+    // Linux terminals need Ctrl+Shift+V (Ctrl+V is reserved for terminal control)
+    #[cfg(target_os = "linux")]
+    enigo
+        .key(Key::Shift, enigo::Direction::Press)
+        .map_err(|e| format!("Failed to press Shift: {}", e))?;
+
+    // Press V
     enigo
         .key(v_key_code, enigo::Direction::Press)
         .map_err(|e| format!("Failed to press V key: {}", e))?;
 
-    // Release V + modifier (reverse order)
+    // Release in reverse order
     enigo
         .key(v_key_code, enigo::Direction::Release)
         .map_err(|e| format!("Failed to release V key: {}", e))?;
+
+    #[cfg(target_os = "linux")]
+    enigo
+        .key(Key::Shift, enigo::Direction::Release)
+        .map_err(|e| format!("Failed to release Shift: {}", e))?;
+
     enigo
         .key(modifier_key, enigo::Direction::Release)
         .map_err(|e| format!("Failed to release modifier key: {}", e))?;


### PR DESCRIPTION
## Issue
Paste functionality failed in Linux terminals because Ctrl+V is reserved for terminal control signals (SIGINT). It worked in GUI apps but not terminal emulators.

## Solution
Changed Linux to use Ctrl+Shift+V, the standard paste shortcut for Linux terminals.

## Why not `enigo.text()`?
The current architecture writes to clipboard then pastes, allowing clipboard restoration after paste (lines 59-75
in clipboard.rs). Using `enigo.text()` would bypass the clipboard entirely, preventing restoration of the user's
original clipboard content. The Ctrl+Shift+V approach preserves this feature with minimal changes and no new
dependencies.

## Testing
- Compiles successfully
- Works in terminal emulators
- Works in GUI applications
- No new dependencies added

Closes #138 and possibly #93 