### PR TITLE
Use dotool to send paste action if on Wayland

### DIFF
--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -54,3 +54,12 @@ pub fn cancel_current_operation(app: &AppHandle) {
 
     info!("Operation cancellation completed - returned to idle state");
 }
+
+/// Check if using the Wayland display server protocol
+#[cfg(target_os = "linux")]
+pub fn is_wayland() -> bool {
+    std::env::var("WAYLAND_DISPLAY").is_ok()
+        || std::env::var("XDG_SESSION_TYPE")
+            .map(|v| v.to_lowercase() == "wayland")
+            .unwrap_or(false)
+}


### PR DESCRIPTION
Discussed in #363

Adds a conditional branch in the two paste actions, using dotool to send the paste action if the user is on Wayland. Tested on my machine, KDE Plasma 6.5.2, and it works. Although I need to click back on the text input after triggering Handy since it steals the focus.

This change assumes that dotool is installed on the user's system. This needs to be communicated somehow, I believe this is the first external dependency on Handy, since everything else has been packaged nicely.