### PR TITLE
feat: Add custom macOS Fn key listener to enable its use as a shortcut.

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "handy-app",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2382,6 +2382,8 @@ version = "0.6.10"
 dependencies = [
  "anyhow",
  "chrono",
+ "core-foundation 0.10.1",
+ "core-graphics 0.24.0",
  "cpal",
  "enigo",
  "env_filter",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -93,6 +93,8 @@ windows = { version = "0.61.3", features = [
 
 [target.'cfg(target_os = "macos")'.dependencies]
 tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2.1" }
+core-graphics = "0.24"
+core-foundation = "0.10"
 
 [profile.release]
 lto = true

--- a/src-tauri/src/fn_listener.rs
+++ b/src-tauri/src/fn_listener.rs
@@ -1,0 +1,159 @@
+// macOS-specific Fn key listener using CGEventTap
+// This avoids the thread-safety issues of rdev::grab
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use crate::actions::ACTION_MAP;
+    use crate::settings::get_settings;
+    use crate::ManagedToggleState;
+    use core_foundation::runloop::{kCFRunLoopCommonModes, CFRunLoop};
+    use core_graphics::event::{
+        CGEventTap, CGEventTapLocation, CGEventTapOptions, CGEventTapPlacement, CGEventType,
+    };
+    use log::{error, info};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use tauri::{AppHandle, Emitter, Manager};
+    use tauri_plugin_global_shortcut::ShortcutState;
+
+    // The Fn key on macOS sets the "SecondaryFn" flag (bit 23, value 0x800000)
+    const FN_KEY_FLAG: u64 = 0x800000; // CGEventFlags::CGEventFlagSecondaryFn
+
+    pub fn start_fn_key_listener(app: AppHandle) {
+        std::thread::spawn(move || {
+            let app_arc = Arc::new(app);
+            let app_for_tap = app_arc.clone();
+
+            // Track Fn key state to detect press/release (use AtomicBool for interior mutability)
+            let fn_was_pressed = Arc::new(AtomicBool::new(false));
+            let fn_state = fn_was_pressed.clone();
+
+            // Create an event tap that intercepts flagsChanged events (modifier key changes)
+            let tap = CGEventTap::new(
+                CGEventTapLocation::HID,
+                CGEventTapPlacement::HeadInsertEventTap,
+                CGEventTapOptions::Default, // Can block events
+                vec![CGEventType::FlagsChanged],
+                move |_proxy, _event_type, event| {
+                    // We only receive FlagsChanged events due to our filter above
+                    let flags = event.get_flags();
+                    let fn_is_pressed = (flags.bits() & FN_KEY_FLAG) != 0;
+                    let was_pressed = fn_state.load(Ordering::SeqCst);
+
+                    // Detect state change
+                    if fn_is_pressed && !was_pressed {
+                        // Fn key was just pressed
+                        fn_state.store(true, Ordering::SeqCst);
+
+                        // Emit event for frontend shortcut recording
+                        let _ = app_for_tap.emit("fn-key-pressed", ());
+
+                        // Check if we should suppress and handle
+                        if should_suppress_fn(&app_for_tap) {
+                            trigger_action(&app_for_tap, ShortcutState::Pressed);
+                            return None; // Block the event
+                        }
+                    } else if !fn_is_pressed && was_pressed {
+                        // Fn key was just released
+                        fn_state.store(false, Ordering::SeqCst);
+
+                        let _ = app_for_tap.emit("fn-key-released", ());
+
+                        if should_suppress_fn(&app_for_tap) {
+                            trigger_action(&app_for_tap, ShortcutState::Released);
+                            return None; // Block the event
+                        }
+                    }
+
+                    Some(event.clone())
+                },
+            );
+
+            match tap {
+                Ok(tap) => {
+                    // Add the event tap to the current run loop
+                    let loop_source = tap
+                        .mach_port
+                        .create_runloop_source(0)
+                        .expect("Failed to create run loop source");
+
+                    unsafe {
+                        CFRunLoop::get_current().add_source(&loop_source, kCFRunLoopCommonModes);
+                    }
+
+                    tap.enable();
+                    info!("Fn key event tap started successfully");
+
+                    // Run the loop - this blocks
+                    CFRunLoop::run_current();
+                }
+                Err(()) => {
+                    error!("Failed to create CGEventTap for Fn key. Make sure Accessibility permissions are granted.");
+                }
+            }
+        });
+    }
+
+    fn should_suppress_fn(app: &AppHandle) -> bool {
+        let settings = get_settings(app);
+        settings
+            .bindings
+            .get("transcribe")
+            .map(|b| b.current_binding.eq_ignore_ascii_case("fn"))
+            .unwrap_or(false)
+    }
+
+    fn trigger_action(app: &AppHandle, state: ShortcutState) {
+        let binding_id = "transcribe";
+        let settings = get_settings(app);
+
+        if let Some(action) = ACTION_MAP.get(binding_id) {
+            if settings.push_to_talk {
+                if state == ShortcutState::Pressed {
+                    action.start(app, binding_id, "Fn");
+                } else {
+                    action.stop(app, binding_id, "Fn");
+                }
+            } else {
+                // Toggle mode: trigger only on press
+                if state == ShortcutState::Pressed {
+                    let should_start: bool;
+                    {
+                        let toggle_state_manager = app.state::<ManagedToggleState>();
+                        let mut states = toggle_state_manager
+                            .lock()
+                            .expect("Failed to lock toggle state manager");
+
+                        let is_currently_active = states
+                            .active_toggles
+                            .entry(binding_id.to_string())
+                            .or_insert(false);
+
+                        should_start = !*is_currently_active;
+                        *is_currently_active = should_start;
+                    }
+
+                    if should_start {
+                        action.start(app, binding_id, "Fn");
+                    } else {
+                        action.stop(app, binding_id, "Fn");
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub use macos::start_fn_key_listener;
+
+// Stub for non-macOS platforms
+#[cfg(not(target_os = "macos"))]
+pub fn start_fn_key_listener(_app: tauri::AppHandle) {
+    // Fn key handling is macOS-specific
+}
+
+// Wrapper for backward compatibility with existing code
+pub fn custom_fn_event_handler(app: tauri::AppHandle) {
+    start_fn_key_listener(app);
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod audio_feedback;
 pub mod audio_toolkit;
 mod clipboard;
 mod commands;
+mod fn_listener;
 mod helpers;
 mod input;
 mod llm_client;
@@ -135,6 +136,8 @@ fn initialize_core_logic(app_handle: &AppHandle) {
 
     // Initialize the shortcuts
     shortcut::init_shortcuts(app_handle);
+    // Initialize Fn listener
+    fn_listener::custom_fn_event_handler(app_handle.clone());
 
     #[cfg(unix)]
     let signals = Signals::new(&[SIGUSR2]).unwrap();

--- a/src-tauri/src/shortcut.rs
+++ b/src-tauri/src/shortcut.rs
@@ -628,6 +628,9 @@ pub fn change_app_language_setting(app: AppHandle, language: String) -> Result<(
 /// We allow single non-modifier keys (e.g. "f5" or "space") but disallow
 /// modifier-only combos (e.g. "ctrl" or "ctrl+shift").
 fn validate_shortcut_string(raw: &str) -> Result<(), String> {
+    if raw.eq_ignore_ascii_case("fn") {
+        return Ok(());
+    }
     let modifiers = [
         "ctrl", "control", "shift", "alt", "option", "meta", "command", "cmd", "super", "win",
         "windows",
@@ -721,6 +724,12 @@ pub fn register_shortcut(app: &AppHandle, binding: ShortcutBinding) -> Result<()
     }
 
     // Parse shortcut and return error if it fails
+    // Special case: "Fn" is handled by our custom listener, not the global shortcut plugin
+    if binding.current_binding.eq_ignore_ascii_case("fn") {
+        // We "register" it by just returning Ok. The fn_listener handles the actual event.
+        return Ok(());
+    }
+
     let shortcut = match binding.current_binding.parse::<Shortcut>() {
         Ok(s) => s,
         Err(e) => {
@@ -810,6 +819,11 @@ pub fn register_shortcut(app: &AppHandle, binding: ShortcutBinding) -> Result<()
 }
 
 pub fn unregister_shortcut(app: &AppHandle, binding: ShortcutBinding) -> Result<(), String> {
+    // Special case: "Fn" is handled by our custom listener, nothing to unregister
+    if binding.current_binding.eq_ignore_ascii_case("fn") {
+        return Ok(());
+    }
+
     let shortcut = match binding.current_binding.parse::<Shortcut>() {
         Ok(s) => s,
         Err(e) => {

--- a/src/components/settings/general/GeneralSettings.tsx
+++ b/src/components/settings/general/GeneralSettings.tsx
@@ -18,6 +18,7 @@ export const GeneralSettings: React.FC = () => {
       <SettingsGroup title={t("settings.general.title")}>
         <HandyShortcut shortcutId="transcribe" grouped={true} />
         <LanguageSelector descriptionMode="tooltip" grouped={true} />
+        <LanguageSelector descriptionMode="tooltip" grouped={true} />
         <PushToTalk descriptionMode="tooltip" grouped={true} />
       </SettingsGroup>
       <SettingsGroup title={t("settings.sound.title")}>


### PR DESCRIPTION
I wanted to use the Fn key for voice transcription as WhisperFlow does, but it wasn't available in the shortcut picker. Regular shortcut APIs can't detect the Fn key because it's a hardware modifier, so I implemented a native macOS solution using CGEventTap that also blocks the emoji picker from appearing.