### PR TITLE
fix: unload model on cancel when immediate unload enabled

### DIFF
--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -170,6 +170,19 @@ impl TranscriptionManager {
         Ok(())
     }
 
+    /// Unloads the model immediately if the setting is enabled and the model is loaded
+    pub fn maybe_unload_immediately(&self, context: &str) {
+        let settings = get_settings(&self.app_handle);
+        if settings.model_unload_timeout == ModelUnloadTimeout::Immediately
+            && self.is_model_loaded()
+        {
+            info!("Immediately unloading model after {}", context);
+            if let Err(e) = self.unload_model() {
+                warn!("Failed to immediately unload model: {}", e);
+            }
+        }
+    }
+
     pub fn load_model(&self, model_id: &str) -> Result<()> {
         let load_start = std::time::Instant::now();
         debug!("Starting to load model: {}", model_id);
@@ -316,16 +329,9 @@ impl TranscriptionManager {
 
         debug!("Audio vector length: {}", audio.len());
 
-        if audio.len() == 0 {
+        if audio.is_empty() {
             debug!("Empty audio vector");
-            // Check if we should immediately unload the model
-            let settings = get_settings(&self.app_handle);
-            if settings.model_unload_timeout == ModelUnloadTimeout::Immediately {
-                info!("Immediately unloading model after empty audio");
-                if let Err(e) = self.unload_model() {
-                    warn!("Failed to immediately unload model: {}", e);
-                }
-            }
+            self.maybe_unload_immediately("empty audio");
             return Ok(String::new());
         }
 
@@ -426,13 +432,7 @@ impl TranscriptionManager {
             info!("Transcription result: {}", final_result);
         }
 
-        // Check if we should immediately unload the model after transcription
-        if settings.model_unload_timeout == ModelUnloadTimeout::Immediately {
-            info!("Immediately unloading model after transcription");
-            if let Err(e) = self.unload_model() {
-                error!("Failed to immediately unload model: {}", e);
-            }
-        }
+        self.maybe_unload_immediately("transcription");
 
         Ok(final_result)
     }


### PR DESCRIPTION
## before submitting this pr

**please confirm you have done the following:**

- [x] i have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] i have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## human written description

- model stays loaded when you cancel a recording with escape, even with "unload immediately" enabled. the unload check was only happening after a successful transcription, not on cancel. this fix in this PR adds the same check to the cancel path so the setting works as expected in both cases

## related issues/discussions

- fixes #479

## testing

- [x] enable "unload model (immediately)" in advanced settings
- [x] trigger recording via shortcut
- [x] cancel with escape key
- [x] verify logs show "immediately unloading model after cancellation"
- [x] verify model is unloaded (check memory/ui indicator)