### PR TITLE
feat: add fallback microphone for clamshell/desktop mode

### DIFF
--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -159,3 +159,23 @@ pub fn play_test_sound(app: AppHandle, sound_type: String) {
     };
     audio_feedback::play_test_sound(&app, sound);
 }
+
+#[tauri::command]
+pub fn set_clamshell_microphone(app: AppHandle, device_name: String) -> Result<(), String> {
+    let mut settings = get_settings(&app);
+    settings.clamshell_microphone = if device_name == "default" {
+        None
+    } else {
+        Some(device_name)
+    };
+    write_settings(&app, settings);
+    Ok(())
+}
+
+#[tauri::command]
+pub fn get_clamshell_microphone(app: AppHandle) -> Result<String, String> {
+    let settings = get_settings(&app);
+    Ok(settings
+        .clamshell_microphone
+        .unwrap_or_else(|| "default".to_string()))
+}

--- a/src-tauri/src/helpers/clamshell.rs
+++ b/src-tauri/src/helpers/clamshell.rs
@@ -1,0 +1,118 @@
+use std::process::Command;
+
+/// Checks if the MacBook is in clamshell mode (lid closed with external display)
+///
+/// This queries the macOS IORegistry for the AppleClamshellState key.
+/// Returns true if the lid is closed, false if open.
+#[tauri::command]
+pub fn is_clamshell() -> Result<bool, String> {
+    let output = Command::new("ioreg")
+        .args(["-r", "-k", "AppleClamshellState", "-d", "4"])
+        .output()
+        .map_err(|e| format!("Failed to execute ioreg: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "ioreg command failed with status: {}",
+            output.status
+        ));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Look for "AppleClamshellState" = Yes in the output
+    Ok(stdout.contains("\"AppleClamshellState\" = Yes"))
+}
+
+/// Checks if the Mac has a built-in display (i.e., is a laptop)
+///
+/// This queries the macOS IORegistry for built-in displays.
+/// Returns true if a built-in display is found (MacBook), false otherwise (Mac Mini, Mac Studio, etc.)
+#[tauri::command]
+pub fn has_builtin_display() -> Result<bool, String> {
+    let output = Command::new("ioreg")
+        .args(["-l", "-w", "0", "-r", "-c", "IODisplayConnect"])
+        .output()
+        .map_err(|e| format!("Failed to execute ioreg: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "ioreg command failed with status: {}",
+            output.status
+        ));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Look for built-in display indicators
+    // Built-in displays typically have AppleDisplay or AppleBacklightDisplay
+    Ok(stdout.contains("AppleBacklightDisplay")
+        || (stdout.contains("built-in") && stdout.contains("IODisplayConnect")))
+}
+
+/// Returns detailed clamshell state information
+#[tauri::command]
+pub fn get_clamshell_info() -> Result<ClamshellInfo, String> {
+    let output = Command::new("ioreg")
+        .args(["-r", "-k", "AppleClamshellState", "-d", "4"])
+        .output()
+        .map_err(|e| format!("Failed to execute ioreg: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "ioreg command failed with status: {}",
+            output.status
+        ));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let is_closed = stdout.contains("\"AppleClamshellState\" = Yes");
+
+    Ok(ClamshellInfo {
+        lid_closed: is_closed,
+        mode: if is_closed { "clamshell" } else { "open" }.to_string(),
+        raw_output: stdout.to_string(),
+    })
+}
+
+#[derive(serde::Serialize)]
+pub struct ClamshellInfo {
+    pub lid_closed: bool,
+    pub mode: String,
+    pub raw_output: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_clamshell_check() {
+        // This will run on macOS and should not panic
+        let result = is_clamshell();
+        assert!(result.is_ok());
+        println!("Clamshell state: {:?}", result.unwrap());
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_clamshell_info() {
+        let result = get_clamshell_info();
+        assert!(result.is_ok());
+        if let Ok(info) = result {
+            println!("Lid closed: {}", info.lid_closed);
+            println!("Mode: {}", info.mode);
+        }
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_has_builtin_display() {
+        let result = has_builtin_display();
+        assert!(result.is_ok());
+        if let Ok(has_builtin) = result {
+            println!("Has built-in display (is laptop): {}", has_builtin);
+        }
+    }
+}

--- a/src-tauri/src/helpers/mod.rs
+++ b/src-tauri/src/helpers/mod.rs
@@ -1,0 +1,1 @@
+pub mod clamshell;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod settings;
 mod shortcut;
 mod tray;
 mod utils;
+mod helpers;
 
 use managers::audio::AudioRecordingManager;
 use managers::history::HistoryManager;
@@ -274,6 +275,11 @@ pub fn run() {
             commands::audio::get_selected_output_device,
             commands::audio::play_test_sound,
             commands::audio::check_custom_sounds,
+            commands::audio::set_clamshell_microphone,
+            commands::audio::get_clamshell_microphone,
+            helpers::clamshell::is_clamshell,
+            helpers::clamshell::has_builtin_display,
+            helpers::clamshell::get_clamshell_info,
             commands::transcription::set_model_unload_timeout,
             commands::transcription::get_model_load_status,
             commands::transcription::unload_model_manually,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -160,6 +160,8 @@ pub struct AppSettings {
     #[serde(default)]
     pub selected_microphone: Option<String>,
     #[serde(default)]
+    pub clamshell_microphone: Option<String>,
+    #[serde(default)]
     pub selected_output_device: Option<String>,
     #[serde(default = "default_translate_to_english")]
     pub translate_to_english: bool,
@@ -350,6 +352,7 @@ pub fn get_default_settings() -> AppSettings {
         selected_model: "".to_string(),
         always_on_microphone: false,
         selected_microphone: None,
+        clamshell_microphone: None,
         selected_output_device: None,
         translate_to_english: false,
         selected_language: "auto".to_string(),

--- a/src/components/settings/ClamshellMicrophoneSelector.tsx
+++ b/src/components/settings/ClamshellMicrophoneSelector.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { Dropdown } from "../ui/Dropdown";
+import { SettingContainer } from "../ui/SettingContainer";
+import { ResetButton } from "../ui/ResetButton";
+import { useSettings } from "../../hooks/useSettings";
+
+interface ClamshellMicrophoneSelectorProps {
+  descriptionMode?: "inline" | "tooltip";
+  grouped?: boolean;
+}
+
+export const ClamshellMicrophoneSelector: React.FC<ClamshellMicrophoneSelectorProps> = React.memo(
+  ({ descriptionMode = "tooltip", grouped = false }) => {
+    const {
+      getSetting,
+      updateSetting,
+      resetSetting,
+      isUpdating,
+      isLoading,
+      audioDevices,
+      refreshAudioDevices,
+    } = useSettings();
+
+    const selectedClamshellMicrophone =
+      getSetting("clamshell_microphone") === "default"
+        ? "Default"
+        : getSetting("clamshell_microphone") || "Default";
+
+    const handleClamshellMicrophoneSelect = async (deviceName: string) => {
+      await updateSetting("clamshell_microphone", deviceName);
+    };
+
+    const handleReset = async () => {
+      await resetSetting("clamshell_microphone");
+    };
+
+    const microphoneOptions = audioDevices.map((device) => ({
+      value: device.name,
+      label: device.name,
+    }));
+
+    return (
+      <SettingContainer
+        title="Desktop Microphone"
+        description="Choose a different microphone to use when your laptop lid is closed"
+        descriptionMode={descriptionMode}
+        grouped={grouped}
+      >
+        <div className="flex items-center space-x-1">
+          <Dropdown
+            options={microphoneOptions}
+            selectedValue={selectedClamshellMicrophone}
+            onSelect={handleClamshellMicrophoneSelect}
+            placeholder={
+              isLoading || audioDevices.length === 0
+                ? "Loading..."
+                : "Select microphone..."
+            }
+            disabled={
+              isUpdating("clamshell_microphone") ||
+              isLoading ||
+              audioDevices.length === 0
+            }
+            onRefresh={refreshAudioDevices}
+          />
+          <ResetButton
+            onClick={handleReset}
+            disabled={isUpdating("clamshell_microphone") || isLoading}
+          />
+        </div>
+      </SettingContainer>
+    );
+  },
+);
+
+ClamshellMicrophoneSelector.displayName = "ClamshellMicrophoneSelector";

--- a/src/components/settings/general/GeneralSettings.tsx
+++ b/src/components/settings/general/GeneralSettings.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { MicrophoneSelector } from "../MicrophoneSelector";
+import { ClamshellMicrophoneSelector } from "../ClamshellMicrophoneSelector";
 import { LanguageSelector } from "../LanguageSelector";
 import { HandyShortcut } from "../HandyShortcut";
 import { SettingsGroup } from "../../ui/SettingsGroup";
@@ -20,6 +21,7 @@ export const GeneralSettings: React.FC = () => {
       </SettingsGroup>
       <SettingsGroup title="Sound">
         <MicrophoneSelector descriptionMode="tooltip" grouped={true} />
+        <ClamshellMicrophoneSelector descriptionMode="tooltip" grouped={true} />
         <AudioFeedback descriptionMode="tooltip" grouped={true} />
         <OutputDeviceSelector
           descriptionMode="tooltip"

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -8,6 +8,7 @@ export { PostProcessingSettings } from "./post-processing/PostProcessingSettings
 
 // Individual setting components
 export { MicrophoneSelector } from "./MicrophoneSelector";
+export { ClamshellMicrophoneSelector } from "./ClamshellMicrophoneSelector";
 export { OutputDeviceSelector } from "./OutputDeviceSelector";
 export { AlwaysOnMicrophone } from "./AlwaysOnMicrophone";
 export { PushToTalk } from "./PushToTalk";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -79,6 +79,7 @@ export const SettingsSchema = z.object({
   selected_model: z.string(),
   always_on_microphone: z.boolean(),
   selected_microphone: z.string().nullable().optional(),
+  clamshell_microphone: z.string().nullable().optional(),
   selected_output_device: z.string().nullable().optional(),
   translate_to_english: z.boolean(),
   selected_language: z.string(),

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -66,6 +66,7 @@ const DEFAULT_SETTINGS: Partial<Settings> = {
   autostart_enabled: false,
   push_to_talk: false,
   selected_microphone: "Default",
+  clamshell_microphone: "Default",
   selected_output_device: "Default",
   translate_to_english: false,
   selected_language: "auto",
@@ -100,6 +101,10 @@ const settingUpdaters: {
   push_to_talk: (value) => invoke("change_ptt_setting", { enabled: value }),
   selected_microphone: (value) =>
     invoke("set_selected_microphone", {
+      deviceName: value === "Default" ? "default" : value,
+    }),
+  clamshell_microphone: (value) =>
+    invoke("set_clamshell_microphone", {
       deviceName: value === "Default" ? "default" : value,
     }),
   selected_output_device: (value) =>
@@ -166,10 +171,11 @@ export const useSettingsStore = create<SettingsStore>()(
         const settings = (await store.get("settings")) as Settings;
 
         // Load additional settings that come from invoke calls
-        const [microphoneMode, selectedMicrophone, selectedOutputDevice] =
+        const [microphoneMode, selectedMicrophone, clamshellMicrophone, selectedOutputDevice] =
           await Promise.allSettled([
             invoke("get_microphone_mode"),
             invoke("get_selected_microphone"),
+            invoke("get_clamshell_microphone"),
             invoke("get_selected_output_device"),
           ]);
 
@@ -183,6 +189,10 @@ export const useSettingsStore = create<SettingsStore>()(
           selected_microphone:
             selectedMicrophone.status === "fulfilled"
               ? (selectedMicrophone.value as string)
+              : "Default",
+          clamshell_microphone:
+            clamshellMicrophone.status === "fulfilled"
+              ? (clamshellMicrophone.value as string)
               : "Default",
           selected_output_device:
             selectedOutputDevice.status === "fulfilled"


### PR DESCRIPTION
Implementation for #326 

Tested for macOS, and is working, would need feedback for Linux and Windows (in theory on these platforms, the Desktop Microphone option should not appear on the settings since this is a macOS only feature)