### PR TITLE
feat(macos): add Fn key support for transcribe shortcut

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -260,6 +260,8 @@ pub fn run() {
         shortcut::update_custom_words,
         shortcut::suspend_binding,
         shortcut::resume_binding,
+        shortcut::init_fn_key_listener,
+        shortcut::is_fn_key_listener_available,
         shortcut::change_mute_while_recording_setting,
         shortcut::change_append_trailing_space_setting,
         shortcut::change_app_language_setting,

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -615,6 +615,17 @@ async isLaptop() : Promise<Result<boolean, string>> {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+async initFnKeyListener() : Promise<Result<boolean, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("init_fn_key_listener") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async isFnKeyListenerAvailable() : Promise<boolean> {
+    return await TAURI_INVOKE("is_fn_key_listener_available");
 }
 }
 


### PR DESCRIPTION




## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Human Written Description

I've been using Handy daily and noticed that pressing a key combination like option+Space every time is inconvenient. I am switching from Whisperflow. Um and I've always been used to use the function key to transcribe and a lot of other tools also use the same pattern. And just having a single key is a lot more useful than having to press a combination. So that's why I think this feels much more convenient

## Related Issues/Discussions

<!-- Link to related issues, discussions, or previous PRs -->

## Community Feedback

<!-- PRs with community support are much more likely to be merged. -->

## Summary of Changes

- Adds support for using the macOS **Fn key** as the transcribe shortcut
- Implements a dedicated Fn key listener using `rdev` that runs on a separate thread
- Works with both push-to-talk and toggle recording modes
- Only available on macOS (requires accessibility permissions)

### Technical Details

- **Backend**: New `init_fn_key_listener` and `is_fn_key_listener_available` Tauri commands
- **Backend**: Fn key listener thread using `rdev` to capture Function key events
- **Frontend**: Integration to detect Fn key presses when editing the transcribe shortcut
- Proper suspend/resume handling for the Fn key binding

## Testing

- [x] Set transcribe shortcut to "Fn" on macOS
- [x] Verify Fn key triggers recording in push-to-talk mode
- [x] Verify Fn key toggles recording in toggle mode
- [x] Verify other shortcuts continue to work normally
- [x] Verify feature is disabled on non-macOS platforms

## Screenshots/Videos (if applicable)

[<!-- Add screenshots or videos demonstrating the change -->](https://github.com/user-attachments/assets/36f21b82-92c8-4163-897b-c6814e8b5471)

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Cursor - Helped with some implementation and testing