### PR TITLE
feat: add shortcut for retyping last transcription

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -544,6 +544,16 @@ pub fn get_default_settings() -> AppSettings {
             current_binding: "escape".to_string(),
         },
     );
+    bindings.insert(
+        "retype_last".to_string(),
+        ShortcutBinding {
+            id: "retype_last".to_string(),
+            name: "Retype Last".to_string(),
+            description: "Retypes the last transcription.".to_string(),
+            default_binding: "".to_string(),
+            current_binding: "".to_string(),
+        },
+    );
 
     AppSettings {
         bindings,

--- a/src-tauri/src/shortcut.rs
+++ b/src-tauri/src/shortcut.rs
@@ -81,6 +81,25 @@ pub fn change_binding(
         }
     }
 
+    // If the new binding is empty, unregister the existing one and save
+    if binding.trim().is_empty() {
+        if !binding_to_modify.current_binding.trim().is_empty() {
+            if let Err(e) = unregister_shortcut(&app, binding_to_modify.clone()) {
+                warn!("Failed to unregister shortcut when clearing: {}", e);
+            }
+        }
+        if let Some(mut b) = settings.bindings.get(&id).cloned() {
+            b.current_binding = binding;
+            settings.bindings.insert(id.clone(), b.clone());
+            settings::write_settings(&app, settings);
+            return Ok(BindingResponse {
+                success: true,
+                binding: Some(b.clone()),
+                error: None,
+            });
+        }
+    }
+
     // Unregister the existing binding
     if let Err(e) = unregister_shortcut(&app, binding_to_modify.clone()) {
         let error_msg = format!("Failed to unregister shortcut: {}", e);

--- a/src/components/settings/HandyShortcut.tsx
+++ b/src/components/settings/HandyShortcut.tsx
@@ -331,10 +331,14 @@ export const HandyShortcut: React.FC<HandyShortcutProps> = ({
           </div>
         ) : (
           <div
-            className="px-2 py-1 text-sm font-semibold bg-mid-gray/10 border border-mid-gray/80 hover:bg-logo-primary/10 rounded cursor-pointer hover:border-logo-primary"
+            className={`px-2 py-1 text-sm bg-mid-gray/10 border border-mid-gray/80 hover:bg-logo-primary/10 rounded cursor-pointer hover:border-logo-primary ${
+              binding.current_binding ? "font-semibold" : "text-mid-gray italic"
+            }`}
             onClick={() => startRecording(shortcutId)}
           >
-            {formatKeyCombination(binding.current_binding, osType)}
+            {binding.current_binding
+              ? formatKeyCombination(binding.current_binding, osType)
+              : t("settings.general.shortcut.notSet", "Not set")}
           </div>
         )}
         <ResetButton

--- a/src/components/settings/general/GeneralSettings.tsx
+++ b/src/components/settings/general/GeneralSettings.tsx
@@ -17,6 +17,7 @@ export const GeneralSettings: React.FC = () => {
     <div className="max-w-3xl w-full mx-auto space-y-6">
       <SettingsGroup title={t("settings.general.title")}>
         <HandyShortcut shortcutId="transcribe" grouped={true} />
+        <HandyShortcut shortcutId="retype_last" grouped={true} />
         <LanguageSelector descriptionMode="tooltip" grouped={true} />
         <PushToTalk descriptionMode="tooltip" grouped={true} />
       </SettingsGroup>

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -89,6 +89,7 @@
         "loading": "Loading shortcuts...",
         "none": "No shortcuts configured",
         "notFound": "Shortcut not found",
+        "notSet": "Not set",
         "pressKeys": "Press keys...",
         "bindings": {
           "transcribe": {
@@ -98,6 +99,10 @@
           "cancel": {
             "name": "Cancel",
             "description": "Cancels the current recording."
+          },
+          "retype_last": {
+            "name": "Retype Last",
+            "description": "Retypes the last transcription."
           }
         },
         "errors": {


### PR DESCRIPTION
create a shortcut for retyping last transcription. sometimes i forget to click on the textbox before starting transcription.

Shortcut defaults to none, must be configured to use.