### PR TITLE
fix: race conditions

### DIFF
--- a/src-tauri/src/global_controller.rs
+++ b/src-tauri/src/global_controller.rs
@@ -1,0 +1,83 @@
+//! Global lock with declarative UI sync.
+
+use std::sync::Mutex;
+use tauri::AppHandle;
+
+use crate::overlay::{hide_recording_overlay, show_recording_overlay, show_transcribing_overlay};
+use crate::tray::{change_tray_icon, TrayIconState};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum GlobalPhase {
+    Idle,
+    Recording,
+    Processing,
+}
+
+pub struct GlobalController {
+    phase: Mutex<GlobalPhase>,
+    app: AppHandle,
+}
+
+impl GlobalController {
+    pub fn new(app: AppHandle) -> Self {
+        Self {
+            phase: Mutex::new(GlobalPhase::Idle),
+            app,
+        }
+    }
+
+    fn sync_ui(&self, phase: &GlobalPhase) {
+        match phase {
+            GlobalPhase::Idle => {
+                change_tray_icon(&self.app, TrayIconState::Idle);
+                hide_recording_overlay(&self.app);
+            }
+            GlobalPhase::Recording => {
+                change_tray_icon(&self.app, TrayIconState::Recording);
+                show_recording_overlay(&self.app);
+            }
+            GlobalPhase::Processing => {
+                change_tray_icon(&self.app, TrayIconState::Transcribing);
+                show_transcribing_overlay(&self.app);
+            }
+        }
+    }
+
+    pub fn begin(&self) -> bool {
+        let mut phase = self.phase.lock().unwrap();
+        if *phase == GlobalPhase::Idle {
+            *phase = GlobalPhase::Recording;
+            self.sync_ui(&phase);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn advance(&self) -> bool {
+        let mut phase = self.phase.lock().unwrap();
+        if *phase == GlobalPhase::Recording {
+            *phase = GlobalPhase::Processing;
+            self.sync_ui(&phase);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn complete(&self) {
+        let mut phase = self.phase.lock().unwrap();
+        *phase = GlobalPhase::Idle;
+        self.sync_ui(&phase);
+    }
+
+    pub fn is_busy(&self) -> bool {
+        *self.phase.lock().unwrap() != GlobalPhase::Idle
+    }
+
+    /// Re-sync UI to current phase (e.g., after theme change)
+    pub fn refresh_ui(&self) {
+        let phase = self.phase.lock().unwrap();
+        self.sync_ui(&phase);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod audio_feedback;
 pub mod audio_toolkit;
 mod clipboard;
 mod commands;
+mod global_controller;
 mod helpers;
 mod input;
 mod llm_client;
@@ -39,6 +40,7 @@ use tauri::{AppHandle, Manager};
 use tauri_plugin_autostart::{MacosLauncher, ManagerExt};
 use tauri_plugin_log::{Builder as LogBuilder, RotationStrategy, Target, TargetKind};
 
+use crate::global_controller::GlobalController;
 use crate::settings::get_settings;
 
 // Global atomic to store the file log level filter
@@ -133,6 +135,9 @@ fn initialize_core_logic(app_handle: &AppHandle) {
     app_handle.manage(model_manager.clone());
     app_handle.manage(transcription_manager.clone());
     app_handle.manage(history_manager.clone());
+
+    // Global lock - prevents concurrent operations
+    app_handle.manage(Arc::new(GlobalController::new(app_handle.clone())));
 
     // Initialize the shortcuts
     shortcut::init_shortcuts(app_handle);
@@ -413,8 +418,9 @@ pub fn run() {
             }
             tauri::WindowEvent::ThemeChanged(theme) => {
                 log::info!("Theme changed to: {:?}", theme);
-                // Update tray icon to match new theme, maintaining idle state
-                utils::change_tray_icon(&window.app_handle(), utils::TrayIconState::Idle);
+                // Re-sync UI to current phase with new theme
+                let controller = window.app_handle().state::<Arc<GlobalController>>();
+                controller.refresh_ui();
             }
             _ => {}
         })

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -262,19 +262,11 @@ pub fn update_overlay_position(app_handle: &AppHandle) {
     }
 }
 
-/// Hides the recording overlay window with fade-out animation
+/// Hides the recording overlay window
 pub fn hide_recording_overlay(app_handle: &AppHandle) {
-    // Always hide the overlay regardless of settings - if setting was changed while recording,
-    // we still want to hide it properly
     if let Some(overlay_window) = app_handle.get_webview_window("recording_overlay") {
-        // Emit event to trigger fade-out animation
         let _ = overlay_window.emit("hide-overlay", ());
-        // Hide the window after a short delay to allow animation to complete
-        let window_clone = overlay_window.clone();
-        std::thread::spawn(move || {
-            std::thread::sleep(std::time::Duration::from_millis(300));
-            let _ = window_clone.hide();
-        });
+        let _ = overlay_window.hide();
     }
 }
 

--- a/src-tauri/src/shortcut/handler.rs
+++ b/src-tauri/src/shortcut/handler.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use tauri::{AppHandle, Manager};
 
 use crate::actions::ACTION_MAP;
-use crate::managers::audio::AudioRecordingManager;
+use crate::global_controller::GlobalController;
 use crate::settings::get_settings;
 use crate::ManagedToggleState;
 
@@ -41,10 +41,10 @@ pub fn handle_shortcut_event(
         return;
     };
 
-    // Cancel binding: only fires when recording and key is pressed
+    // Cancel binding: only fires when busy and key is pressed
     if binding_id == "cancel" {
-        let audio_manager = app.state::<Arc<AudioRecordingManager>>();
-        if audio_manager.is_recording() && is_pressed {
+        let controller = app.state::<Arc<GlobalController>>();
+        if controller.is_busy() && is_pressed {
             action.start(app, binding_id, hotkey_string);
         }
         return;

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -1,3 +1,4 @@
+use crate::global_controller::GlobalController;
 use crate::managers::audio::AudioRecordingManager;
 use crate::managers::transcription::TranscriptionManager;
 use crate::shortcut;
@@ -33,13 +34,13 @@ pub fn cancel_current_operation(app: &AppHandle) {
     let audio_manager = app.state::<Arc<AudioRecordingManager>>();
     audio_manager.cancel_recording();
 
-    // Update tray icon and hide overlay
-    change_tray_icon(app, crate::tray::TrayIconState::Idle);
-    hide_recording_overlay(app);
-
     // Unload model if immediate unload is enabled
     let tm = app.state::<Arc<TranscriptionManager>>();
     tm.maybe_unload_immediately("cancellation");
+
+    // Release the global lock
+    let controller = app.state::<Arc<GlobalController>>();
+    controller.complete();
 
     info!("Operation cancellation completed - returned to idle state");
 }


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Human Written Description

Implements state machine, single source of truth, declarative UI pattern, testing pattern, fixes race conditions at multiple layers. Trades off concurrency for simplicity, laying the foundation for future extensibility (and concurrency). Replaces jQuery style imperative UI management with React style declarative updates.

I am new to Rust and tried to do my best with AI, open to feedback / feel free to close and "steal" the idea but I would love feedback and/or credit!

## Related Issues/Discussions

Fixes #641, #462

## How to Reproduce

Three ways to trigger / different issue(s):

1. **During transcription**: Record something, release hotkey, then while transcribing trigger the hotkey again., global lock solves it
2. **Rapid toggle**: Quickly press and release the hotkey multiple times in succession capturing small empty audio packets rapidly, causes "deadlock" (not responding), global lock solves it.
3. **Hold and spam**: Hold down the hotkey key rapidly (same as 2) but UI panel disappears but audio cues indicates its still recording (which it is). Global lock does not solve it, required declarative UI.


## Testing

Tested locally by triggering all three reproduction scenarios above.

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Pair programming to implement the global lock and declarative UI sync

---

The app has multiple sources of state that can get out of sync - different mutex locks at different layers, imperative UI updates with delays that don't get cancelled. This PR demonstrates a pattern that fixes the UI overlay and tray icon: a single source of truth state machine where UI syncs declaratively when the phase changes (similar to React's model).

This also fixes the "Not Responding" freeze by adding a global lock that prevents concurrent operations.

**Intentionally pragmatic**: I've kept this PR minimal to avoid overwhelming reviewers with huge changes. It focuses on fixing the immediate issue and demonstrating a pattern that could be extended to other parts of the app in future PRs.

Other state could be consolidated into this pattern in follow-up PRs:

- Audio feedback timing (stop playing one sound, play the latest sound instead, etc)
- The functionality that mutes the sound on the users system also feels like declarative "UI" state, but is out of scope for this PR too.

---

In “Rust way” terms: I made state transitions explicit, serialized with a single lock, and made UI a pure projection of state.
  That’s consistent with correctness-first design.

I’d pitch it as:

  - The previous decentralized approach lacked a single source of truth for phase, which caused races.
  - The controller is a minimal, scoped state machine with clear transitions.
  - If we want “Rustier” later, we can evolve it into a channel-driven state machine without changing call sites (hopefully with tests and mock services, or something).