### PR TITLE
feat: add (Dev) indicator to tray menu in debug builds

### DIFF
--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -84,7 +84,11 @@ pub fn update_tray_menu(app: &AppHandle, state: &TrayIconState) {
     let (settings_accelerator, quit_accelerator) = (Some("Ctrl+,"), Some("Ctrl+Q"));
 
     // Create common menu items
-    let version_label = format!("Handy v{}", env!("CARGO_PKG_VERSION"));
+    let version_label = if cfg!(debug_assertions) {
+        format!("Handy v{} (Dev)", env!("CARGO_PKG_VERSION"))
+    } else {
+        format!("Handy v{}", env!("CARGO_PKG_VERSION"))
+    };
     let version_i = MenuItem::with_id(app, "version", &version_label, false, None::<&str>)
         .expect("failed to create version item");
     let settings_i = MenuItem::with_id(app, "settings", "Settings...", true, settings_accelerator)


### PR DESCRIPTION
## summary
- adds "(Dev)" suffix to the version label in the tray menu when running debug builds
- helps distinguish between dev and release builds during testing

## technical details
- uses `cfg!(debug_assertions)` to conditionally append "(Dev)" to version string
- only affects tray menu display, no functional changes
- release builds remain unchanged

| Prod      | Dev |
| ----------- | ----------- |
| <img width="209" height="162" alt="Screenshot 2025-12-18 at 5 36 29 PM" src="https://github.com/user-attachments/assets/8af877ee-f081-4395-a2ee-eb18fd07b750" />      | <img width="204" height="162" alt="Screenshot 2025-12-18 at 5 37 03 PM" src="https://github.com/user-attachments/assets/78f8157b-69f6-4933-9a70-0b12cdf06e2f" />       |

## test plan
- [x] run `bun run tauri dev` and verify tray shows "Handy v0.6.8 (Dev)"
- [x] build release and verify tray shows "Handy v0.6.8" (no Dev suffix)