### PR TITLE
feat(history): add search functionality

### DIFF
--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,32 +1,32 @@
-import React from "react";
+import React, { forwardRef } from "react";
 
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   variant?: "default" | "compact";
 }
 
-export const Input: React.FC<InputProps> = ({
-  className = "",
-  variant = "default",
-  disabled,
-  ...props
-}) => {
-  const baseClasses =
-    "px-2 py-1 text-sm font-semibold bg-mid-gray/10 border border-mid-gray/80 rounded text-left transition-all duration-150";
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ className = "", variant = "default", disabled, ...props }, ref) => {
+    const baseClasses =
+      "px-2 py-1 text-sm font-semibold bg-mid-gray/10 border border-mid-gray/80 rounded text-left transition-all duration-150";
 
-  const interactiveClasses = disabled
-    ? "opacity-60 cursor-not-allowed bg-mid-gray/10 border-mid-gray/40"
-    : "hover:bg-logo-primary/10 hover:border-logo-primary focus:outline-none focus:bg-logo-primary/20 focus:border-logo-primary";
+    const interactiveClasses = disabled
+      ? "opacity-60 cursor-not-allowed bg-mid-gray/10 border-mid-gray/40"
+      : "hover:bg-logo-primary/10 hover:border-logo-primary focus:outline-none focus:bg-logo-primary/20 focus:border-logo-primary";
 
-  const variantClasses = {
-    default: "px-3 py-2",
-    compact: "px-2 py-1",
-  } as const;
+    const variantClasses = {
+      default: "px-3 py-2",
+      compact: "px-2 py-1",
+    } as const;
 
-  return (
-    <input
-      className={`${baseClasses} ${variantClasses[variant]} ${interactiveClasses} ${className}`}
-      disabled={disabled}
-      {...props}
-    />
-  );
-};
+    return (
+      <input
+        ref={ref}
+        className={`${baseClasses} ${variantClasses[variant]} ${interactiveClasses} ${className}`}
+        disabled={disabled}
+        {...props}
+      />
+    );
+  },
+);
+
+Input.displayName = "Input";

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -290,6 +290,8 @@
       "openFolder": "Open Recordings Folder",
       "loading": "Loading history...",
       "empty": "No transcriptions yet. Start recording to build your history!",
+      "searchPlaceholder": "Search...",
+      "noResults": "No matching transcriptions found.",
       "copyToClipboard": "Copy transcription to clipboard",
       "save": "Save transcription",
       "unsave": "Remove from saved",


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Human Written Description

<!-- Please fill in your own words here - this section needs YOUR thinking -->

I wanted to be able to search through my transcription history to find past recordings. With many transcriptions building up over time, it becomes hard to find specific ones without scrolling through everything.

## Related Issues/Discussions

N/A - new feature suggestion

## Testing

- Tested search filtering with various queries
- Verified Cmd+F keyboard shortcut focuses the search input
- Confirmed clear button (X) resets search
- Checked "no results" message displays correctly

## Screenshots/Videos (if applicable)

N/A

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Claude Opus 4.5)
- How extensively: AI wrote the implementation code; human provided direction and testing