### PR TITLE
Allow users to deactivate save to history functionality

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -292,22 +292,26 @@ impl ShortcutAction for TranscribeAction {
                                 }
                             }
 
-                            // Save to history with post-processed text and prompt
-                            let hm_clone = Arc::clone(&hm);
-                            let transcription_for_history = transcription.clone();
-                            tauri::async_runtime::spawn(async move {
-                                if let Err(e) = hm_clone
-                                    .save_transcription(
-                                        samples_clone,
-                                        transcription_for_history,
-                                        post_processed_text,
-                                        post_process_prompt,
-                                    )
-                                    .await
-                                {
-                                    error!("Failed to save transcription to history: {}", e);
-                                }
-                            });
+                            if settings.save_to_history {
+                                // Save to history with post-processed text and prompt
+                                let hm_clone = Arc::clone(&hm);
+                                let transcription_for_history = transcription.clone();
+                                tauri::async_runtime::spawn(async move {
+                                    if let Err(e) = hm_clone
+                                        .save_transcription(
+                                            samples_clone,
+                                            transcription_for_history,
+                                            post_processed_text,
+                                            post_process_prompt,
+                                        )
+                                        .await
+                                    {
+                                        error!("Failed to save transcription to history: {}", e);
+                                    }
+                                });
+                            } else {
+                                debug!("Skipping saving recording/transcription to history.");
+                            }
 
                             // Paste the final text (either processed or original)
                             let ah_clone = ah.clone();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -299,6 +299,7 @@ pub fn run() {
             shortcut::change_start_hidden_setting,
             shortcut::change_autostart_setting,
             shortcut::change_translate_to_english_setting,
+            shortcut::change_save_to_history_setting,
             shortcut::change_selected_language_setting,
             shortcut::change_overlay_position_setting,
             shortcut::change_debug_mode_setting,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -177,6 +177,8 @@ pub struct AppSettings {
     pub selected_output_device: Option<String>,
     #[serde(default = "default_translate_to_english")]
     pub translate_to_english: bool,
+    #[serde(default = "default_save_to_history")]
+    pub save_to_history: bool,
     #[serde(default = "default_selected_language")]
     pub selected_language: String,
     #[serde(default = "default_overlay_position")]
@@ -227,6 +229,10 @@ fn default_always_on_microphone() -> bool {
 
 fn default_translate_to_english() -> bool {
     false
+}
+
+fn default_save_to_history() -> bool {
+    true
 }
 
 fn default_start_hidden() -> bool {
@@ -379,6 +385,7 @@ pub fn get_default_settings() -> AppSettings {
         clamshell_microphone: None,
         selected_output_device: None,
         translate_to_english: false,
+        save_to_history: default_save_to_history(),
         selected_language: "auto".to_string(),
         overlay_position: OverlayPosition::Bottom,
         debug_mode: false,

--- a/src-tauri/src/shortcut.rs
+++ b/src-tauri/src/shortcut.rs
@@ -154,6 +154,24 @@ pub fn change_translate_to_english_setting(app: AppHandle, enabled: bool) -> Res
 }
 
 #[tauri::command]
+pub fn change_save_to_history_setting(app: AppHandle, enabled: bool) -> Result<(), String> {
+    let mut settings = settings::get_settings(&app);
+    settings.save_to_history = enabled;
+    settings::write_settings(&app, settings);
+
+    // Notify frontend
+    let _ = app.emit(
+        "settings-changed",
+        serde_json::json!({
+            "setting": "save_to_history",
+            "value": enabled
+        }),
+    );
+
+    Ok(())
+}
+
+#[tauri::command]
 pub fn change_selected_language_setting(app: AppHandle, language: String) -> Result<(), String> {
     let mut settings = settings::get_settings(&app);
     settings.selected_language = language;

--- a/src/components/settings/SaveToHistory.tsx
+++ b/src/components/settings/SaveToHistory.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useMemo } from "react";
+import { ToggleSwitch } from "../ui/ToggleSwitch";
+import { useSettings } from "../../hooks/useSettings";
+
+interface SaveToHistoryProps {
+  descriptionMode?: "inline" | "tooltip";
+  grouped?: boolean;
+}
+
+export const SaveToHistory: React.FC<SaveToHistoryProps> = React.memo(
+  ({ descriptionMode = "tooltip", grouped = false }) => {
+    const { getSetting, updateSetting, isUpdating } = useSettings();
+
+    const SaveToHistory = getSetting("save_to_history") ?? true;
+
+    const description = "Save recordings and transcriptions to history." ;
+
+    return (
+      <ToggleSwitch
+        checked={SaveToHistory}
+        onChange={(enabled) => updateSetting("save_to_history", enabled)}
+        isUpdating={isUpdating("save_to_history")}
+        label="Save to history"
+        description={description}
+        descriptionMode={descriptionMode}
+        grouped={grouped}
+      />
+    );
+  }
+);

--- a/src/components/settings/advanced/AdvancedSettings.tsx
+++ b/src/components/settings/advanced/AdvancedSettings.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ShowOverlay } from "../ShowOverlay";
 import { TranslateToEnglish } from "../TranslateToEnglish";
+import { SaveToHistory } from "../SaveToHistory";
 import { ModelUnloadTimeoutSetting } from "../ModelUnloadTimeout";
 import { CustomWords } from "../CustomWords";
 import { SettingsGroup } from "../../ui/SettingsGroup";
@@ -19,6 +20,7 @@ export const AdvancedSettings: React.FC = () => {
         <PasteMethodSetting descriptionMode="tooltip" grouped={true} />
         <ClipboardHandlingSetting descriptionMode="tooltip" grouped={true} />
         <TranslateToEnglish descriptionMode="tooltip" grouped={true} />
+        <SaveToHistory descriptionMode="tooltip" grouped={true} />
         <ModelUnloadTimeoutSetting descriptionMode="tooltip" grouped={true} />
         <CustomWords descriptionMode="tooltip" grouped />
       </SettingsGroup>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -96,6 +96,7 @@ export const SettingsSchema = z.object({
   clamshell_microphone: z.string().nullable().optional(),
   selected_output_device: z.string().nullable().optional(),
   translate_to_english: z.boolean(),
+  save_to_history: z.boolean(),
   selected_language: z.string(),
   overlay_position: OverlayPositionSchema,
   debug_mode: z.boolean(),

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -69,6 +69,7 @@ const DEFAULT_SETTINGS: Partial<Settings> = {
   clamshell_microphone: "Default",
   selected_output_device: "Default",
   translate_to_english: false,
+  save_to_history: true,
   selected_language: "auto",
   overlay_position: "bottom",
   debug_mode: false,
@@ -117,6 +118,8 @@ const settingUpdaters: {
     invoke("update_recording_retention_period", { period: value }),
   translate_to_english: (value) =>
     invoke("change_translate_to_english_setting", { enabled: value }),
+  save_to_history: (value) =>
+    invoke("change_save_to_history_setting", { enabled: value }),
   selected_language: (value) =>
     invoke("change_selected_language_setting", { language: value }),
   overlay_position: (value) =>


### PR DESCRIPTION
This pull request allows users to deactivate saving transcriptions and recordings to history.
<img width="670" height="416" alt="image" src="https://github.com/user-attachments/assets/89e4ed72-de0c-4e35-8561-502260587a12" />

Looking forward to your feedback.