### PR TITLE
Updating Cargo.lock packages (crossbeam-channel, ring and tokio)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3080,7 +3080,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4870,15 +4870,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]


### PR DESCRIPTION
 ## Summary
 
1. Why:
To remove CVEs:
     - [CVE-2025-4574](https://osv.dev/vulnerability/CVE-2025-4574)
     - [RUSTSEC-2025-0024](https://osv.dev/vulnerability/RUSTSEC-2025-0024)

     - [RUSTSEC-2025-0009](https://osv.dev/vulnerability/RUSTSEC-2025-0009)
     - [GHSA-4p46-pwfr-66x6](https://osv.dev/vulnerability/GHSA-4p46-pwfr-66x6)
     - [CVE-2025-4432](https://osv.dev/vulnerability/CVE-2025-4432)
     
     - [RUSTSEC-2025-0023](https://osv.dev/vulnerability/RUSTSEC-2025-0023)
     - [GHSA-rr8g-9fpq-6wmg](https://osv.dev/vulnerability/GHSA-rr8g-9fpq-6wmg)


2. What:

     - Update crossbeam-channel to 0.5.15 to remove [CVE-2025-4574](https://osv.dev/vulnerability/CVE-2025-4574) and [RUSTSEC-2025-0024](https://osv.dev/vulnerability/RUSTSEC-2025-0024)

     - Update ring to 0.17.14, windows-targets to 0.48.5 and removed spin for compatibility to remove [RUSTSEC-2025-0009](https://osv.dev/vulnerability/RUSTSEC-2025-0009), [GHSA-4p46-pwfr-66x6](https://osv.dev/vulnerability/GHSA-4p46-pwfr-66x6) and [CVE-2025-4432](https://osv.dev/vulnerability/CVE-2025-4432)

     - Update tokio to v1.47.1 and socket2 to 0.5.8 to remove [RUSTSEC-2025-0023](https://osv.dev/vulnerability/RUSTSEC-2025-0023) and [GHSA-rr8g-9fpq-6wmg](https://osv.dev/vulnerability/GHSA-rr8g-9fpq-6wmg)

 
 ## Additional evidence
 
 Partial output from osv-security scanner:
<img width="910" height="422" alt="cves handy cargo" src="https://github.com/user-attachments/assets/3601bc22-b4a3-4700-842d-41dc6858d722" />


 ## Categorization
 

- [x] security/CVE