### PR TITLE
fix(nix): add missing dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,8 @@
           # Frontend
           nodejs
           bun
+          # Tauri CLI
+          cargo-tauri
           # Native deps
           pkg-config
           openssl
@@ -63,9 +65,18 @@
           webkitgtk_4_1
           gtk3
           glib
-          # Tauri CLI
-          cargo-tauri
+          libxtst
+          libevdev
+          llvmPackages.libclang
+          cmake
+          vulkan-headers
+          vulkan-loader
+          shaderc
+          libappindicator
         ];
+
+        LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+        LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath [ pkgs.libappindicator ]}";
 
         shellHook = ''
           echo "Handy development environment"


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [X] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [X] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Human Written Description

Hello! `bun run tauri dev` fails on NixOS

Running `bun run tauri dev` gives the following error:

```
➜ bun run tauri dev
$ vite

  ➜  Local:   http://localhost:1420/
     Running DevCommand (`cargo  run --no-default-features --color always --`)
        Info Watching /home/username/Temp/0-repo/Handy/src-tauri for changes...
   Compiling unicode-ident v1.0.20
   ...
   Compiling kuchikiki v0.8.8-speedreader
error: failed to run custom build command for `x11 v2.21.0`

Caused by:
  process didn't exit successfully: `/home/username/repo/Handy/src-tauri/target/debug/build/x11-f4a8ff296fc69456/build-script-build` (exit status: 101)

  --- stderr

  thread 'main' (454872) panicked at /home/username/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/x11-2.21.0/build.rs:42:14:
  called `Result::unwrap()` on an `Err` value:
  pkg-config exited with status code 1
  > PKG_CONFIG_ALLOW_SYSTEM_LIBS=1 PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --libs --cflags xtst 'xtst >= 1.2'

  The system library `xtst` required by crate `x11` was not found.
  The file `xtst.pc` needs to be installed and the PKG_CONFIG_PATH environment variable must contain its parent directory.
  PKG_CONFIG_PATH_FOR_TARGET contains the following:
      ...
      - /nix/store/x65ckn9l1nlgpqkq6ribgyjlkxbwd1mg-gmp-with-cxx-6.3.0-dev/lib/pkgconfig

  HINT: you may need to install a package such as xtst, xtst-dev or xtst-devel.

  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
error: script "tauri" exited with code 101
```

As suggested by the HINT, I tried adding `libxtst` to `buildInputs` but it still failed to build with a different error:

```
error: failed to run custom build command for `whisper-rs-sys v0.11.1`

Caused by:
  process didn't exit successfully: `/home/username/repo/Handy/src-tauri/target/debug/build/whisper-rs-sys-9d2ef0efc8fa90d6/build-script-build` (exit status: 101)

  --- stderr

  thread 'main' (464687) panicked at /home/username/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bindgen-0.69.5/lib.rs:622:31:
  Unable to find libclang: "couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so', 'libclang.so.*', 'libclang-*.so.*'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
error: script "tauri" exited with code 101
```

```
   Compiling whisper-rs-sys v0.11.1
error: failed to run custom build command for `whisper-rs-sys v0.11.1`

Caused by:
  process didn't exit successfully: `/home/username/repo/Handy/src-tauri/target/debug/build/whisper-rs-sys-9d2ef0efc8fa90d6/build-script-build` (exit status: 101)

  --- stderr

  thread 'main' (471403) panicked at /home/username/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bindgen-0.69.5/lib.rs:622:31:
  Unable to find libclang: "couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so', 'libclang.so.*', 'libclang-*.so.*'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
error: failed to run custom build command for `evdev-sys v0.2.6`

Caused by:
  process didn't exit successfully: `/home/username/repo/Handy/src-tauri/target/debug/build/evdev-sys-e78f54a7e5ff6081/build-script-build` (exit status: 101)
  --- stderr
  Couldn't find libevdev from pkgconfig (
  pkg-config exited with status code 1
  > PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --libs --cflags libevdev

  The system library `libevdev` required by crate `evdev-sys` was not found.
  The file `libevdev.pc` needs to be installed and the PKG_CONFIG_PATH environment variable must contain its parent directory.

  HINT: you may need to install a package such as libevdev, libevdev-dev or libevdev-devel.
  ), compiling it from source...

  thread 'main' (471354) panicked at /home/username/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/evdev-sys-0.2.6/build.rs:121:5:
  assertion failed: cmd.status()?.success()
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
error: script "tauri" exited with code 101
```

```
error: failed to run custom build command for `whisper-rs-sys v0.11.1`

Caused by:
  process didn't exit successfully: `/home/username/repo/Handy/src-tauri/target/debug/build/whisper-rs-sys-9d2ef0efc8fa90d6/build-script-build` (exit status: 101)
  --- stderr

  thread 'main' (474388) panicked at /home/username/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bindgen-0.69.5/lib.rs:622:31:
  Unable to find libclang: "couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so', 'libclang.so.*', 'libclang-*.so.*'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"
error: script "tauri" exited with code 101
```

This goes on and on until the current PR is in place. Thank you!

## AI Assistance

- [X] No AI was used in this PR
