### PR TITLE
docs: clarify Linux gtk-layer-shell runtime requirements

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -32,12 +32,13 @@ This guide covers how to set up the development environment and build Handy from
   ```bash
   # Ubuntu/Debian
   sudo apt update
-  sudo apt install build-essential libasound2-dev pkg-config libssl-dev libvulkan-dev vulkan-tools glslc libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf cmake
+  sudo apt install build-essential libasound2-dev pkg-config libssl-dev libvulkan-dev vulkan-tools glslc libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev libgtk-layer-shell0 libgtk-layer-shell-dev patchelf cmake
 
   # Fedora/RHEL
   sudo dnf groupinstall "Development Tools"
   sudo dnf install alsa-lib-devel pkgconf openssl-devel vulkan-devel \
     gtk3-devel webkit2gtk4.1-devel libappindicator-gtk3-devel librsvg2-devel \
+    gtk-layer-shell gtk-layer-shell-devel \
     cmake
 
   # Arch Linux

--- a/README.md
+++ b/README.md
@@ -105,6 +105,17 @@ Without these tools, Handy falls back to enigo which may have limited compatibil
 
 **Other Notes:**
 
+- **Runtime library dependency (`libgtk-layer-shell.so.0`)**:
+  - Handy links `gtk-layer-shell` on Linux. If startup fails with `error while loading shared libraries: libgtk-layer-shell.so.0`, install the runtime package for your distro:
+
+    | Distro        | Package to install         | Example command                              |
+    | ------------- | -------------------------- | -------------------------------------------- |
+    | Ubuntu/Debian | `libgtk-layer-shell0`      | `sudo apt install libgtk-layer-shell0`      |
+    | Fedora/RHEL   | `gtk-layer-shell`          | `sudo dnf install gtk-layer-shell`          |
+    | Arch Linux    | `gtk-layer-shell`          | `sudo pacman -S gtk-layer-shell`            |
+
+  - For building from source on Ubuntu/Debian, you may also need `libgtk-layer-shell-dev`.
+
 - The recording overlay is disabled by default on Linux (`Overlay Position: None`) because certain compositors treat it as the active window. When the overlay is visible it can steal focus, which prevents Handy from pasting back into the application that triggered transcription. If you enable the overlay anyway, be aware that clipboard-based pasting might fail or end up in the wrong window.
 - If you are having trouble with the app, running with the environment variable `WEBKIT_DISABLE_DMABUF_RENDERER=1` may help
 - You can manage global shortcuts outside of Handy and still control the app via signals. Sending `SIGUSR2` to the Handy process toggles recording on/off, which lets Wayland window managers or other hotkey daemons keep ownership of keybindings. Example (Sway):


### PR DESCRIPTION
## Summary
- document the Linux startup failure caused by missing `libgtk-layer-shell.so.0` in `README.md` with distro-specific runtime package names and install commands
- align `BUILD.md` Linux dependency instructions so Debian/Ubuntu and Fedora users install the required `gtk-layer-shell` runtime packages
- note the Ubuntu/Debian build-time dev package separately to reduce confusion between runtime and development dependencies

## Why
Handy links `gtk-layer-shell` on Linux, but current docs did not clearly call out the runtime package on all distros. Users can hit a hard loader failure before app startup, so this change provides direct, actionable install guidance.