### PR TITLE
feat: add Paste Last Transcription shortcut

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -567,6 +567,22 @@ pub fn get_default_settings() -> AppSettings {
         },
     );
 
+    #[cfg(target_os = "macos")]
+    let paste_last_shortcut = "ctrl+option+v";
+    #[cfg(not(target_os = "macos"))]
+    let paste_last_shortcut = "ctrl+alt+v";
+
+    bindings.insert(
+        "paste_last".to_string(),
+        ShortcutBinding {
+            id: "paste_last".to_string(),
+            name: "Paste Last Transcription".to_string(),
+            description: "Paste the most recent transcription from history.".to_string(),
+            default_binding: paste_last_shortcut.to_string(),
+            current_binding: paste_last_shortcut.to_string(),
+        },
+    );
+
     AppSettings {
         bindings,
         push_to_talk: true,

--- a/src/components/model-selector/ModelSelector.tsx
+++ b/src/components/model-selector/ModelSelector.tsx
@@ -99,7 +99,7 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ onError }) => {
       (event) => {
         const progress = event.payload;
         setModelDownloadProgress(
-          produce((downloadProgress) => {
+          produce((downloadProgress: Record<string, DownloadProgress>) => {
             downloadProgress[progress.model_id] = progress;
           }),
         );
@@ -108,7 +108,7 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ onError }) => {
         // Update download stats for speed calculation
         const now = Date.now();
         setDownloadStats(
-          produce((stats) => {
+          produce((stats: Record<string, DownloadStats>) => {
             const current = stats[progress.model_id];
 
             if (!current) {
@@ -153,12 +153,12 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ onError }) => {
       (event) => {
         const modelId = event.payload;
         setModelDownloadProgress(
-          produce((progress) => {
+          produce((progress: Record<string, DownloadProgress>) => {
             delete progress[modelId];
           }),
         );
         setDownloadStats(
-          produce((stats) => {
+          produce((stats: Record<string, DownloadStats>) => {
             delete stats[modelId];
           }),
         );
@@ -182,7 +182,7 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ onError }) => {
       (event) => {
         const modelId = event.payload;
         setExtractingModels(
-          produce((extracting) => {
+          produce((extracting: Record<string, true>) => {
             extracting[modelId] = true;
           }),
         );
@@ -195,7 +195,7 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ onError }) => {
       (event) => {
         const modelId = event.payload;
         setExtractingModels(
-          produce((extracting) => {
+          produce((extracting: Record<string, true>) => {
             delete extracting[modelId];
           }),
         );

--- a/src/components/settings/general/GeneralSettings.tsx
+++ b/src/components/settings/general/GeneralSettings.tsx
@@ -22,6 +22,7 @@ export const GeneralSettings: React.FC = () => {
     <div className="max-w-3xl w-full mx-auto space-y-6">
       <SettingsGroup title={t("settings.general.title")}>
         <ShortcutInput shortcutId="transcribe" grouped={true} />
+        <ShortcutInput shortcutId="paste_last" grouped={true} />
         {showLanguageSelector && (
           <LanguageSelector descriptionMode="tooltip" grouped={true} />
         )}

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -119,6 +119,10 @@
           "cancel": {
             "name": "Cancel Shortcut",
             "description": "The keyboard shortcut to cancel the current recording."
+          },
+          "paste_last": {
+            "name": "Paste Last Transcription",
+            "description": "Paste the most recent transcription from history without using the clipboard."
           }
         },
         "errors": {


### PR DESCRIPTION
## Summary

Add a new global keyboard shortcut to paste the most recent transcription from history.

## Motivation

Sometimes the transcription does not make it to where you need it:

- **Clipboard overwritten**: You transcribe something, then copy something else before pasting - your transcription is gone from the clipboard
- **Paste failed**: The target app did not accept the paste (wrong focus, read-only field, etc.)
- **Need to paste again**: You want to paste the same transcription in multiple places
- **Clipboard mode "Do not Modify"**: If you use this setting to preserve your clipboard, you need another way to retrieve the transcription later

With this shortcut, you can always recover your last transcription without having to go to History, find the entry, and copy it manually.

## Implementation

- Default binding: `Ctrl+Option+V` (macOS) / `Ctrl+Alt+V` (Windows/Linux)
- Configurable in General settings alongside the existing Transcribe shortcut
- Added `PasteLastAction` in `actions.rs` that fetches the most recent history entry
- Uses the existing `utils::paste()` function, so it respects paste_method and append_trailing_space settings
- Prefers `post_processed_text` if available, falls back to `transcription_text`
- Silently does nothing if no history exists

## Bonus fix

Fixed TypeScript build errors in `ModelSelector.tsx` by adding explicit type annotations to immer `produce()` callbacks. (Note: upstream main currently fails `bun run build` without this fix due to missing type annotations.)

## Test plan

- [x] Build completes successfully
- [ ] New shortcut appears in General settings
- [ ] Shortcut can be customized  
- [ ] Pressing shortcut pastes the last transcription
- [ ] Works correctly when no history exists (no error)

🤖 Generated with [Claude Code](https://claude.ai/code)