### PR TITLE
fix first launch on macos

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -164,3 +164,28 @@ pub fn initialize_enigo(app: AppHandle) -> Result<(), String> {
         }
     }
 }
+
+/// Marker state to track if shortcuts have been initialized.
+pub struct ShortcutsInitialized;
+
+/// Initialize keyboard shortcuts.
+/// On macOS, this should be called after accessibility permissions are granted.
+/// This is idempotent - calling it multiple times is safe.
+#[specta::specta]
+#[tauri::command]
+pub fn initialize_shortcuts(app: AppHandle) -> Result<(), String> {
+    // Check if already initialized
+    if app.try_state::<ShortcutsInitialized>().is_some() {
+        log::debug!("Shortcuts already initialized");
+        return Ok(());
+    }
+
+    // Initialize shortcuts
+    crate::shortcut::init_shortcuts(&app);
+
+    // Mark as initialized
+    app.manage(ShortcutsInitialized);
+
+    log::info!("Shortcuts initialized successfully");
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -134,8 +134,10 @@ fn initialize_core_logic(app_handle: &AppHandle) {
     app_handle.manage(transcription_manager.clone());
     app_handle.manage(history_manager.clone());
 
-    // Initialize the shortcuts
-    shortcut::init_shortcuts(app_handle);
+    // Note: Shortcuts are NOT initialized here.
+    // The frontend is responsible for calling the `initialize_shortcuts` command
+    // after permissions are confirmed (on macOS) or after onboarding completes.
+    // This matches the pattern used for Enigo initialization.
 
     #[cfg(unix)]
     let signals = Signals::new(&[SIGUSR2]).unwrap();
@@ -285,6 +287,7 @@ pub fn run() {
         commands::open_app_data_dir,
         commands::check_apple_intelligence_available,
         commands::initialize_enigo,
+        commands::initialize_shortcuts,
         commands::models::get_available_models,
         commands::models::get_model_info,
         commands::models::download_model,

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -412,6 +412,19 @@ async initializeEnigo() : Promise<Result<null, string>> {
     else return { status: "error", error: e  as any };
 }
 },
+/**
+ * Initialize keyboard shortcuts.
+ * On macOS, this should be called after accessibility permissions are granted.
+ * This is idempotent - calling it multiple times is safe.
+ */
+async initializeShortcuts() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("initialize_shortcuts") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async getAvailableModels() : Promise<Result<ModelInfo[], string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_available_models") };

--- a/src/components/onboarding/AccessibilityOnboarding.tsx
+++ b/src/components/onboarding/AccessibilityOnboarding.tsx
@@ -68,12 +68,15 @@ const AccessibilityOnboarding: React.FC<AccessibilityOnboardingProps> = ({
           checkMicrophonePermission(),
         ]);
 
-        // If accessibility is granted, initialize Enigo
+        // If accessibility is granted, initialize Enigo and shortcuts
         if (accessibilityGranted) {
           try {
-            await commands.initializeEnigo();
+            await Promise.all([
+              commands.initializeEnigo(),
+              commands.initializeShortcuts(),
+            ]);
           } catch (e) {
-            console.warn("Failed to initialize Enigo:", e);
+            console.warn("Failed to initialize after permission grant:", e);
           }
         }
 
@@ -118,9 +121,12 @@ const AccessibilityOnboarding: React.FC<AccessibilityOnboardingProps> = ({
 
           if (accessibilityGranted && prev.accessibility !== "granted") {
             newState.accessibility = "granted";
-            // Initialize Enigo when accessibility is granted
-            commands.initializeEnigo().catch((e) => {
-              console.warn("Failed to initialize Enigo:", e);
+            // Initialize Enigo and shortcuts when accessibility is granted
+            Promise.all([
+              commands.initializeEnigo(),
+              commands.initializeShortcuts(),
+            ]).catch((e) => {
+              console.warn("Failed to initialize after permission grant:", e);
             });
           }
 


### PR DESCRIPTION
The 0.7.0 release introduced a bug on MacOS. Essentially on the first launch of the app, the user would give the app permissions for accessibility, but the keyboard driver was init before this. When they go to change shortcuts, the app would be in a broken state until a restart.

This PR fixes this issue, deferring the init until after the permissions are granted.

It also throws the user back to the onboarding if permissions are not granted