### PR TITLE
fix: add required defaults option to plugin-store configuration

### DIFF
--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -134,7 +134,10 @@ export const useSettingsStore = create<SettingsStore>()(
     refreshSettings: async () => {
       try {
         const { load } = await import("@tauri-apps/plugin-store");
-        const store = await load("settings_store.json", { autoSave: false });
+        const store = await load("settings_store.json", { 
+          defaults: DEFAULT_SETTINGS,
+          autoSave: false 
+        });
         const settings = (await store.get("settings")) as Settings;
 
         // Load additional settings that come from invoke calls


### PR DESCRIPTION
## Summary
Fixes a TypeScript compilation error introduced when updating @tauri-apps/plugin-store to v2.4.1.

The store plugin now requires the `defaults` property in StoreOptions, but the refreshSettings method was only passing `autoSave: false`. This caused a build failure.

## Changes
- Added `defaults: DEFAULT_SETTINGS` to the load() call in settingsStore.ts
- Ensures the store has proper default values when initialized

## Related
- Triggered by recent dependency updates (commit: dd40d8e)
- @tauri-apps/plugin-store v2.4.1 now requires `defaults` in StoreOptions

## Testing
✓ Build succeeds (vite build + tsc validation)