### PR TITLE
feat(linux): add ydotool support for text input

### DIFF
--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -59,7 +59,7 @@ fn paste_via_clipboard(
 #[cfg(target_os = "linux")]
 fn try_send_key_combo_linux(paste_method: &PasteMethod) -> Result<bool, String> {
     if is_wayland() {
-        // Wayland: prefer wtype, then dotool
+        // Wayland: prefer wtype, then dotool, then ydotool
         if is_wtype_available() {
             info!("Using wtype for key combo");
             send_key_combo_via_wtype(paste_method)?;
@@ -70,11 +70,21 @@ fn try_send_key_combo_linux(paste_method: &PasteMethod) -> Result<bool, String> 
             send_key_combo_via_dotool(paste_method)?;
             return Ok(true);
         }
+        if is_ydotool_available() {
+            info!("Using ydotool for key combo");
+            send_key_combo_via_ydotool(paste_method)?;
+            return Ok(true);
+        }
     } else {
-        // X11: prefer xdotool
+        // X11: prefer xdotool, then ydotool
         if is_xdotool_available() {
             info!("Using xdotool for key combo");
             send_key_combo_via_xdotool(paste_method)?;
+            return Ok(true);
+        }
+        if is_ydotool_available() {
+            info!("Using ydotool for key combo");
+            send_key_combo_via_ydotool(paste_method)?;
             return Ok(true);
         }
     }
@@ -87,7 +97,7 @@ fn try_send_key_combo_linux(paste_method: &PasteMethod) -> Result<bool, String> 
 #[cfg(target_os = "linux")]
 fn try_direct_typing_linux(text: &str) -> Result<bool, String> {
     if is_wayland() {
-        // Wayland: prefer wtype, then dotool
+        // Wayland: prefer wtype, then dotool, then ydotool
         if is_wtype_available() {
             info!("Using wtype for direct text input");
             type_text_via_wtype(text)?;
@@ -98,11 +108,21 @@ fn try_direct_typing_linux(text: &str) -> Result<bool, String> {
             type_text_via_dotool(text)?;
             return Ok(true);
         }
+        if is_ydotool_available() {
+            info!("Using ydotool for direct text input");
+            type_text_via_ydotool(text)?;
+            return Ok(true);
+        }
     } else {
-        // X11: prefer xdotool
+        // X11: prefer xdotool, then ydotool
         if is_xdotool_available() {
             info!("Using xdotool for direct text input");
             type_text_via_xdotool(text)?;
+            return Ok(true);
+        }
+        if is_ydotool_available() {
+            info!("Using ydotool for direct text input");
+            type_text_via_ydotool(text)?;
             return Ok(true);
         }
     }
@@ -125,6 +145,16 @@ fn is_wtype_available() -> bool {
 fn is_dotool_available() -> bool {
     Command::new("which")
         .arg("dotool")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+/// Check if ydotool is available (uinput-based, works on both Wayland and X11)
+#[cfg(target_os = "linux")]
+fn is_ydotool_available() -> bool {
+    Command::new("which")
+        .arg("ydotool")
         .output()
         .map(|output| output.status.success())
         .unwrap_or(false)
@@ -204,6 +234,24 @@ fn type_text_via_dotool(text: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Type text directly via ydotool (uinput-based, requires ydotoold daemon).
+#[cfg(target_os = "linux")]
+fn type_text_via_ydotool(text: &str) -> Result<(), String> {
+    let output = Command::new("ydotool")
+        .arg("type")
+        .arg("--")
+        .arg(text)
+        .output()
+        .map_err(|e| format!("Failed to execute ydotool: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("ydotool failed: {}", stderr));
+    }
+
+    Ok(())
+}
+
 /// Send a key combination (e.g., Ctrl+V) via wtype on Wayland.
 #[cfg(target_os = "linux")]
 fn send_key_combo_via_wtype(paste_method: &PasteMethod) -> Result<(), String> {
@@ -245,6 +293,31 @@ fn send_key_combo_via_dotool(paste_method: &PasteMethod) -> Result<(), String> {
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(format!("dotool failed: {}", stderr));
+    }
+
+    Ok(())
+}
+
+/// Send a key combination (e.g., Ctrl+V) via ydotool (requires ydotoold daemon).
+#[cfg(target_os = "linux")]
+fn send_key_combo_via_ydotool(paste_method: &PasteMethod) -> Result<(), String> {
+    // ydotool uses Linux input event keycodes with format <keycode>:<pressed>
+    // where pressed is 1 for down, 0 for up. Keycodes: ctrl=29, shift=42, v=47, insert=110
+    let args: Vec<&str> = match paste_method {
+        PasteMethod::CtrlV => vec!["key", "29:1", "47:1", "47:0", "29:0"],
+        PasteMethod::ShiftInsert => vec!["key", "42:1", "110:1", "110:0", "42:0"],
+        PasteMethod::CtrlShiftV => vec!["key", "29:1", "42:1", "47:1", "47:0", "42:0", "29:0"],
+        _ => return Err("Unsupported paste method".into()),
+    };
+
+    let output = Command::new("ydotool")
+        .args(&args)
+        .output()
+        .map_err(|e| format!("Failed to execute ydotool: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("ydotool failed: {}", stderr));
     }
 
     Ok(())


### PR DESCRIPTION
- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Human Written Description

  I'm running Handy on Fedora 43 with GNOME/Wayland. The existing tools (wtype, dotool) either aren't packaged for Fedora or don't work with GNOME's compositor. ydotool is available in Fedora repos and uses uinput, which bypasses compositor limitations. This gives Fedora/GNOME users another option for text input.

## Related Issues/Discussions

https://github.com/cjpais/Handy/issues/522

## Testing

Tested on Fedora 43 (Wayland/GNOME):
  - ydotool detection works (logs show "Using ydotool for direct text input")
  - Requires ydotoold daemon running and user in input group
  - Note: Key combo simulation may have issues on some GNOME setups due
    to keycode mapping, but direct text typing works
