### PR TITLE
Fix for flickering recording overlay

### DIFF
--- a/src-tauri/src/audio_toolkit/audio/recorder.rs
+++ b/src-tauri/src/audio_toolkit/audio/recorder.rs
@@ -245,7 +245,7 @@ fn run_consumer(
         in_sample_rate,
         WINDOW_SIZE,
         BUCKETS,
-        80.0,   // vocal_min_hz
+        400.0,  // vocal_min_hz
         4000.0, // vocal_max_hz
     );
 

--- a/src/overlay/RecordingOverlay.tsx
+++ b/src/overlay/RecordingOverlay.tsx
@@ -76,8 +76,8 @@ const RecordingOverlay: React.FC = () => {
                 className="bar"
                 style={{
                   height: `${Math.min(20, 4 + Math.pow(v, 0.7) * 16)}px`, // Cap at 20px max height
-                  transition: "height 60ms ease-out",
-                  opacity: Math.max(0.4, v * 1.7), // Minimum opacity for visibility
+                  transition: "height 60ms ease-out, opacity 120ms ease-out",
+                  opacity: Math.max(0.2, v * 1.7), // Minimum opacity for visibility
                 }}
               />
             ))}


### PR DESCRIPTION
Super small fix for the flickering you see while recording. I also don't think we need to go as low as 80 for a vocal range.