### PR TITLE
feat: add analytics dashboard

### DIFF
--- a/src-tauri/src/commands/history.rs
+++ b/src-tauri/src/commands/history.rs
@@ -1,4 +1,4 @@
-use crate::managers::history::{HistoryEntry, HistoryManager};
+use crate::managers::history::{AnalyticsStats, HistoryEntry, HistoryManager};
 use std::sync::Arc;
 use tauri::{AppHandle, State};
 
@@ -98,4 +98,16 @@ pub async fn update_recording_retention_period(
         .map_err(|e| e.to_string())?;
 
     Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn get_analytics(
+    _app: AppHandle,
+    history_manager: State<'_, Arc<HistoryManager>>,
+    period: String,
+) -> Result<AnalyticsStats, String> {
+    history_manager
+        .get_analytics(&period)
+        .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -305,6 +305,7 @@ pub fn run() {
         commands::history::delete_history_entry,
         commands::history::update_history_limit,
         commands::history::update_recording_retention_period,
+        commands::history::get_analytics,
         helpers::clamshell::is_laptop,
     ]);
 

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -584,6 +584,14 @@ async updateRecordingRetentionPeriod(period: string) : Promise<Result<null, stri
     else return { status: "error", error: e  as any };
 }
 },
+async getAnalytics(period: string) : Promise<Result<AnalyticsStats, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_analytics", { period }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 /**
  * Checks if the Mac is a laptop by detecting battery presence
  * 
@@ -610,13 +618,14 @@ async isLaptop() : Promise<Result<boolean, string>> {
 
 /** user-defined types **/
 
+export type AnalyticsStats = { total_words: number; total_duration_seconds: number; transcription_count: number; average_wpm: number | null; current_streak_days: number }
 export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk: boolean; audio_feedback: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; selected_model?: string; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: string; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: Partial<{ [key in string]: string }>; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean }
 export type AudioDevice = { index: string; name: string; is_default: boolean }
 export type BindingResponse = { success: boolean; binding: ShortcutBinding | null; error: string | null }
 export type ClipboardHandling = "dont_modify" | "copy_to_clipboard"
 export type CustomSounds = { start: boolean; stop: boolean }
 export type EngineType = "Whisper" | "Parakeet"
-export type HistoryEntry = { id: string; file_name: string; timestamp: string; saved: boolean; title: string; transcription_text: string; post_processed_text: string | null; post_process_prompt: string | null }
+export type HistoryEntry = { id: string; file_name: string; timestamp: string; saved: boolean; title: string; transcription_text: string; post_processed_text: string | null; post_process_prompt: string | null; duration_seconds: number | null; word_count: number | null }
 export type LLMPrompt = { id: string; name: string; prompt: string }
 export type LogLevel = "trace" | "debug" | "info" | "warn" | "error"
 export type ModelInfo = { id: string; name: string; description: string; filename: string; url: string | null; size_mb: string; is_downloaded: boolean; is_downloading: boolean; partial_size: string; is_directory: boolean; engine_type: EngineType; accuracy_score: number; speed_score: number }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,13 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { Cog, FlaskConical, History, Info, Sparkles } from "lucide-react";
+import {
+  BarChart3,
+  Cog,
+  FlaskConical,
+  History,
+  Info,
+  Sparkles,
+} from "lucide-react";
 import HandyTextLogo from "./icons/HandyTextLogo";
 import HandyHand from "./icons/HandyHand";
 import { useSettings } from "../hooks/useSettings";
@@ -8,6 +15,7 @@ import {
   GeneralSettings,
   AdvancedSettings,
   HistorySettings,
+  AnalyticsSettings,
   DebugSettings,
   AboutSettings,
   PostProcessingSettings,
@@ -53,6 +61,12 @@ export const SECTIONS_CONFIG = {
     labelKey: "sidebar.history",
     icon: History,
     component: HistorySettings,
+    enabled: () => true,
+  },
+  analytics: {
+    labelKey: "sidebar.analytics",
+    icon: BarChart3,
+    component: AnalyticsSettings,
     enabled: () => true,
   },
   debug: {

--- a/src/components/settings/analytics/AnalyticsSettings.tsx
+++ b/src/components/settings/analytics/AnalyticsSettings.tsx
@@ -1,0 +1,95 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { listen } from "@tauri-apps/api/event";
+import { type AnalyticsStats, commands } from "@/bindings";
+import { type Period, PeriodSelector } from "./PeriodSelector";
+import { StatsGrid } from "./StatsGrid";
+
+export const AnalyticsSettings: React.FC = () => {
+  const { t } = useTranslation();
+  const [period, setPeriod] = useState<Period>("all_time");
+  const [stats, setStats] = useState<AnalyticsStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadAnalytics = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await commands.getAnalytics(period);
+      if (result.status === "ok") {
+        setStats(result.data);
+      } else {
+        setError(result.error);
+      }
+    } catch (err) {
+      console.error("Failed to load analytics:", err);
+      setError(t("settings.analytics.loadError"));
+    } finally {
+      setLoading(false);
+    }
+  }, [period, t]);
+
+  useEffect(() => {
+    loadAnalytics();
+  }, [loadAnalytics]);
+
+  useEffect(() => {
+    const setupListener = async () => {
+      return await listen("history-updated", () => {
+        loadAnalytics();
+      });
+    };
+
+    const unlistenPromise = setupListener();
+
+    return () => {
+      unlistenPromise.then((unlisten) => {
+        if (unlisten) {
+          unlisten();
+        }
+      });
+    };
+  }, [loadAnalytics]);
+
+  const renderContent = () => {
+    if (loading) {
+      return (
+        <div className="px-4 py-8 text-center text-text/60">
+          {t("settings.analytics.loading")}
+        </div>
+      );
+    }
+
+    if (error) {
+      return <div className="px-4 py-8 text-center text-red-500">{error}</div>;
+    }
+
+    if (stats && stats.transcription_count > 0) {
+      return <StatsGrid stats={stats} />;
+    }
+
+    return (
+      <div className="px-4 py-8 text-center text-text/60">
+        {t("settings.analytics.noData")}
+      </div>
+    );
+  };
+
+  return (
+    <div className="max-w-3xl w-full mx-auto space-y-6">
+      <div className="space-y-2">
+        <div className="px-4">
+          <h2 className="text-xs font-medium text-mid-gray uppercase tracking-wide">
+            {t("settings.analytics.title")}
+          </h2>
+        </div>
+
+        <div className="bg-background border border-mid-gray/20 rounded-lg overflow-visible">
+          <PeriodSelector period={period} onPeriodChange={setPeriod} />
+          {renderContent()}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/settings/analytics/PeriodSelector.tsx
+++ b/src/components/settings/analytics/PeriodSelector.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+export type Period = "today" | "this_week" | "all_time";
+
+interface PeriodSelectorProps {
+  period: Period;
+  onPeriodChange: (period: Period) => void;
+}
+
+const periods: { key: Period; labelKey: string }[] = [
+  { key: "today", labelKey: "settings.analytics.periods.today" },
+  { key: "this_week", labelKey: "settings.analytics.periods.thisWeek" },
+  { key: "all_time", labelKey: "settings.analytics.periods.allTime" },
+];
+
+export const PeriodSelector: React.FC<PeriodSelectorProps> = ({
+  period,
+  onPeriodChange,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="px-4 py-3 flex gap-2 border-b border-mid-gray/20">
+      {periods.map((p) => (
+        <button
+          key={p.key}
+          onClick={() => onPeriodChange(p.key)}
+          className={`px-3 py-1.5 text-sm rounded-md transition-colors cursor-pointer ${
+            period === p.key
+              ? "bg-logo-primary text-white"
+              : "bg-mid-gray/20 hover:bg-mid-gray/30"
+          }`}
+        >
+          {t(p.labelKey)}
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/src/components/settings/analytics/StatCard.tsx
+++ b/src/components/settings/analytics/StatCard.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+interface StatCardProps {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  subtitle?: string;
+}
+
+export const StatCard: React.FC<StatCardProps> = ({
+  icon,
+  label,
+  value,
+  subtitle,
+}) => (
+  <div className="bg-mid-gray/10 rounded-lg p-4">
+    <div className="flex items-center gap-2 text-mid-gray mb-2">
+      {icon}
+      <span className="text-xs uppercase tracking-wide">{label}</span>
+    </div>
+    <div className="text-2xl font-semibold">{value}</div>
+    {subtitle ? <div className="text-xs text-mid-gray">{subtitle}</div> : null}
+  </div>
+);

--- a/src/components/settings/analytics/StatsGrid.tsx
+++ b/src/components/settings/analytics/StatsGrid.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { type AnalyticsStats } from "@/bindings";
+import { BarChart3, Clock, Flame, Type } from "lucide-react";
+import { StatCard } from "./StatCard";
+
+interface StatsGridProps {
+  stats: AnalyticsStats;
+}
+
+const formatDuration = (seconds: number): string => {
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+  const hours = Math.floor(seconds / 3600);
+  const mins = Math.round((seconds % 3600) / 60);
+  return `${hours}h ${mins}m`;
+};
+
+const formatWpm = (wpm: number | null): string => {
+  if (wpm === null) return "-";
+  return Math.round(wpm).toString();
+};
+
+export const StatsGrid: React.FC<StatsGridProps> = ({ stats }) => {
+  const { t } = useTranslation();
+
+  const streakSubtitle =
+    stats.current_streak_days === 1
+      ? t("settings.analytics.day")
+      : t("settings.analytics.days");
+
+  return (
+    <div className="px-4 py-4 grid grid-cols-2 gap-4">
+      <StatCard
+        icon={<Type className="w-5 h-5" />}
+        label={t("settings.analytics.totalWords")}
+        value={stats.total_words.toLocaleString()}
+      />
+      <StatCard
+        icon={<Clock className="w-5 h-5" />}
+        label={t("settings.analytics.recordingTime")}
+        value={formatDuration(stats.total_duration_seconds)}
+      />
+      <StatCard
+        icon={<BarChart3 className="w-5 h-5" />}
+        label={t("settings.analytics.averageWpm")}
+        value={formatWpm(stats.average_wpm)}
+        subtitle={t("settings.analytics.wordsPerMinute")}
+      />
+      <StatCard
+        icon={<Flame className="w-5 h-5" />}
+        label={t("settings.analytics.currentStreak")}
+        value={stats.current_streak_days.toString()}
+        subtitle={streakSubtitle}
+      />
+    </div>
+  );
+};

--- a/src/components/settings/analytics/index.ts
+++ b/src/components/settings/analytics/index.ts
@@ -1,0 +1,1 @@
+export { AnalyticsSettings } from "./AnalyticsSettings";

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -3,6 +3,7 @@ export { GeneralSettings } from "./general/GeneralSettings";
 export { AdvancedSettings } from "./advanced/AdvancedSettings";
 export { DebugSettings } from "./debug/DebugSettings";
 export { HistorySettings } from "./history/HistorySettings";
+export { AnalyticsSettings } from "./analytics";
 export { AboutSettings } from "./about/AboutSettings";
 export { PostProcessingSettings } from "./post-processing/PostProcessingSettings";
 

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -4,6 +4,7 @@
     "advanced": "Advanced",
     "postProcessing": "Post Process",
     "history": "History",
+    "analytics": "Analytics",
     "debug": "Debug",
     "about": "About"
   },
@@ -264,6 +265,24 @@
       "unsave": "Remove from saved",
       "delete": "Delete entry",
       "deleteError": "Failed to delete entry. Please try again."
+    },
+    "analytics": {
+      "title": "Analytics",
+      "loading": "Loading analytics...",
+      "loadError": "Failed to load analytics. Please try again.",
+      "noData": "No analytics data yet. Start recording to build your stats!",
+      "periods": {
+        "today": "Today",
+        "thisWeek": "This Week",
+        "allTime": "All Time"
+      },
+      "totalWords": "Total Words",
+      "recordingTime": "Recording Time",
+      "averageWpm": "Avg WPM",
+      "wordsPerMinute": "words per minute",
+      "currentStreak": "Current Streak",
+      "day": "day",
+      "days": "days"
     },
     "debug": {
       "title": "Debug",


### PR DESCRIPTION
## Summary
- adds analytics tab to sidebar showing transcription statistics
- tracks total words, recording time, average wpm, and current streak
- supports filtering by today, this week, or all time
- includes proper error handling and singular / plural formatting
- this feature only tracks new transcriptions going forward and does not backfill historical data. existing transcriptions will not have analytics data
- this semi-addresses the feature request in #194, which was previously closed as not planned. happy to discuss if there are concerns about scope or maintenance

<img width="792" height="682" alt="handy-analytics" src="https://github.com/user-attachments/assets/ce47909c-d4f7-45e6-af03-5698311c814c" />

## Testing
- [x] create a new transcription and verify analytics update
- [x] check all three time periods (today, this week, all time)
- [x] verify streak increments on consecutive days
- [x] confirm singular / plural formatting ("1 day" vs "2 days")