### PR TITLE
feat: Enable enigo wayland feature

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1451,6 +1451,10 @@ dependencies = [
  "objc2 0.6.3",
  "objc2-app-kit",
  "objc2-foundation 0.3.2",
+ "tempfile",
+ "wayland-client",
+ "wayland-protocols-misc",
+ "wayland-protocols-wlr",
  "windows 0.61.3",
  "x11rb",
  "xkbcommon",
@@ -7542,6 +7546,19 @@ dependencies = [
  "bitflags 2.10.0",
  "wayland-backend",
  "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-misc"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfe33d551eb8bffd03ff067a8b44bb963919157841a99957151299a6307d19c"
+dependencies = [
+ "bitflags 2.10.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,7 +53,7 @@ env_logger = "0.11.6"
 log = "0.4.25"
 tokio = "1.43.0"
 vad-rs = { git = "https://github.com/cjpais/vad-rs", default-features = false }
-enigo = "0.6.1"
+enigo = { version = "0.6.1", features = ["wayland"] }
 rodio = { git = "https://github.com/cjpais/rodio.git" }
 reqwest = { version = "0.12", features = ["json", "stream"] }
 async-openai = "0.30.1"


### PR DESCRIPTION
## Motivation

Currently Handy cannot be used in Wayland compositors

## Changes

Enable enigo's [wayland feature](https://docs.rs/crate/enigo/latest/features).
- [wayland input method protocol is supported](https://wayland.app/protocols/input-method-unstable-v2#compositor-support) in some of the compositors such as Hyprland and Cosmic.

## Tested with PopOS 24.04 Cosmic

This makes Handy usable on at least PopOS 24.04 Cosmic with paste method "Clipboard (CTRL+V)".
<img width="452" height="136" alt="image" src="https://github.com/user-attachments/assets/15255403-5af1-4602-b17b-d3820960822e" />

To enable the global hot key in Cosmic it's necessary to change X11 compatibility settings and set the "Global shortcuts in X11 applications" value to "All keys".

<img width="981" height="474" alt="image" src="https://github.com/user-attachments/assets/7ab0167c-013c-413c-b621-dd22f74f87f4" />



