### PR TITLE
Wake-Word

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2307,6 +2307,7 @@ dependencies = [
  "log",
  "natural",
  "once_cell",
+ "ort",
  "rdev",
  "regex",
  "reqwest",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -73,6 +73,10 @@ ferrous-opencc = "0.2.3"
 specta = "=2.0.0-rc.22"
 specta-typescript = "0.0.9"
 tauri-specta = { version = "=2.0.0-rc.21", features = ["derive", "typescript"] }
+ort = { version = "2.0.0-rc.10" }
+
+[dev-dependencies]
+hound = "3.5" # Used just for testing the wakeword
 
 [target.'cfg(unix)'.dependencies]
 signal-hook = "0.3"

--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -486,4 +486,8 @@ pub fn start_transcription_via_wakeword(app: &AppHandle) {
 pub fn stop_transcription_via_wakeword(app: &AppHandle) {
     let action = TranscribeAction;
     action.stop(app, "wakeword", "wakeword");
+    // After the short transcription window, re-activate wake-word if enabled
+    if let Some(rm) = app.try_state::<Arc<AudioRecordingManager>>() {
+        rm.restart_wakeword_manager();
+    }
 }

--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -476,3 +476,14 @@ pub static ACTION_MAP: Lazy<HashMap<String, Arc<dyn ShortcutAction>>> = Lazy::ne
     );
     map
 });
+
+// Helpers to trigger transcription flow from wake-word
+pub fn start_transcription_via_wakeword(app: &AppHandle) {
+    let action = TranscribeAction;
+    action.start(app, "wakeword", "wakeword");
+}
+
+pub fn stop_transcription_via_wakeword(app: &AppHandle) {
+    let action = TranscribeAction;
+    action.stop(app, "wakeword", "wakeword");
+}

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -6,7 +6,6 @@ use log::warn;
 use serde::{Deserialize, Serialize};
 use specta::Type;
 use std::sync::Arc;
-use tauri::Emitter;
 use tauri::{AppHandle, Manager};
 
 #[derive(Serialize, Type)]

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -6,6 +6,7 @@ use log::warn;
 use serde::{Deserialize, Serialize};
 use specta::Type;
 use std::sync::Arc;
+use tauri::Emitter;
 use tauri::{AppHandle, Manager};
 
 #[derive(Serialize, Type)]
@@ -199,4 +200,29 @@ pub fn get_clamshell_microphone(app: AppHandle) -> Result<String, String> {
 pub fn is_recording(app: AppHandle) -> bool {
     let audio_manager = app.state::<Arc<AudioRecordingManager>>();
     audio_manager.is_recording()
+}
+
+// Wake-word control commands
+#[tauri::command]
+#[specta::specta]
+pub fn start_wakeword(app: AppHandle, threshold: Option<f32>) -> Result<(), String> {
+    let thr = threshold.unwrap_or(0.5);
+    let rm = app.state::<Arc<AudioRecordingManager>>();
+    rm.enable_wakeword(false, thr)
+        .map_err(|e| format!("Failed to set wake-word flag: {}", e))
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn stop_wakeword(app: AppHandle) -> Result<(), String> {
+    let rm = app.state::<Arc<AudioRecordingManager>>();
+    rm.disable_wakeword();
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn is_wakeword_running(app: AppHandle) -> Result<bool, String> {
+    let rm = app.state::<Arc<AudioRecordingManager>>();
+    Ok(rm.is_wakeword_running())
 }

--- a/src-tauri/src/managers/audio.rs
+++ b/src-tauri/src/managers/audio.rs
@@ -3,6 +3,7 @@ use crate::helpers::clamshell;
 use crate::settings::{get_settings, AppSettings};
 use crate::utils;
 use log::{debug, error, info};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tauri::Manager;
@@ -149,6 +150,8 @@ pub struct AudioRecordingManager {
     is_open: Arc<Mutex<bool>>,
     is_recording: Arc<Mutex<bool>>,
     did_mute: Arc<Mutex<bool>>,
+    wakeword: Arc<Mutex<Option<crate::managers::wakeword::WakeWordManagerHandle>>>,
+    wakeword_enabled: Arc<AtomicBool>,
 }
 
 impl AudioRecordingManager {
@@ -171,6 +174,8 @@ impl AudioRecordingManager {
             is_open: Arc::new(Mutex::new(false)),
             is_recording: Arc::new(Mutex::new(false)),
             did_mute: Arc::new(Mutex::new(false)),
+            wakeword: Arc::new(Mutex::new(None)),
+            wakeword_enabled: Arc::new(AtomicBool::new(false)),
         };
 
         // Always-on?  Open immediately.
@@ -258,10 +263,22 @@ impl AudioRecordingManager {
         let mut recorder_opt = self.recorder.lock().unwrap();
 
         if recorder_opt.is_none() {
-            *recorder_opt = Some(create_audio_recorder(
-                vad_path.to_str().unwrap(),
-                &self.app_handle,
-            )?);
+            log::info!("Audio: creating recorder with VAD at {:?}", vad_path);
+            let mut recorder = create_audio_recorder(vad_path.to_str().unwrap(), &self.app_handle)?;
+            // Attach speech-frame callback unconditionally; gate on wakeword manager existence/running.
+            let ww_arc = self.wakeword.clone();
+            let enabled_flag = self.wakeword_enabled.clone();
+            recorder = recorder.with_speech_frame_callback(move |frame: &[f32]| {
+                if enabled_flag.load(Ordering::Relaxed) {
+                    if let Some(ref ww_handle) = *ww_arc.lock().unwrap() {
+                        if let Ok(mut det) = ww_handle.lock() {
+                            let _ = det.on_speech_frame(frame);
+                        }
+                    }
+                }
+            });
+            log::info!("Audio: speech-frame callback attached (gated by flag)");
+            *recorder_opt = Some(recorder);
         }
 
         // Get the selected device from settings, considering clamshell mode
@@ -269,6 +286,12 @@ impl AudioRecordingManager {
         let selected_device = self.get_effective_microphone_device(&settings);
 
         if let Some(rec) = recorder_opt.as_mut() {
+            let dev_state = if selected_device.is_some() {
+                "Some(device)"
+            } else {
+                "None"
+            };
+            log::info!("Audio: opening recorder device: {}", dev_state);
             rec.open(selected_device)
                 .map_err(|e| anyhow::anyhow!("Failed to open recorder: {}", e))?;
         }
@@ -300,10 +323,45 @@ impl AudioRecordingManager {
                 *self.is_recording.lock().unwrap() = false;
             }
             let _ = rec.close();
+            log::info!("Audio: recorder closed");
         }
 
         *open_flag = false;
         debug!("Microphone stream stopped");
+    }
+
+    pub fn enable_wakeword(&self, _verbose: bool, _threshold: f32) -> Result<(), anyhow::Error> {
+        debug!("Wakeword flag enabled");
+        self.wakeword_enabled.store(true, Ordering::Relaxed);
+        Ok(())
+    }
+
+    pub fn disable_wakeword(&self) {
+        debug!("Wakeword flag disabled");
+        self.wakeword_enabled.store(false, Ordering::Relaxed);
+    }
+
+    pub fn is_wakeword_running(&self) -> bool {
+        self.wakeword_enabled.load(Ordering::Relaxed)
+    }
+
+    pub fn init_wakeword_models(&self, verbose: bool, threshold: f32) -> Result<(), anyhow::Error> {
+        if self.wakeword.lock().unwrap().is_none() {
+            let ww = crate::managers::wakeword::WakeWordManager::new(
+                &self.app_handle,
+                verbose,
+                threshold,
+            )?;
+            // Start running; gating handled by flag
+            let mut ww_instance = ww;
+            ww_instance.start();
+            *self.wakeword.lock().unwrap() = Some(Arc::new(Mutex::new(ww_instance)));
+            log::info!(
+                "Wake-word: models initialized at startup (threshold={})",
+                threshold
+            );
+        }
+        Ok(())
     }
 
     /* ---------- mode switching --------------------------------------------- */

--- a/src-tauri/src/managers/audio.rs
+++ b/src-tauri/src/managers/audio.rs
@@ -364,6 +364,21 @@ impl AudioRecordingManager {
         Ok(())
     }
 
+    /// Reactivate the wake-word manager after a detection window ends.
+    /// Only starts if the manager exists and the wake-word flag is enabled.
+    pub fn restart_wakeword_manager(&self) {
+        let enabled = self.wakeword_enabled.load(Ordering::Relaxed);
+        if !enabled {
+            return;
+        }
+        if let Some(ref ww_handle) = *self.wakeword.lock().unwrap() {
+            if let Ok(mut det) = ww_handle.lock() {
+                det.start();
+                log::debug!("Wake-word: manager restarted after transcription window");
+            }
+        }
+    }
+
     /* ---------- mode switching --------------------------------------------- */
 
     pub fn update_mode(&self, new_mode: MicrophoneMode) -> Result<(), anyhow::Error> {

--- a/src-tauri/src/managers/mod.rs
+++ b/src-tauri/src/managers/mod.rs
@@ -2,3 +2,4 @@ pub mod audio;
 pub mod history;
 pub mod model;
 pub mod transcription;
+pub mod wakeword;

--- a/src-tauri/src/managers/wakeword.rs
+++ b/src-tauri/src/managers/wakeword.rs
@@ -1,0 +1,485 @@
+use anyhow::{anyhow, Context, Result};
+use ort::{inputs, session::Session, value::Tensor};
+use std::collections::VecDeque;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use tauri::{Emitter, Manager};
+
+const FRAME_SAMPLES: usize = 1280; // target chunk size for inference
+const MEL_ROWS: usize = 76;
+const MEL_COLS: usize = 32;
+const EMBED_DIMS: usize = 96;
+
+pub struct WakeWordManager {
+    app_handle: tauri::AppHandle,
+    threshold: f32,
+    // Model sessions
+    melspec: Session,
+    embed: Session,
+    wake: Session,
+    // Streaming buffers
+    mel_buf: VecDeque<[f32; MEL_COLS]>,
+    feat_buf: VecDeque<[f32; EMBED_DIMS]>,
+    wake_window: usize,
+    audio_tail: Vec<i16>,
+    // Sample aggregation buffer (i16)
+    i16_buf: Vec<i16>,
+    frames_seen: usize,
+    verbose: bool,
+    running: bool,
+}
+impl WakeWordManager {
+    pub fn new(app_handle: &tauri::AppHandle, verbose: bool, threshold: f32) -> Result<Self> {
+        // Resolve models with robust fallbacks for dev vs bundled paths
+        fn try_resolve(app: &tauri::AppHandle, rel: &str) -> Option<PathBuf> {
+            // Attempt resolution via the Tauri Resource base
+            if let Ok(p) = app
+                .path()
+                .resolve(rel, tauri::path::BaseDirectory::Resource)
+            {
+                if p.exists() {
+                    return Some(p);
+                }
+            }
+            // Fallback to current working directory (useful in dev)
+            if let Ok(cwd) = std::env::current_dir() {
+                let p = cwd.join(rel);
+                if p.exists() {
+                    return Some(p);
+                }
+            }
+            None
+        }
+
+        // Candidate relative paths to handle both dev and bundled layouts
+        let candidates = [
+            (
+                "melspectrogram.onnx",
+                [
+                    "resources/models/melspectrogram.onnx",
+                    "models/melspectrogram.onnx",
+                    "src-tauri/resources/models/melspectrogram.onnx",
+                ],
+            ),
+            (
+                "embedding_model.onnx",
+                [
+                    "resources/models/embedding_model.onnx",
+                    "models/embedding_model.onnx",
+                    "src-tauri/resources/models/embedding_model.onnx",
+                ],
+            ),
+            (
+                "hey_mycroft_v0.1.onnx",
+                [
+                    "resources/models/hey_mycroft_v0.1.onnx",
+                    "models/hey_mycroft_v0.1.onnx",
+                    "src-tauri/resources/models/hey_mycroft_v0.1.onnx",
+                ],
+            ),
+        ];
+
+        let mut melspec_path: Option<PathBuf> = None;
+        let mut embed_path: Option<PathBuf> = None;
+        let mut wake_path: Option<PathBuf> = None;
+
+        for (name, paths) in candidates.iter() {
+            let mut found: Option<PathBuf> = None;
+            for rel in paths {
+                if let Some(p) = try_resolve(app_handle, rel) {
+                    found = Some(p);
+                    break;
+                }
+            }
+            match *name {
+                "melspectrogram.onnx" => melspec_path = found,
+                "embedding_model.onnx" => embed_path = found,
+                "hey_mycroft_v0.1.onnx" => wake_path = found,
+                _ => {}
+            }
+        }
+
+        let (melspec_path, embed_path, wake_path) = (melspec_path, embed_path, wake_path);
+        if melspec_path.is_none() || embed_path.is_none() || wake_path.is_none() {
+            return Err(anyhow!(
+                "Wake-word models not found in resources/models (melspectrogram.onnx, embedding_model.onnx, hey_mycroft_v0.1.onnx)"
+            ));
+        }
+        let melspec_path = melspec_path.unwrap();
+        let embed_path = embed_path.unwrap();
+        let wake_path = wake_path.unwrap();
+
+        log::info!(
+            "Wake-word: resolved models -> melspec={:?}, embed={:?}, wake={:?}",
+            melspec_path,
+            embed_path,
+            wake_path
+        );
+
+        let melspec = Session::builder()?
+            .with_intra_threads(1)?
+            .with_inter_threads(1)?
+            .commit_from_file(melspec_path)?;
+        let embed = Session::builder()?
+            .with_intra_threads(1)?
+            .with_inter_threads(1)?
+            .commit_from_file(embed_path)?;
+        let wake = Session::builder()?
+            .with_intra_threads(1)?
+            .with_inter_threads(1)?
+            .commit_from_file(wake_path)?;
+
+        log::info!("Wake-word: ONNX sessions created");
+
+        // Initialize buffers
+        let mut mel_buf = VecDeque::with_capacity(MEL_ROWS);
+        for _ in 0..MEL_ROWS {
+            mel_buf.push_back([0.0; MEL_COLS]);
+        }
+
+        let mut feat_buf = VecDeque::new();
+        // Seed with zeros to avoid random triggers on startup
+        for _ in 0..41 {
+            feat_buf.push_back([0.0f32; EMBED_DIMS]);
+        }
+
+        Ok(Self {
+            app_handle: app_handle.clone(),
+            threshold,
+            melspec,
+            embed,
+            wake,
+            mel_buf,
+            feat_buf,
+            wake_window: 16,
+            audio_tail: vec![0i16; 480],
+            i16_buf: Vec::with_capacity(FRAME_SAMPLES * 2),
+            frames_seen: 0,
+            verbose,
+            running: false,
+        })
+    }
+
+    pub fn start(&mut self) {
+        self.running = true;
+        self.frames_seen = 0;
+        self.i16_buf.clear();
+        log::info!("Wake-word: started (threshold={})", self.threshold);
+        let _ = self
+            .app_handle
+            .emit("wakeword-log", "started (running=true)");
+    }
+
+    pub fn stop(&mut self) {
+        self.running = false;
+        self.i16_buf.clear();
+        log::info!("Wake-word: stopped");
+        let _ = self
+            .app_handle
+            .emit("wakeword-log", "stopped (running=false)");
+    }
+
+    pub fn is_running(&self) -> bool {
+        self.running
+    }
+
+    /// Accept 30ms speech frames (f32, -1..1), aggregate to 1280-sample chunks and run inference.
+    pub fn on_speech_frame(&mut self, frame: &[f32]) -> Result<()> {
+        log::debug!("Calling on_speech_frame on wakeword");
+        if !self.running {
+            return Ok(());
+        }
+
+        log::info!("Wake-word: speech frame received len={}", frame.len());
+
+        // Convert f32 to i16 and append
+        self.i16_buf.reserve(frame.len());
+        for &x in frame {
+            let s = (x.clamp(-1.0, 1.0) * 32767.0) as i16;
+            self.i16_buf.push(s);
+        }
+
+        // Process as many full chunks as available
+        while self.i16_buf.len() >= FRAME_SAMPLES {
+            let chunk: Vec<i16> = self.i16_buf.drain(0..FRAME_SAMPLES).collect();
+            let p = match self.predict(&chunk) {
+                Ok(val) => val,
+                Err(e) => {
+                    log::error!("Wake-word: predict error: {}", e);
+                    let _ = self
+                        .app_handle
+                        .emit("wakeword-log", format!("predict error: {}", e));
+                    0.0
+                }
+            };
+            if self.verbose {
+                log::debug!("wake p={:.6}", p);
+            }
+            log::info!("Wake-word: p={:.4} (frame={})", p, self.frames_seen);
+            let _ = self.app_handle.emit("wakeword-prob", p);
+            if self.frames_seen >= 5 && p > self.threshold {
+                // Immediately inactivate wake-word before any recording to avoid interference
+                self.stop();
+                log::debug!("Ordering: wake-word stopped; scheduling start/stop actions");
+
+                // Optional: also emit an event for frontend listeners
+                let _ = self.app_handle.emit("wakeword-detected", p);
+                let _ = self
+                    .app_handle
+                    .emit("wakeword-log", format!("detected p={:.4}", p));
+
+                // Start a short recording window (5 seconds) via transcription action
+                // Run actions asynchronously to avoid blocking the UI thread.
+                let app_start = self.app_handle.clone();
+                tauri::async_runtime::spawn(async move {
+                    super::super::actions::start_transcription_via_wakeword(&app_start);
+                });
+
+                let app_stop = self.app_handle.clone();
+                tauri::async_runtime::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                    super::super::actions::stop_transcription_via_wakeword(&app_stop);
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    fn predict(&mut self, frame_i16: &[i16]) -> Result<f32> {
+        log::info!(
+            "Wake-word: starting prediction (frame_i16.len={})",
+            frame_i16.len()
+        );
+        if frame_i16.len() != FRAME_SAMPLES {
+            return Err(anyhow!("frame must be {} samples", FRAME_SAMPLES));
+        }
+
+        // Build streaming window: last 480 samples + this frame (1280) => up to 1760
+        let mut window_i16: Vec<i16> = Vec::with_capacity(480 + FRAME_SAMPLES);
+        window_i16.extend_from_slice(&self.audio_tail);
+        window_i16.extend_from_slice(frame_i16);
+        if window_i16.len() > FRAME_SAMPLES + 480 {
+            let start = window_i16.len() - (FRAME_SAMPLES + 480);
+            window_i16.drain(0..start);
+        }
+        // Update tail for next call: last 480 samples of current window
+        if window_i16.len() >= 480 {
+            let start_tail = window_i16.len() - 480;
+            self.audio_tail.clear();
+            self.audio_tail.extend_from_slice(&window_i16[start_tail..]);
+        }
+
+        // Convert to f32 and create tensor (1, len)
+        let x: Vec<f32> = window_i16.iter().map(|&s| s as f32).collect();
+        let x_len = x.len();
+        let input_tensor = Tensor::from_array(([1usize, x_len], x.into_boxed_slice()))?;
+        let mel_in_name = self.melspec.inputs[0].name.clone();
+        let outputs = match self.melspec.run(inputs! { &*mel_in_name => input_tensor }) {
+            Ok(o) => o,
+            Err(e) => {
+                log::error!("Wake-word: melspec run error: {}", e);
+                return Err(anyhow!("melspec run error: {}", e));
+            }
+        };
+        let mel_arr = outputs[0]
+            .try_extract_array::<f32>()
+            .context("extract mel array")?;
+
+        // Normalize: spec/10 + 2 and append all rows to mel buffer.
+        let shape = mel_arr.shape().to_vec();
+        match shape.as_slice() {
+            // [32] => single row
+            [mel_cols_const] if *mel_cols_const == MEL_COLS => {
+                let mut row = [0.0f32; MEL_COLS];
+                for (i, v) in mel_arr.iter().take(MEL_COLS).enumerate() {
+                    row[i] = *v / 10.0 + 2.0;
+                }
+                self.mel_buf.push_back(row);
+            }
+            // [rows, 32]
+            [rows, mel_cols_const] if *mel_cols_const == MEL_COLS => {
+                let rows = *rows;
+                let data = mel_arr.iter().copied().collect::<Vec<f32>>();
+                for r in 0..rows {
+                    let mut row = [0.0f32; MEL_COLS];
+                    let offs = r * MEL_COLS;
+                    for c in 0..MEL_COLS {
+                        row[c] = data[offs + c] / 10.0 + 2.0;
+                    }
+                    self.mel_buf.push_back(row);
+                }
+            }
+            // [1, rows, 32]
+            [1, rows, mel_cols_const] if *mel_cols_const == MEL_COLS => {
+                let rows = *rows;
+                let data = mel_arr.iter().copied().collect::<Vec<f32>>();
+                for r in 0..rows {
+                    let mut row = [0.0f32; MEL_COLS];
+                    let offs = r * MEL_COLS;
+                    for c in 0..MEL_COLS {
+                        row[c] = data[offs + c] / 10.0 + 2.0;
+                    }
+                    self.mel_buf.push_back(row);
+                }
+            }
+            // [1, 1, rows, 32]
+            [1, 1, rows, mel_cols_const] if *mel_cols_const == MEL_COLS => {
+                let rows = *rows;
+                let data = mel_arr.iter().copied().collect::<Vec<f32>>();
+                for r in 0..rows {
+                    let mut row = [0.0f32; MEL_COLS];
+                    let offs = r * MEL_COLS;
+                    for c in 0..MEL_COLS {
+                        row[c] = data[offs + c] / 10.0 + 2.0;
+                    }
+                    self.mel_buf.push_back(row);
+                }
+            }
+            _ => {
+                // Fallback: take last 32 values as one row
+                let flat = mel_arr.iter().copied().collect::<Vec<f32>>();
+                let mut row = [0.0f32; MEL_COLS];
+                for i in 0..MEL_COLS {
+                    let v = if flat.len() >= MEL_COLS {
+                        flat[flat.len() - MEL_COLS + i]
+                    } else {
+                        0.0
+                    };
+                    row[i] = v / 10.0 + 2.0;
+                }
+                self.mel_buf.push_back(row);
+            }
+        }
+        while self.mel_buf.len() > MEL_ROWS {
+            self.mel_buf.pop_front();
+        }
+
+        // Prepare (1, 76, 32, 1)
+        let mut emb_input = Vec::with_capacity(MEL_ROWS * MEL_COLS);
+        for r in self
+            .mel_buf
+            .iter()
+            .rev()
+            .take(MEL_ROWS)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+        {
+            emb_input.extend_from_slice(r);
+        }
+        let emb_tensor = Tensor::from_array((
+            [1usize, MEL_ROWS, MEL_COLS, 1usize],
+            emb_input.into_boxed_slice(),
+        ))?;
+
+        let emb_in_name = self.embed.inputs[0].name.clone();
+        let emb_out = match self.embed.run(inputs! { &*emb_in_name => emb_tensor }) {
+            Ok(o) => o,
+            Err(e) => {
+                log::error!("Wake-word: embed run error: {}", e);
+                return Err(anyhow!("embed run error: {}", e));
+            }
+        };
+        let emb_arr = emb_out[0]
+            .try_extract_array::<f32>()
+            .context("extract embedding")?;
+        let flat_emb = emb_arr.iter().copied().collect::<Vec<f32>>();
+        let mut emb_vec = [0.0f32; EMBED_DIMS];
+        for i in 0..EMBED_DIMS {
+            emb_vec[i] = if flat_emb.len() > i { flat_emb[i] } else { 0.0 };
+        }
+        self.feat_buf.push_back(emb_vec);
+        while self.feat_buf.len() > 512 {
+            self.feat_buf.pop_front();
+        }
+
+        // Select window
+        let t = self.wake_window.min(self.feat_buf.len());
+        let start = self.feat_buf.len() - t;
+        let mut wake_input = Vec::with_capacity(t * EMBED_DIMS);
+        for v in self.feat_buf.iter().skip(start) {
+            wake_input.extend_from_slice(v);
+        }
+        let wake_tensor =
+            Tensor::from_array(([1usize, t, EMBED_DIMS], wake_input.into_boxed_slice()))?;
+        let in_name = self.wake.inputs[0].name.clone();
+        let wake_out = match self.wake.run(inputs! { &*in_name => wake_tensor }) {
+            Ok(o) => o,
+            Err(e) => {
+                log::error!("Wake-word: wake run error: {}", e);
+                return Err(anyhow!("wake run error: {}", e));
+            }
+        };
+        let prob = wake_out[0]
+            .try_extract_array::<f32>()
+            .context("extract wake prob")?;
+        let first = prob
+            .iter()
+            .copied()
+            .next()
+            .ok_or_else(|| anyhow!("empty wake output"))?;
+        self.frames_seen = self.frames_seen.saturating_add(1);
+        Ok(first)
+    }
+}
+
+pub type WakeWordManagerHandle = Arc<Mutex<WakeWordManager>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hound;
+
+    // Helper to read mono PCM samples from a WAV file as i16.
+    fn read_wav_i16(path: &std::path::Path) -> Result<Vec<i16>> {
+        let mut reader = hound::WavReader::open(path).map_err(|e| anyhow!("open wav: {}", e))?;
+        let spec = reader.spec();
+        if spec.channels != 1 {
+            return Err(anyhow!("expected mono wav, got {} channels", spec.channels));
+        }
+        // Prefer int samples; fallback to f32
+        let samples: Vec<i16> = match spec.sample_format {
+            hound::SampleFormat::Int => reader.samples::<i16>().map(|s| s.unwrap_or(0)).collect(),
+            hound::SampleFormat::Float => reader
+                .samples::<f32>()
+                .map(|s| {
+                    let x = s.unwrap_or(0.0).clamp(-1.0, 1.0);
+                    (x * 32767.0) as i16
+                })
+                .collect(),
+        };
+        Ok(samples)
+    }
+
+    #[test]
+    fn wakeword_prob_exceeds_threshold_on_test_wav() -> Result<()> {
+        // Build a minimal Tauri app to get an AppHandle for resource resolution and event emits.
+        let app = tauri::Builder::default()
+            .build(tauri::generate_context!())
+            .map_err(|e| anyhow!("build tauri app: {}", e))?;
+        let handle = app.handle();
+
+        // Initialize manager (verbose off to keep test logs tidy).
+        let mut mgr = WakeWordManager::new(&handle, false, 0.5)?;
+
+        // Load test audio from resources.
+        let wav_path = std::path::Path::new("resources/hey_mycroft_test.wav");
+        let mut samples = read_wav_i16(wav_path)?;
+
+        // Stream through the model in FRAME_SAMPLES chunks, track max probability.
+        let mut max_p = 0.0f32;
+        while samples.len() >= FRAME_SAMPLES {
+            let chunk: Vec<i16> = samples.drain(0..FRAME_SAMPLES).collect();
+            let p = mgr.predict(&chunk)?;
+            if p > max_p {
+                max_p = p;
+            }
+        }
+
+        // Basic assertion: expect a noticeable activation on the wake-word audio.
+        // Threshold chosen conservatively to avoid flakiness across platforms.
+        assert!(max_p > 0.40, "max wake-word prob too low: {:.3}", max_p);
+        Ok(())
+    }
+}

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -547,6 +547,30 @@ async getClamshellMicrophone() : Promise<Result<string, string>> {
 async isRecording() : Promise<boolean> {
     return await TAURI_INVOKE("is_recording");
 },
+async startWakeword(threshold: number | null) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("start_wakeword", { threshold }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async stopWakeword() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("stop_wakeword") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async isWakewordRunning() : Promise<Result<boolean, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("is_wakeword_running") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async setModelUnloadTimeout(timeout: ModelUnloadTimeout) : Promise<void> {
     await TAURI_INVOKE("set_model_unload_timeout", { timeout });
 },

--- a/src/components/settings/debug/DebugSettings.tsx
+++ b/src/components/settings/debug/DebugSettings.tsx
@@ -7,6 +7,7 @@ import { LogLevelSelector } from "./LogLevelSelector";
 import { SettingsGroup } from "../../ui/SettingsGroup";
 import { HistoryLimit } from "../HistoryLimit";
 import { AlwaysOnMicrophone } from "../AlwaysOnMicrophone";
+import { WakeWordToggle } from "./WakeWordToggle";
 import { SoundPicker } from "../SoundPicker";
 import { PostProcessingToggle } from "../PostProcessingToggle";
 import { MuteWhileRecording } from "../MuteWhileRecording";
@@ -40,6 +41,7 @@ export const DebugSettings: React.FC = () => {
           grouped={true}
         />
         <AlwaysOnMicrophone descriptionMode="tooltip" grouped={true} />
+        <WakeWordToggle descriptionMode="tooltip" grouped={true} />
         <ClamshellMicrophoneSelector descriptionMode="tooltip" grouped={true} />
         <PostProcessingToggle descriptionMode="tooltip" grouped={true} />
         <MuteWhileRecording descriptionMode="tooltip" grouped={true} />

--- a/src/components/settings/debug/WakeWordToggle.tsx
+++ b/src/components/settings/debug/WakeWordToggle.tsx
@@ -1,0 +1,135 @@
+import React, { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ToggleSwitch } from "../../ui/ToggleSwitch";
+import { commands } from "../../../bindings";
+import { listen } from "@tauri-apps/api/event";
+import { useSettings } from "../../../hooks/useSettings";
+
+interface WakeWordToggleProps {
+    descriptionMode?: "inline" | "tooltip";
+    grouped?: boolean;
+}
+
+export const WakeWordToggle: React.FC<WakeWordToggleProps> = ({
+    descriptionMode = "tooltip",
+    grouped = false,
+}) => {
+    const { t } = useTranslation();
+    const { getSetting } = useSettings();
+    const alwaysOnMode = getSetting("always_on_microphone") || false;
+
+    const [running, setRunning] = useState(false);
+    const [updating, setUpdating] = useState(false);
+
+    useEffect(() => {
+        let cancelled = false;
+        // Event listeners for backend wake-word logs
+        const unsubs: Array<() => void> = [];
+        (async () => {
+            try {
+                unsubs.push(
+                    await listen<string>("wakeword-log", (e) => {
+                        const msg = e.payload || "";
+                        // Reflect backend state in UI to avoid polling delays
+                        if (msg.includes("started")) {
+                            setRunning(true);
+                            setUpdating(false);
+                        } else if (msg.includes("stopped")) {
+                            setRunning(false);
+                            setUpdating(false);
+                        }
+                    })
+                );
+                unsubs.push(
+                    await listen<number>("wakeword-detected", (e) => {
+                        // eslint-disable-next-line no-console
+                        console.log("[wakeword-detected] p=", e.payload);
+                    })
+                );
+                unsubs.push(
+                    await listen<number>("wakeword-prob", (e) => {
+                        // eslint-disable-next-line no-console
+                        console.log("[wakeword-prob] p=", e.payload);
+                    })
+                );
+            } catch { }
+        })();
+        (async () => {
+            try {
+                const res = await commands.isWakewordRunning();
+                if (!cancelled) setRunning(res.status === "ok" ? !!res.data : false);
+            } catch {
+                if (!cancelled) setRunning(false);
+            }
+        })();
+        return () => {
+            cancelled = true;
+            // Unsubscribe listeners
+            unsubs.forEach((u) => {
+                try {
+                    u();
+                } catch { }
+            });
+        };
+    }, []);
+
+    const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+    const onChange = async (enabled: boolean) => {
+        // eslint-disable-next-line no-console
+        console.log(`Wake-word toggled: enabled=${enabled}`);
+        // Optimistically update so the toggle moves immediately
+        setRunning(enabled);
+        setUpdating(true);
+        try {
+            if (enabled) {
+                const res = await commands.startWakeword(0.5);
+                if (res.status !== "ok") {
+                    console.log(`Wake-word start error: ${res.error}`);
+                    setRunning(!enabled);
+                } else {
+                    // Rely on backend wakeword-log "started" event to update state;
+                    // keep a soft fallback check after a generous grace period
+                    setTimeout(async () => {
+                        const s = await commands.isWakewordRunning();
+                        if (!(s.status === "ok" && s.data === true)) {
+                            console.log("Wake-word still initializing; backend may be loading models");
+                        }
+                    }, 15000);
+                }
+            } else {
+                const res = await commands.stopWakeword();
+                if (res.status !== "ok") {
+                    console.log(`Wake-word stop error: ${res.error}`);
+                    setRunning(!enabled);
+                }
+                // Give the backend a moment to detach callback
+                await sleep(200);
+                const confirm = await commands.isWakewordRunning();
+                setRunning(confirm.status === "ok" ? !!confirm.data : false);
+            }
+        } catch (e) {
+            console.log(`Wake-word toggle error: ${e}`);
+            // Revert on failure
+            setRunning(!enabled);
+        } finally {
+            setUpdating(false);
+        }
+    };
+
+    return (
+        <ToggleSwitch
+            checked={running}
+            onChange={onChange}
+            disabled={!alwaysOnMode}
+            isUpdating={updating}
+            label={t("settings.debug.wakeword.label", { defaultValue: "Wake-word (debug)" })}
+            description={t("settings.debug.wakeword.description", {
+                defaultValue:
+                    "Runs a local wake-word detector while the Always-On microphone is active.",
+            })}
+            descriptionMode={descriptionMode}
+            grouped={grouped}
+        />
+    );
+};

--- a/src/components/settings/debug/WakeWordToggle.tsx
+++ b/src/components/settings/debug/WakeWordToggle.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ToggleSwitch } from "../../ui/ToggleSwitch";
 import { commands } from "../../../bindings";
-import { listen } from "@tauri-apps/api/event";
 import { useSettings } from "../../../hooks/useSettings";
 
 interface WakeWordToggleProps {
@@ -18,100 +17,36 @@ export const WakeWordToggle: React.FC<WakeWordToggleProps> = ({
     const { getSetting } = useSettings();
     const alwaysOnMode = getSetting("always_on_microphone") || false;
 
-    const [running, setRunning] = useState(false);
+    const [enabled, setEnabled] = useState(false);
     const [updating, setUpdating] = useState(false);
 
+    // Simple initialization: reflect current backend flag state
     useEffect(() => {
         let cancelled = false;
-        // Event listeners for backend wake-word logs
-        const unsubs: Array<() => void> = [];
-        (async () => {
-            try {
-                unsubs.push(
-                    await listen<string>("wakeword-log", (e) => {
-                        const msg = e.payload || "";
-                        // Reflect backend state in UI to avoid polling delays
-                        if (msg.includes("started")) {
-                            setRunning(true);
-                            setUpdating(false);
-                        } else if (msg.includes("stopped")) {
-                            setRunning(false);
-                            setUpdating(false);
-                        }
-                    })
-                );
-                unsubs.push(
-                    await listen<number>("wakeword-detected", (e) => {
-                        // eslint-disable-next-line no-console
-                        console.log("[wakeword-detected] p=", e.payload);
-                    })
-                );
-                unsubs.push(
-                    await listen<number>("wakeword-prob", (e) => {
-                        // eslint-disable-next-line no-console
-                        console.log("[wakeword-prob] p=", e.payload);
-                    })
-                );
-            } catch { }
-        })();
         (async () => {
             try {
                 const res = await commands.isWakewordRunning();
-                if (!cancelled) setRunning(res.status === "ok" ? !!res.data : false);
+                if (!cancelled) setEnabled(res.status === "ok" ? !!res.data : false);
             } catch {
-                if (!cancelled) setRunning(false);
+                if (!cancelled) setEnabled(false);
             }
         })();
         return () => {
             cancelled = true;
-            // Unsubscribe listeners
-            unsubs.forEach((u) => {
-                try {
-                    u();
-                } catch { }
-            });
         };
     }, []);
 
-    const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-
-    const onChange = async (enabled: boolean) => {
-        // eslint-disable-next-line no-console
-        console.log(`Wake-word toggled: enabled=${enabled}`);
-        // Optimistically update so the toggle moves immediately
-        setRunning(enabled);
+    const onChange = async (next: boolean) => {
+        setEnabled(next);
         setUpdating(true);
         try {
-            if (enabled) {
+            if (next) {
                 const res = await commands.startWakeword(0.5);
-                if (res.status !== "ok") {
-                    console.log(`Wake-word start error: ${res.error}`);
-                    setRunning(!enabled);
-                } else {
-                    // Rely on backend wakeword-log "started" event to update state;
-                    // keep a soft fallback check after a generous grace period
-                    setTimeout(async () => {
-                        const s = await commands.isWakewordRunning();
-                        if (!(s.status === "ok" && s.data === true)) {
-                            console.log("Wake-word still initializing; backend may be loading models");
-                        }
-                    }, 15000);
-                }
+                if (res.status !== "ok") setEnabled(!next);
             } else {
                 const res = await commands.stopWakeword();
-                if (res.status !== "ok") {
-                    console.log(`Wake-word stop error: ${res.error}`);
-                    setRunning(!enabled);
-                }
-                // Give the backend a moment to detach callback
-                await sleep(200);
-                const confirm = await commands.isWakewordRunning();
-                setRunning(confirm.status === "ok" ? !!confirm.data : false);
+                if (res.status !== "ok") setEnabled(!next);
             }
-        } catch (e) {
-            console.log(`Wake-word toggle error: ${e}`);
-            // Revert on failure
-            setRunning(!enabled);
         } finally {
             setUpdating(false);
         }
@@ -119,7 +54,7 @@ export const WakeWordToggle: React.FC<WakeWordToggleProps> = ({
 
     return (
         <ToggleSwitch
-            checked={running}
+            checked={enabled}
             onChange={onChange}
             disabled={!alwaysOnMode}
             isUpdating={updating}

--- a/src/components/settings/debug/index.ts
+++ b/src/components/settings/debug/index.ts
@@ -1,3 +1,4 @@
 export { WordCorrectionThreshold } from "./WordCorrectionThreshold";
 export { LogDirectory } from "./LogDirectory";
 export { LogLevelSelector } from "./LogLevelSelector";
+export { WakeWordToggle } from "./WakeWordToggle";


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [X] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

<!-- Describe your changes clearly and concisely

Please write 2-3 sentences in your own words explaining:
- What problem you noticed or idea you had
- Why you think this change matters

This section should be YOUR thinking, not AI-generated text. Even if AI helped write the code, we want to hear from you directly. Your perspective as a human is what makes contributions meaningful. Your PR may be rejected if you do not
include a human-written description.
-->

Hi! This is a Draft PR for the discussion of the WakeWord implementation. I chose a draft PR because the code is not production ready, and most likely won't be until we sort out all the details.

I started from the [openWakeWord](https://github.com/dscripka/openWakeWord) project, that seems to train wakewords, as well as provide an inference engine based on onnx to run them.

In order to understand how openWakeWord works, I stripped the entire logic and one example into a single file, very easy to understand, that I provide in this [github gist](https://gist.github.com/tachyonicbytes/850ffd8c7a02d7d87a44521592e46541) here.

Basically, there are three models, the melspectrogram model, the embedding model from google and the actual wakeword model. And all that's needed is chopping up the audio into suitable pieces (resampling if needed), feeding the input from one model into the other up until the wakeword model, which gives us the prediction. The "Hey Mycroft" model seemed to have the best activation from all the models included.

Secondly, I translated the code to Rust, as a standalone example, provided in this [github gist](https://gist.github.com/tachyonicbytes/1e4be48ef5029ad958642a282d406144) here. There are some more goodies than the simple example here. A project that already ports a form of openWakeWord to rust already [exists](https://github.com/skoky/oww_rs), but I couldn't make it work.

Using the functional code from this example, I was able to implement a very rudimentary wakeword function for Handy, using the already present "Always-On Microphone", that's a prerequisite for the wakeword to function.

I posit that the models themselves are small enough and the license is not problematic to distribute them along with the app, not making the user also download them, but closer inspection of the openWakeWord repo should be done in order to do so. Otherwise, we can just download them like we do for the transcription models.


There is an additional question of stopping the recording after the wakeword was uttered. For the simple example, I did a 5 second delay, but we should find something more permanent here.

Ideally also, a "Hey Handy" model should be trained. The code from the oww repo seems to provide us with all we need in order to do it, we just need the computing capacity and data. I'd be an interesting exercise for the Handy community, if they want their voice / pronunciation to be a part of the model :)

You have to manually download these three models from openWakeWord and place them in order to form this directory tree:

https://github.com/dscripka/openWakeWord/releases/download/v0.5.1/hey_mycroft_v0.1.onnx
https://github.com/dscripka/openWakeWord/releases/download/v0.5.1/embedding_model.onnx
https://github.com/dscripka/openWakeWord/releases/download/v0.5.1/melspectrogram.onnx

```
src-tauri/resources/models/embedding_model.onnx
src-tauri/resources/models/hey_mycroft_v0.1.onnx
src-tauri/resources/models/melspectrogram.onnx
```


## Related Issues/Discussions

<!-- Link to related issues, discussions, or previous PRs -->
<!-- If reopening something previously closed, explain why this should be reconsidered -->

Fixes #
Discussion:

## Community Feedback

<!--
PRs with community support are much more likely to be merged.

For features: Link to a discussion where community members have expressed interest.
For bug fixes: Link to the issue where others have confirmed the bug.

If you haven't gathered feedback yet, consider starting a discussion first:
https://github.com/cjpais/Handy/discussions

It is not explicitly required to gather feedback, but it certainly helps your PR get merged.
-->
I announced the community on discord, with a video of the feature. @cjpais seemed interested in the code itself, saying that the feature was previously requested, but I couldn't find exactly where.
## Testing
I tested the code manually, because only some e2e tests would be able to test such a vertical feature fully. But there didn't seem to be any e2e tests when I started.

I also added a test for the activation itself. It requires another external resource, a single-channel 16khz `.wav` file of the wake-word being spoken, that I didn't also include until we sort out what files are acceptable in a PR.
<!-- Describe how you tested your changes and if you need help getting additional testing -->

## Screenshots/Videos (if applicable)
The original video

https://github.com/user-attachments/assets/9f8c6e7a-7f8c-4dda-b5e7-dbbe93266127

<!-- Add screenshots or videos demonstrating the change -->

## AI Assistance

<!-- AI-assisted PRs are welcome! Just let us know so we can review appropriately. -->

- [ ] No AI was used in this PR
- [X] AI was used (please describe below)

**If AI was used:**

- Tools used: VSCode + Agent mode, with either GPT5, GPT-4o or Claude Sonnet 4.
- How extensively: Much of the editing and making sense of the code. It needed a lot of steering and hand-holding. I originally tried a direct port from openWakeWord, but it failed spectacularly. It couldn't even make the first gist in this PR description, that was made manually. It did translate that code to rust though (the second gist), but bugfixes were needed even then.
