### PR TITLE
feat: add hidden OCR template context for post-processing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
         if: contains(inputs.platform, 'ubuntu-24.04') && !contains(inputs.platform, 'arm')
         run: |
           sudo apt-get update
-          sudo apt-get install -y libappindicator3-dev librsvg2-dev patchelf libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev libgtk-layer-shell0 libgtk-layer-shell-dev \
+          sudo apt-get install -y libappindicator3-dev librsvg2-dev patchelf libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev libgtk-layer-shell0 libgtk-layer-shell-dev tesseract-ocr \
             libwebkit2gtk-4.1-0=2.44.0-2 \
             libwebkit2gtk-4.1-dev=2.44.0-2 \
             libjavascriptcoregtk-4.1-0=2.44.0-2 \
@@ -117,13 +117,13 @@ jobs:
         if: contains(inputs.platform, 'ubuntu-24.04-arm')
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev libgtk-layer-shell0 libgtk-layer-shell-dev xdg-utils
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev libgtk-layer-shell0 libgtk-layer-shell-dev xdg-utils tesseract-ocr
 
       - name: install dependencies (ubuntu 22.04)
         if: contains(inputs.platform, 'ubuntu-22.04') && !contains(inputs.platform, 'arm')
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev libgtk-layer-shell0 libgtk-layer-shell-dev
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev libgtk-layer-shell0 libgtk-layer-shell-dev tesseract-ocr
 
       - name: Verify gtk-layer-shell runtime dependency (Ubuntu)
         if: contains(inputs.platform, 'ubuntu')

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,31 @@
+# Handy Architecture Notes
+
+## OCR Context Providers
+
+The `${OCR}` / `${ocr}` prompt template variable is resolved in `src-tauri/src/actions.rs` through platform-specific OCR providers.
+
+- macOS: `src-tauri/src/macos_ocr.rs` and Swift bridge files under `src-tauri/swift/`.
+- Windows: `src-tauri/src/windows_ocr.rs` using Windows Media OCR APIs.
+- Linux: `src-tauri/src/linux_ocr.rs` using backend selection at startup:
+  - X11 session: X11 active-window capture + `tesseract` CLI OCR.
+  - Wayland session: desktop screenshot CLI fallback (`gnome-screenshot` or `spectacle`) + `tesseract`.
+
+## Linux OCR Flow
+
+1. On app startup (`initialize_core_logic`), Linux OCR detects:
+   - Session type (`XDG_SESSION_TYPE`)
+   - Desktop environment (`XDG_CURRENT_DESKTOP` / `DESKTOP_SESSION`)
+   - Available Wayland screenshot tools (`gnome-screenshot`, `spectacle`)
+2. Capture strategy is selected once and cached:
+   - X11/unknown session -> X11 capture path.
+   - Wayland -> screenshot command fallback path (desktop-preferred tool first).
+3. Capture pipeline:
+   - X11 path: resolve active window (`_NET_ACTIVE_WINDOW`), capture via `XGetImage`, encode temporary PPM.
+   - Wayland path: execute screenshot tool to a temporary PNG.
+4. Execute `tesseract <image> stdout --psm 6`.
+5. Return OCR text to `actions.rs`, where OCR text is truncated to `MAX_OCR_TEXT_CHARS` before prompt expansion.
+
+## Packaging and Build Requirements
+
+- Linux build workflow installs `tesseract-ocr` in `.github/workflows/build.yml`.
+- Debian bundle metadata includes `tesseract-ocr` dependency in `src-tauri/tauri.conf.json`.

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,0 +1,62 @@
+# Dev Log
+
+## 2026-02-21
+
+### Summary
+Added Linux OCR support for `${OCR}` / `${ocr}` prompt variables using Tesseract.
+
+### What Changed and Why
+- Added `src-tauri/src/linux_ocr.rs`.
+  - Captures active window pixels from X11 and performs OCR via `tesseract`.
+  - Adds fallback to root window capture when active window capture fails.
+  - Returns OCR text to the existing prompt-template expansion pipeline.
+- Updated `src-tauri/src/actions.rs`.
+  - Wired Linux into `fetch_ocr_template_value`.
+  - Kept existing macOS/Windows behavior unchanged.
+  - Fixed unit tests to call the current prompt-template helper function.
+- Updated `src-tauri/src/lib.rs` and `src-tauri/Cargo.toml`.
+  - Registered Linux OCR module.
+  - Added Linux `x11` crate dependency.
+- Updated Linux build/package config.
+  - `.github/workflows/build.yml`: install `tesseract-ocr` on Ubuntu build jobs.
+  - `src-tauri/tauri.conf.json`: add Debian dependency on `tesseract-ocr`.
+
+### Verification
+- `bun run build` passed on Ubuntu 24.04 ARM64 VM.
+- `cd src-tauri && cargo test` passed (`42 passed, 0 failed`).
+- `bun run tauri build --bundles appimage,deb,rpm --target aarch64-unknown-linux-gnu --config '{"bundle":{"createUpdaterArtifacts":false}}'` passed.
+
+### Gotchas / Follow-up
+- Linux OCR implementation currently targets X11 capture path.
+  - Wayland-only sessions may not provide active-window capture through this path.
+- Tauri still emits pre-existing bundler warnings about `__TAURI_BUNDLE_TYPE`; no functional change made for that in this task.
+
+### Follow-up Update
+Implemented Linux OCR backend selection for Wayland fallback screenshot tools.
+
+### What Changed and Why
+- Updated `src-tauri/src/linux_ocr.rs`.
+  - Added startup-time backend detection (`XDG_SESSION_TYPE`, desktop environment, command availability).
+  - Added cached capture strategy selection:
+    - X11/unknown session -> existing X11 capture path.
+    - Wayland session -> `gnome-screenshot` or `spectacle` fallback.
+  - Added Wayland screenshot capture execution:
+    - GNOME: `gnome-screenshot -f <temp.png>`
+    - KDE fallback: `spectacle -b -n -o <temp.png>`
+  - Added startup warning messages when Wayland has no supported screenshot command.
+  - Added unit tests for session parsing, desktop parsing, and Wayland tool selection logic.
+- Updated `src-tauri/src/lib.rs`.
+  - Initialize Linux OCR backend strategy during app startup (`initialize_core_logic`).
+
+### Verification
+- Local:
+  - `bun run build` passed.
+  - `cd src-tauri && cargo test` blocked by existing macOS Swift Apple Intelligence toolchain issue (`FoundationModelsMacros` unavailable).
+- Ubuntu VM:
+  - `cd /home/evren/code/Handy/src-tauri && cargo test` passed (`46 passed, 0 failed`).
+
+### Gotchas / Follow-up
+- Wayland fallback currently relies on desktop screenshot CLI tools rather than xdg-desktop-portal.
+  - This is intentionally pragmatic and should be treated as an interim compatibility path.
+- GNOME exposes screenshot capabilities over D-Bus (`org.gnome.Shell.Screenshot`), including window-specific methods.
+  - A future Linux improvement could replace CLI screenshot calls with compositor API integration for better active-window behavior and fewer external tool assumptions.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2496,6 +2496,7 @@ dependencies = [
  "transcribe-rs",
  "vad-rs",
  "windows 0.61.3",
+ "x11",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -109,6 +109,7 @@ tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2.
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk-layer-shell = { version = "0.8", features = ["v0_6"] }
 gtk = "0.18"
+x11 = "2.21.0"
 
 [patch.crates-io]
 tauri-runtime = { git = "https://github.com/cjpais/tauri.git", branch = "handy-2.9.1" }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -88,10 +88,18 @@ tauri-plugin-updater = "2.9.0"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.61.3", features = [
+  "Foundation",
+  "Graphics_Imaging",
+  "Media_Ocr",
+  "Security_Cryptography",
+  "Storage_Streams",
   "Win32_Media_Audio_Endpoints",
+  "Win32_Storage_Xps",
+  "Win32_System_Com",
   "Win32_System_Com_StructuredStorage",
   "Win32_System_Variant",
   "Win32_Foundation",
+  "Win32_Graphics_Gdi",
   "Win32_UI_WindowsAndMessaging",
 ] }
 

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,10 +1,122 @@
 fn main() {
+    #[cfg(target_os = "macos")]
+    build_macos_ocr_bridge();
+
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
     build_apple_intelligence_bridge();
 
     generate_tray_translations();
 
     tauri_build::build()
+}
+
+#[cfg(target_os = "macos")]
+fn build_macos_ocr_bridge() {
+    use std::env;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    const SWIFT_FILE: &str = "swift/macos_ocr.swift";
+    const BRIDGE_HEADER: &str = "swift/macos_ocr_bridge.h";
+    const DEPLOYMENT_TARGET: &str = "10.13";
+
+    println!("cargo:rerun-if-changed={SWIFT_FILE}");
+    println!("cargo:rerun-if-changed={BRIDGE_HEADER}");
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
+    let object_path = out_dir.join("macos_ocr.o");
+    let static_lib_path = out_dir.join("libmacos_ocr.a");
+
+    if !Path::new(SWIFT_FILE).exists() {
+        panic!("Source file {} is missing!", SWIFT_FILE);
+    }
+
+    let sdk_path = String::from_utf8(
+        Command::new("xcrun")
+            .args(["--sdk", "macosx", "--show-sdk-path"])
+            .output()
+            .expect("Failed to locate macOS SDK")
+            .stdout,
+    )
+    .expect("SDK path is not valid UTF-8")
+    .trim()
+    .to_string();
+
+    let swiftc_path = String::from_utf8(
+        Command::new("xcrun")
+            .args(["--find", "swiftc"])
+            .output()
+            .expect("Failed to locate swiftc")
+            .stdout,
+    )
+    .expect("swiftc path is not valid UTF-8")
+    .trim()
+    .to_string();
+
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "arm64".to_string());
+    let swift_target = format!("{target_arch}-apple-macosx{DEPLOYMENT_TARGET}");
+
+    let toolchain_swift_lib = Path::new(&swiftc_path)
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|root| root.join("lib/swift/macosx"))
+        .expect("Unable to determine Swift toolchain lib directory");
+    let sdk_swift_lib = Path::new(&sdk_path).join("usr/lib/swift");
+
+    let status = Command::new("xcrun")
+        .args([
+            "swiftc",
+            "-target",
+            &swift_target,
+            "-sdk",
+            &sdk_path,
+            "-O",
+            "-import-objc-header",
+            BRIDGE_HEADER,
+            "-c",
+            SWIFT_FILE,
+            "-o",
+            object_path
+                .to_str()
+                .expect("Failed to convert object path to string"),
+        ])
+        .status()
+        .expect("Failed to invoke swiftc for macOS OCR bridge");
+
+    if !status.success() {
+        panic!("swiftc failed to compile {SWIFT_FILE}");
+    }
+
+    let status = Command::new("libtool")
+        .args([
+            "-static",
+            "-o",
+            static_lib_path
+                .to_str()
+                .expect("Failed to convert static lib path to string"),
+            object_path
+                .to_str()
+                .expect("Failed to convert object path to string"),
+        ])
+        .status()
+        .expect("Failed to create static library for macOS OCR bridge");
+
+    if !status.success() {
+        panic!("libtool failed for macOS OCR bridge");
+    }
+
+    println!("cargo:rustc-link-search=native={}", out_dir.display());
+    println!("cargo:rustc-link-lib=static=macos_ocr");
+    println!(
+        "cargo:rustc-link-search=native={}",
+        toolchain_swift_lib.display()
+    );
+    println!("cargo:rustc-link-search=native={}", sdk_swift_lib.display());
+    println!("cargo:rustc-link-lib=framework=Foundation");
+    println!("cargo:rustc-link-lib=framework=AppKit");
+    println!("cargo:rustc-link-lib=framework=CoreGraphics");
+    println!("cargo:rustc-link-lib=framework=Vision");
+    println!("cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift");
 }
 
 /// Generate tray menu translations from frontend locale files.

--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -1,6 +1,8 @@
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 use crate::apple_intelligence;
 use crate::audio_feedback::{play_feedback_sound, play_feedback_sound_blocking, SoundType};
+#[cfg(target_os = "macos")]
+use crate::macos_ocr;
 use crate::managers::audio::AudioRecordingManager;
 use crate::managers::history::HistoryManager;
 use crate::managers::transcription::TranscriptionManager;
@@ -15,6 +17,8 @@ use ferrous_opencc::{config::BuiltinConfig, OpenCC};
 use log::{debug, error, warn};
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
+#[cfg(target_os = "macos")]
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 use tauri::AppHandle;
@@ -44,6 +48,13 @@ struct TranscribeAction {
 
 /// Field name for structured output JSON schema
 const TRANSCRIPTION_FIELD: &str = "transcription";
+const OUTPUT_TEMPLATE_VARIABLE: &str = "${output}";
+const OCR_TEMPLATE_VARIABLE_UPPER: &str = "${OCR}";
+const OCR_TEMPLATE_VARIABLE_LOWER: &str = "${ocr}";
+const MAX_OCR_TEXT_CHARS: usize = 8_000;
+
+#[cfg(target_os = "macos")]
+static SCREEN_CAPTURE_PERMISSION_REQUESTED: AtomicBool = AtomicBool::new(false);
 
 /// Strip invisible Unicode characters that some LLMs may insert
 fn strip_invisible_chars(s: &str) -> String {
@@ -53,7 +64,132 @@ fn strip_invisible_chars(s: &str) -> String {
 /// Build a system prompt from the user's prompt template.
 /// Removes `${output}` placeholder since the transcription is sent as the user message.
 fn build_system_prompt(prompt_template: &str) -> String {
-    prompt_template.replace("${output}", "").trim().to_string()
+    prompt_template
+        .replace(OUTPUT_TEMPLATE_VARIABLE, "")
+        .trim()
+        .to_string()
+}
+
+fn prompt_uses_ocr_variable(prompt_template: &str) -> bool {
+    prompt_template.contains(OCR_TEMPLATE_VARIABLE_UPPER)
+        || prompt_template.contains(OCR_TEMPLATE_VARIABLE_LOWER)
+}
+
+fn truncate_to_char_limit(text: &str, max_chars: usize) -> String {
+    text.chars().take(max_chars).collect()
+}
+
+fn replace_ocr_template_variables(prompt_template: &str, ocr_text: &str) -> String {
+    let with_upper = prompt_template.replace(OCR_TEMPLATE_VARIABLE_UPPER, ocr_text);
+    with_upper.replace(OCR_TEMPLATE_VARIABLE_LOWER, ocr_text)
+}
+
+fn expand_prompt_template(prompt_template: &str, transcription: &str, ocr_text: &str) -> String {
+    let with_output = prompt_template.replace(OUTPUT_TEMPLATE_VARIABLE, transcription);
+    replace_ocr_template_variables(&with_output, ocr_text)
+}
+
+fn resolve_ocr_template_value<F>(
+    prompt_template: &str,
+    experimental_enabled: bool,
+    fetch_ocr_text: F,
+) -> String
+where
+    F: FnOnce() -> String,
+{
+    if !prompt_uses_ocr_variable(prompt_template) {
+        return String::new();
+    }
+
+    if !experimental_enabled {
+        debug!(
+            "Prompt contains OCR template variable but experimental features are disabled; injecting empty OCR value"
+        );
+        return String::new();
+    }
+
+    fetch_ocr_text()
+}
+
+#[cfg(target_os = "macos")]
+fn fetch_ocr_template_value() -> String {
+    if !macos_ocr::has_screen_capture_access() {
+        if SCREEN_CAPTURE_PERMISSION_REQUESTED.swap(true, Ordering::Relaxed) {
+            debug!(
+                "Screen capture permission missing and request already attempted once; injecting empty OCR value"
+            );
+            return String::new();
+        }
+
+        debug!("Screen capture permission missing; requesting access for OCR");
+        if !macos_ocr::request_screen_capture_access() {
+            debug!("Screen capture permission request denied; injecting empty OCR value");
+            return String::new();
+        }
+    }
+
+    let ocr_start = Instant::now();
+    match macos_ocr::capture_frontmost_window_ocr_text() {
+        Ok(text) => {
+            debug!(
+                "Captured OCR context in {:?} ({} chars before truncation)",
+                ocr_start.elapsed(),
+                text.chars().count()
+            );
+            text
+        }
+        Err(err) => {
+            error!("Failed to capture OCR context: {}", err);
+            String::new()
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn fetch_ocr_template_value() -> String {
+    debug!("OCR template variable is only supported on macOS; injecting empty OCR value");
+    String::new()
+}
+
+fn build_prompt_templates_with_fetcher<F>(
+    experimental_enabled: bool,
+    prompt_template: &str,
+    transcription: &str,
+    fetch_ocr_text: F,
+) -> (String, String)
+where
+    F: FnOnce() -> String,
+{
+    let ocr_text =
+        resolve_ocr_template_value(prompt_template, experimental_enabled, fetch_ocr_text);
+    let ocr_char_count = ocr_text.chars().count();
+    let truncated_ocr_text = truncate_to_char_limit(&ocr_text, MAX_OCR_TEXT_CHARS);
+    let truncated_char_count = truncated_ocr_text.chars().count();
+
+    if truncated_char_count < ocr_char_count {
+        debug!(
+            "Truncated OCR context from {} to {} chars",
+            ocr_char_count, truncated_char_count
+        );
+    }
+
+    let prompt_with_ocr = replace_ocr_template_variables(prompt_template, &truncated_ocr_text);
+    let processed_prompt = expand_prompt_template(prompt_template, transcription, &truncated_ocr_text);
+    let system_prompt = build_system_prompt(&prompt_with_ocr);
+    (processed_prompt, system_prompt)
+}
+
+fn build_prompt_templates(
+    settings: &AppSettings,
+    prompt_template: &str,
+    transcription: &str,
+) -> (String, String) {
+    build_prompt_templates_with_fetcher(
+        settings.experimental_enabled,
+        prompt_template,
+        transcription,
+        fetch_ocr_template_value,
+    )
 }
 
 async fn post_process_transcription(settings: &AppSettings, transcription: &str) -> Option<String> {
@@ -112,6 +248,8 @@ async fn post_process_transcription(settings: &AppSettings, transcription: &str)
         provider.id, model
     );
 
+    let (processed_prompt, system_prompt) = build_prompt_templates(settings, &prompt, transcription);
+    debug!("Processed prompt length: {} chars", processed_prompt.len());
     let api_key = settings
         .post_process_api_keys
         .get(&provider.id)
@@ -120,8 +258,6 @@ async fn post_process_transcription(settings: &AppSettings, transcription: &str)
 
     if provider.supports_structured_output {
         debug!("Using structured outputs for provider '{}'", provider.id);
-
-        let system_prompt = build_system_prompt(&prompt);
         let user_content = transcription.to_string();
 
         // Handle Apple Intelligence separately since it uses native Swift APIs
@@ -233,10 +369,7 @@ async fn post_process_transcription(settings: &AppSettings, transcription: &str)
         }
     }
 
-    // Legacy mode: Replace ${output} variable in the prompt with the actual text
-    let processed_prompt = prompt.replace("${output}", transcription);
-    debug!("Processed prompt length: {} chars", processed_prompt.len());
-
+    // Legacy mode uses the prompt with resolved OCR/output template variables.
     match crate::llm_client::send_chat_completion(&provider, api_key, &model, processed_prompt)
         .await
     {
@@ -590,3 +723,62 @@ pub static ACTION_MAP: Lazy<HashMap<String, Arc<dyn ShortcutAction>>> = Lazy::ne
     );
     map
 });
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    #[test]
+    fn prompt_uses_ocr_variable_detects_supported_tokens() {
+        assert!(prompt_uses_ocr_variable("Use ${OCR} here"));
+        assert!(prompt_uses_ocr_variable("Use ${ocr} here"));
+        assert!(!prompt_uses_ocr_variable("No OCR variable"));
+    }
+
+    #[test]
+    fn resolve_ocr_template_value_skips_fetch_without_ocr_token() {
+        let called = Cell::new(false);
+        let value = resolve_ocr_template_value("Only ${output}", true, || {
+            called.set(true);
+            "ocr".to_string()
+        });
+
+        assert!(value.is_empty());
+        assert!(!called.get());
+    }
+
+    #[test]
+    fn resolve_ocr_template_value_skips_fetch_when_experimental_disabled() {
+        let called = Cell::new(false);
+        let value = resolve_ocr_template_value("Use ${OCR}", false, || {
+            called.set(true);
+            "ocr".to_string()
+        });
+
+        assert!(value.is_empty());
+        assert!(!called.get());
+    }
+
+    #[test]
+    fn build_processed_prompt_replaces_output_and_ocr_tokens() {
+        let prompt = "Transcript: ${output}\nContext:\n${OCR}\nAgain:\n${ocr}";
+        let result = build_processed_prompt_with_fetcher(true, prompt, "hello", || {
+            "window text".to_string()
+        });
+
+        assert_eq!(
+            result,
+            "Transcript: hello\nContext:\nwindow text\nAgain:\nwindow text"
+        );
+    }
+
+    #[test]
+    fn build_processed_prompt_truncates_ocr_text_to_char_limit() {
+        let long_text = "a".repeat(MAX_OCR_TEXT_CHARS + 42);
+        let result = build_processed_prompt_with_fetcher(true, "${OCR}", "ignored", || long_text);
+
+        assert_eq!(result.len(), MAX_OCR_TEXT_CHARS);
+        assert_eq!(result, "a".repeat(MAX_OCR_TEXT_CHARS));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,8 @@ mod transcription_coordinator;
 mod tray;
 mod tray_i18n;
 mod utils;
+#[cfg(target_os = "windows")]
+mod windows_ocr;
 
 pub use cli::CliArgs;
 use specta_typescript::{BigIntExportBehavior, Typescript};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,8 @@ mod clipboard;
 mod commands;
 mod helpers;
 mod input;
+#[cfg(target_os = "linux")]
+mod linux_ocr;
 mod llm_client;
 #[cfg(target_os = "macos")]
 mod macos_ocr;
@@ -109,6 +111,9 @@ fn show_main_window(app: &AppHandle) {
 }
 
 fn initialize_core_logic(app_handle: &AppHandle) {
+    #[cfg(target_os = "linux")]
+    linux_ocr::initialize_capture_backend();
+
     // Note: Enigo (keyboard/mouse simulation) is NOT initialized here.
     // The frontend is responsible for calling the `initialize_enigo` command
     // after onboarding completes. This avoids triggering permission dialogs

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,8 @@ mod commands;
 mod helpers;
 mod input;
 mod llm_client;
+#[cfg(target_os = "macos")]
+mod macos_ocr;
 mod managers;
 mod overlay;
 mod settings;

--- a/src-tauri/src/linux_ocr.rs
+++ b/src-tauri/src/linux_ocr.rs
@@ -1,0 +1,683 @@
+use std::env;
+use std::fs;
+use std::os::raw::{c_int, c_long, c_uchar, c_ulong, c_void};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::ptr;
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+use x11::xlib;
+
+use log::{info, warn};
+
+const MIN_WINDOW_DIMENSION: i32 = 32;
+const PPM_RGB_CHANNELS: usize = 3;
+const PPM_MAX_COLOR_VALUE: u16 = 255;
+const ACTIVE_WINDOW_PROPERTY_NAME: &str = "_NET_ACTIVE_WINDOW";
+const ACTIVE_WINDOW_PROPERTY_ITEMS: c_long = 1;
+const TESSERACT_EXECUTABLE: &str = "tesseract";
+const TESSERACT_OUTPUT_TARGET: &str = "stdout";
+const TESSERACT_PAGE_SEGMENT_MODE: &str = "6";
+const XDG_SESSION_TYPE: &str = "XDG_SESSION_TYPE";
+const XDG_CURRENT_DESKTOP: &str = "XDG_CURRENT_DESKTOP";
+const DESKTOP_SESSION: &str = "DESKTOP_SESSION";
+const SESSION_TYPE_X11: &str = "x11";
+const SESSION_TYPE_WAYLAND: &str = "wayland";
+const GNOME_SCREENSHOT_EXECUTABLE: &str = "gnome-screenshot";
+const GNOME_SCREENSHOT_OUTPUT_FLAG: &str = "-f";
+const SPECTACLE_EXECUTABLE: &str = "spectacle";
+const SPECTACLE_BACKGROUND_FLAG: &str = "-b";
+const SPECTACLE_NO_NOTIFY_FLAG: &str = "-n";
+const SPECTACLE_OUTPUT_FLAG: &str = "-o";
+
+static CAPTURE_BACKEND: OnceLock<CaptureBackendState> = OnceLock::new();
+
+pub fn capture_frontmost_window_ocr_text() -> Result<String, String> {
+    let backend = capture_backend();
+    match backend.strategy {
+        CaptureStrategy::X11 => capture_x11_ocr_text(),
+        CaptureStrategy::Wayland(WaylandScreenshotTool::GnomeScreenshot) => {
+            capture_wayland_ocr_text(WaylandScreenshotTool::GnomeScreenshot)
+        }
+        CaptureStrategy::Wayland(WaylandScreenshotTool::Spectacle) => {
+            capture_wayland_ocr_text(WaylandScreenshotTool::Spectacle)
+        }
+        CaptureStrategy::UnsupportedWayland => Err(missing_wayland_tool_message(backend.desktop)),
+    }
+}
+
+pub fn initialize_capture_backend() {
+    let backend = capture_backend();
+    log_capture_backend(backend);
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SessionType {
+    X11,
+    Wayland,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DesktopEnvironment {
+    Gnome,
+    Kde,
+    Other,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum WaylandScreenshotTool {
+    GnomeScreenshot,
+    Spectacle,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CaptureStrategy {
+    X11,
+    Wayland(WaylandScreenshotTool),
+    UnsupportedWayland,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct CaptureBackendState {
+    session: SessionType,
+    desktop: DesktopEnvironment,
+    strategy: CaptureStrategy,
+}
+
+fn capture_backend() -> &'static CaptureBackendState {
+    CAPTURE_BACKEND.get_or_init(detect_capture_backend)
+}
+
+fn detect_capture_backend() -> CaptureBackendState {
+    let session = detect_session_type();
+    let desktop = detect_desktop_environment();
+    let has_gnome_screenshot = command_exists(GNOME_SCREENSHOT_EXECUTABLE);
+    let has_spectacle = command_exists(SPECTACLE_EXECUTABLE);
+
+    let strategy = match session {
+        SessionType::X11 | SessionType::Unknown => CaptureStrategy::X11,
+        SessionType::Wayland => {
+            match select_wayland_tool(desktop, has_gnome_screenshot, has_spectacle) {
+                Some(tool) => CaptureStrategy::Wayland(tool),
+                None => CaptureStrategy::UnsupportedWayland,
+            }
+        }
+    };
+
+    CaptureBackendState {
+        session,
+        desktop,
+        strategy,
+    }
+}
+
+fn log_capture_backend(backend: &CaptureBackendState) {
+    match backend.strategy {
+        CaptureStrategy::X11 => {
+            info!(
+                "Linux OCR capture backend initialized: X11 (session={:?}, desktop={:?})",
+                backend.session, backend.desktop
+            );
+        }
+        CaptureStrategy::Wayland(WaylandScreenshotTool::GnomeScreenshot) => {
+            info!(
+                "Linux OCR capture backend initialized: Wayland + gnome-screenshot (session={:?}, desktop={:?})",
+                backend.session, backend.desktop
+            );
+        }
+        CaptureStrategy::Wayland(WaylandScreenshotTool::Spectacle) => {
+            info!(
+                "Linux OCR capture backend initialized: Wayland + spectacle (session={:?}, desktop={:?})",
+                backend.session, backend.desktop
+            );
+        }
+        CaptureStrategy::UnsupportedWayland => {
+            warn!("{}", missing_wayland_tool_message(backend.desktop));
+        }
+    }
+}
+
+fn missing_wayland_tool_message(desktop: DesktopEnvironment) -> String {
+    match desktop {
+        DesktopEnvironment::Gnome => "Wayland OCR capture is unavailable. Install `gnome-screenshot` (preferred on GNOME) or `spectacle`.".to_string(),
+        DesktopEnvironment::Kde => "Wayland OCR capture is unavailable. Install `spectacle` (preferred on KDE) or `gnome-screenshot`.".to_string(),
+        DesktopEnvironment::Other => "Wayland OCR capture is unavailable. Install `gnome-screenshot` or `spectacle`.".to_string(),
+    }
+}
+
+fn detect_session_type() -> SessionType {
+    let session = env::var(XDG_SESSION_TYPE)
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase();
+    parse_session_type(if session.is_empty() {
+        None
+    } else {
+        Some(session.as_str())
+    })
+}
+
+fn parse_session_type(session_type: Option<&str>) -> SessionType {
+    match session_type {
+        Some(value) if value.eq_ignore_ascii_case(SESSION_TYPE_X11) => SessionType::X11,
+        Some(value) if value.eq_ignore_ascii_case(SESSION_TYPE_WAYLAND) => SessionType::Wayland,
+        _ => SessionType::Unknown,
+    }
+}
+
+fn detect_desktop_environment() -> DesktopEnvironment {
+    let current_desktop = env::var(XDG_CURRENT_DESKTOP).ok();
+    let desktop_session = env::var(DESKTOP_SESSION).ok();
+    parse_desktop_environment(current_desktop.as_deref(), desktop_session.as_deref())
+}
+
+fn parse_desktop_environment(
+    current_desktop: Option<&str>,
+    desktop_session: Option<&str>,
+) -> DesktopEnvironment {
+    let desktop = current_desktop
+        .or(desktop_session)
+        .unwrap_or_default()
+        .to_ascii_uppercase();
+
+    if desktop.contains("KDE") || desktop.contains("PLASMA") {
+        DesktopEnvironment::Kde
+    } else if desktop.contains("GNOME") || desktop.contains("UBUNTU") {
+        DesktopEnvironment::Gnome
+    } else {
+        DesktopEnvironment::Other
+    }
+}
+
+fn select_wayland_tool(
+    desktop: DesktopEnvironment,
+    has_gnome_screenshot: bool,
+    has_spectacle: bool,
+) -> Option<WaylandScreenshotTool> {
+    match desktop {
+        DesktopEnvironment::Kde => {
+            if has_spectacle {
+                Some(WaylandScreenshotTool::Spectacle)
+            } else if has_gnome_screenshot {
+                Some(WaylandScreenshotTool::GnomeScreenshot)
+            } else {
+                None
+            }
+        }
+        DesktopEnvironment::Gnome | DesktopEnvironment::Other => {
+            if has_gnome_screenshot {
+                Some(WaylandScreenshotTool::GnomeScreenshot)
+            } else if has_spectacle {
+                Some(WaylandScreenshotTool::Spectacle)
+            } else {
+                None
+            }
+        }
+    }
+}
+
+fn command_exists(command: &str) -> bool {
+    if command.contains('/') {
+        return is_executable(Path::new(command));
+    }
+
+    env::var_os("PATH")
+        .map(|path_var| {
+            env::split_paths(&path_var).any(|directory| is_executable(&directory.join(command)))
+        })
+        .unwrap_or(false)
+}
+
+fn is_executable(path: &Path) -> bool {
+    fs::metadata(path)
+        .map(|metadata| metadata.is_file() && (metadata.permissions().mode() & 0o111 != 0))
+        .unwrap_or(false)
+}
+
+fn capture_x11_ocr_text() -> Result<String, String> {
+    let display = XDisplayHandle::open()?;
+    let root_window = display.root_window();
+    let target_window = display.active_window().unwrap_or(root_window);
+
+    let (rgb_pixels, width, height) = match display.capture_window_rgb(target_window) {
+        Ok(result) => result,
+        Err(active_error) if target_window != root_window => {
+            display.capture_window_rgb(root_window).map_err(|root_error| {
+                format!(
+                    "Failed to capture active window ({active_error}); fallback root capture failed ({root_error})"
+                )
+            })?
+        }
+        Err(error) => return Err(error),
+    };
+
+    let ppm_file = TempPpmFile::create(width, height, &rgb_pixels)?;
+    run_tesseract(ppm_file.path())
+}
+
+fn capture_wayland_ocr_text(tool: WaylandScreenshotTool) -> Result<String, String> {
+    let screenshot_file = TempImageFile::create("png")?;
+    run_wayland_screenshot(tool, screenshot_file.path())?;
+    run_tesseract(screenshot_file.path())
+}
+
+fn run_wayland_screenshot(tool: WaylandScreenshotTool, output_path: &Path) -> Result<(), String> {
+    let output = match tool {
+        WaylandScreenshotTool::GnomeScreenshot => Command::new(GNOME_SCREENSHOT_EXECUTABLE)
+            .arg(GNOME_SCREENSHOT_OUTPUT_FLAG)
+            .arg(output_path)
+            .output()
+            .map_err(|error| {
+                format!("Failed to launch {}: {error}", GNOME_SCREENSHOT_EXECUTABLE)
+            })?,
+        WaylandScreenshotTool::Spectacle => Command::new(SPECTACLE_EXECUTABLE)
+            .arg(SPECTACLE_BACKGROUND_FLAG)
+            .arg(SPECTACLE_NO_NOTIFY_FLAG)
+            .arg(SPECTACLE_OUTPUT_FLAG)
+            .arg(output_path)
+            .output()
+            .map_err(|error| format!("Failed to launch {}: {error}", SPECTACLE_EXECUTABLE))?,
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let tool_name = match tool {
+            WaylandScreenshotTool::GnomeScreenshot => GNOME_SCREENSHOT_EXECUTABLE,
+            WaylandScreenshotTool::Spectacle => SPECTACLE_EXECUTABLE,
+        };
+
+        if stderr.trim().is_empty() {
+            return Err(format!(
+                "{} exited with status {}.",
+                tool_name, output.status
+            ));
+        }
+
+        return Err(format!("{} failed: {}", tool_name, stderr.trim()));
+    }
+
+    let metadata = fs::metadata(output_path).map_err(|error| {
+        format!(
+            "Screenshot command did not produce output file '{}': {error}",
+            output_path.display()
+        )
+    })?;
+
+    if metadata.len() == 0 {
+        return Err(format!(
+            "Screenshot command produced an empty file: '{}'.",
+            output_path.display()
+        ));
+    }
+
+    Ok(())
+}
+
+struct XDisplayHandle {
+    display: *mut xlib::Display,
+}
+
+impl XDisplayHandle {
+    fn open() -> Result<Self, String> {
+        let display = unsafe { xlib::XOpenDisplay(ptr::null()) };
+        if display.is_null() {
+            return Err(
+                "Could not connect to an X11 display. OCR is currently available on Linux X11 sessions."
+                    .to_string(),
+            );
+        }
+
+        Ok(Self { display })
+    }
+
+    fn root_window(&self) -> xlib::Window {
+        unsafe { xlib::XDefaultRootWindow(self.display) }
+    }
+
+    fn active_window(&self) -> Result<xlib::Window, String> {
+        let property_name = std::ffi::CString::new(ACTIVE_WINDOW_PROPERTY_NAME)
+            .map_err(|_| "Invalid active window property name".to_string())?;
+
+        let active_window_atom =
+            unsafe { xlib::XInternAtom(self.display, property_name.as_ptr(), xlib::False) };
+        if active_window_atom == 0 {
+            return Err("Failed to resolve _NET_ACTIVE_WINDOW atom.".to_string());
+        }
+
+        let mut actual_type: c_ulong = 0;
+        let mut actual_format: c_int = 0;
+        let mut item_count: c_ulong = 0;
+        let mut bytes_after: c_ulong = 0;
+        let mut property_data: *mut c_uchar = ptr::null_mut();
+
+        let status = unsafe {
+            xlib::XGetWindowProperty(
+                self.display,
+                self.root_window(),
+                active_window_atom,
+                0,
+                ACTIVE_WINDOW_PROPERTY_ITEMS,
+                xlib::False,
+                xlib::AnyPropertyType as c_ulong,
+                &mut actual_type,
+                &mut actual_format,
+                &mut item_count,
+                &mut bytes_after,
+                &mut property_data,
+            )
+        };
+
+        if status != xlib::Success as c_int {
+            return Err("Failed to read active window property from X11.".to_string());
+        }
+
+        if property_data.is_null() || item_count == 0 {
+            return Err("X11 active window property returned no window.".to_string());
+        }
+
+        let window = unsafe { *(property_data.cast::<c_ulong>()) };
+        unsafe {
+            xlib::XFree(property_data.cast::<c_void>());
+        }
+
+        if actual_type != xlib::XA_WINDOW || actual_format != 32 || window == 0 {
+            return Err("X11 active window property has an unexpected format.".to_string());
+        }
+
+        Ok(window)
+    }
+
+    fn capture_window_rgb(&self, window: xlib::Window) -> Result<(Vec<u8>, i32, i32), String> {
+        let mut attributes: xlib::XWindowAttributes = unsafe { std::mem::zeroed() };
+        let attributes_status =
+            unsafe { xlib::XGetWindowAttributes(self.display, window, &mut attributes) };
+        if attributes_status == 0 {
+            return Err("Failed to read X11 window attributes.".to_string());
+        }
+
+        if attributes.map_state != xlib::IsViewable {
+            return Err("Target X11 window is not viewable.".to_string());
+        }
+
+        if attributes.width < MIN_WINDOW_DIMENSION || attributes.height < MIN_WINDOW_DIMENSION {
+            return Err("Foreground window is too small for OCR.".to_string());
+        }
+
+        let image = unsafe {
+            xlib::XGetImage(
+                self.display,
+                window,
+                0,
+                0,
+                attributes.width as u32,
+                attributes.height as u32,
+                xlib::XAllPlanes(),
+                xlib::ZPixmap,
+            )
+        };
+
+        if image.is_null() {
+            return Err("Failed to capture X11 window pixels.".to_string());
+        }
+
+        let pixels_result = extract_rgb_pixels(image, attributes.width, attributes.height);
+        unsafe {
+            xlib::XDestroyImage(image);
+        }
+        let pixels = pixels_result?;
+
+        Ok((pixels, attributes.width, attributes.height))
+    }
+}
+
+impl Drop for XDisplayHandle {
+    fn drop(&mut self) {
+        unsafe {
+            xlib::XCloseDisplay(self.display);
+        }
+    }
+}
+
+fn extract_rgb_pixels(
+    image: *mut xlib::XImage,
+    width: i32,
+    height: i32,
+) -> Result<Vec<u8>, String> {
+    if width <= 0 || height <= 0 {
+        return Err("Invalid image dimensions for OCR.".to_string());
+    }
+
+    let pixel_count = (width as usize)
+        .checked_mul(height as usize)
+        .ok_or_else(|| "Image dimensions are too large for OCR processing.".to_string())?;
+
+    let mut rgb = Vec::with_capacity(pixel_count * PPM_RGB_CHANNELS);
+
+    let red_mask = unsafe { (*image).red_mask as u64 };
+    let green_mask = unsafe { (*image).green_mask as u64 };
+    let blue_mask = unsafe { (*image).blue_mask as u64 };
+
+    for y in 0..height {
+        for x in 0..width {
+            let pixel = unsafe { xlib::XGetPixel(image, x, y) } as u64;
+            rgb.push(extract_channel_value(pixel, red_mask));
+            rgb.push(extract_channel_value(pixel, green_mask));
+            rgb.push(extract_channel_value(pixel, blue_mask));
+        }
+    }
+
+    Ok(rgb)
+}
+
+fn extract_channel_value(pixel: u64, mask: u64) -> u8 {
+    if mask == 0 {
+        return 0;
+    }
+
+    let shift = mask.trailing_zeros();
+    let channel_max = mask >> shift;
+    if channel_max == 0 {
+        return 0;
+    }
+
+    let raw_value = (pixel & mask) >> shift;
+    ((raw_value * u64::from(PPM_MAX_COLOR_VALUE)) / channel_max) as u8
+}
+
+fn encode_ppm_bytes(width: i32, height: i32, rgb_pixels: &[u8]) -> Result<Vec<u8>, String> {
+    if width <= 0 || height <= 0 {
+        return Err("PPM encoding requires positive image dimensions.".to_string());
+    }
+
+    let expected_size = (width as usize)
+        .checked_mul(height as usize)
+        .and_then(|pixel_count| pixel_count.checked_mul(PPM_RGB_CHANNELS))
+        .ok_or_else(|| "PPM image dimensions are too large.".to_string())?;
+
+    if rgb_pixels.len() != expected_size {
+        return Err(format!(
+            "PPM pixel payload size mismatch (expected {}, got {}).",
+            expected_size,
+            rgb_pixels.len()
+        ));
+    }
+
+    let mut data = format!("P6\n{} {}\n{}\n", width, height, PPM_MAX_COLOR_VALUE).into_bytes();
+    data.extend_from_slice(rgb_pixels);
+    Ok(data)
+}
+
+struct TempPpmFile {
+    path: PathBuf,
+}
+
+impl TempPpmFile {
+    fn create(width: i32, height: i32, rgb_pixels: &[u8]) -> Result<Self, String> {
+        let ppm_data = encode_ppm_bytes(width, height, rgb_pixels)?;
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or_default();
+
+        let path = env::temp_dir().join(format!(
+            "handy-ocr-{}-{}.ppm",
+            std::process::id(),
+            timestamp
+        ));
+
+        fs::write(&path, ppm_data)
+            .map_err(|error| format!("Failed to write temporary OCR image: {error}"))?;
+
+        Ok(Self { path })
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempPpmFile {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+struct TempImageFile {
+    path: PathBuf,
+}
+
+impl TempImageFile {
+    fn create(extension: &str) -> Result<Self, String> {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or_default();
+
+        let path = env::temp_dir().join(format!(
+            "handy-ocr-{}-{}.{}",
+            std::process::id(),
+            timestamp,
+            extension
+        ));
+
+        Ok(Self { path })
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempImageFile {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+fn run_tesseract(image_path: &Path) -> Result<String, String> {
+    let output = Command::new(TESSERACT_EXECUTABLE)
+        .arg(image_path)
+        .arg(TESSERACT_OUTPUT_TARGET)
+        .arg("--psm")
+        .arg(TESSERACT_PAGE_SEGMENT_MODE)
+        .output()
+        .map_err(|error| format!("Failed to launch tesseract: {error}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.trim().is_empty() {
+            return Err(format!("Tesseract exited with status {}.", output.status));
+        }
+
+        return Err(format!("Tesseract OCR failed: {}", stderr.trim()));
+    }
+
+    String::from_utf8(output.stdout)
+        .map(|text| text.trim().to_string())
+        .map_err(|error| format!("Failed to decode Tesseract output: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_channel_value_scales_full_range() {
+        assert_eq!(extract_channel_value(0x00ff_0000, 0x00ff_0000), 255);
+        assert_eq!(extract_channel_value(0x0000_0000, 0x00ff_0000), 0);
+    }
+
+    #[test]
+    fn extract_channel_value_scales_sub_byte_masks() {
+        assert_eq!(extract_channel_value(0x00f0_0000, 0x00f0_0000), 255);
+        assert_eq!(extract_channel_value(0x0080_0000, 0x00f0_0000), 136);
+    }
+
+    #[test]
+    fn encode_ppm_bytes_writes_header_and_pixels() {
+        let rgb = vec![255, 0, 0, 0, 255, 0];
+        let ppm = encode_ppm_bytes(2, 1, &rgb).expect("PPM encoding should succeed");
+
+        assert!(ppm.starts_with(b"P6\n2 1\n255\n"));
+        assert!(ppm.ends_with(&rgb));
+    }
+
+    #[test]
+    fn encode_ppm_bytes_rejects_invalid_pixel_size() {
+        let result = encode_ppm_bytes(2, 2, &[255, 0, 0]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_session_type_handles_known_values() {
+        assert_eq!(parse_session_type(Some("x11")), SessionType::X11);
+        assert_eq!(parse_session_type(Some("wayland")), SessionType::Wayland);
+        assert_eq!(parse_session_type(Some("tty")), SessionType::Unknown);
+    }
+
+    #[test]
+    fn parse_desktop_environment_handles_known_values() {
+        assert_eq!(
+            parse_desktop_environment(Some("ubuntu:GNOME"), None),
+            DesktopEnvironment::Gnome
+        );
+        assert_eq!(
+            parse_desktop_environment(Some("KDE"), None),
+            DesktopEnvironment::Kde
+        );
+        assert_eq!(
+            parse_desktop_environment(Some("XFCE"), None),
+            DesktopEnvironment::Other
+        );
+    }
+
+    #[test]
+    fn select_wayland_tool_prefers_desktop_default() {
+        assert_eq!(
+            select_wayland_tool(DesktopEnvironment::Gnome, true, true),
+            Some(WaylandScreenshotTool::GnomeScreenshot)
+        );
+        assert_eq!(
+            select_wayland_tool(DesktopEnvironment::Kde, true, true),
+            Some(WaylandScreenshotTool::Spectacle)
+        );
+    }
+
+    #[test]
+    fn select_wayland_tool_uses_secondary_when_primary_missing() {
+        assert_eq!(
+            select_wayland_tool(DesktopEnvironment::Gnome, false, true),
+            Some(WaylandScreenshotTool::Spectacle)
+        );
+        assert_eq!(
+            select_wayland_tool(DesktopEnvironment::Kde, true, false),
+            Some(WaylandScreenshotTool::GnomeScreenshot)
+        );
+        assert_eq!(
+            select_wayland_tool(DesktopEnvironment::Other, false, false),
+            None
+        );
+    }
+}

--- a/src-tauri/src/macos_ocr.rs
+++ b/src-tauri/src/macos_ocr.rs
@@ -1,0 +1,54 @@
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int};
+
+#[repr(C)]
+pub struct OCRTextResponse {
+    pub text: *mut c_char,
+    pub success: c_int,
+    pub error_message: *mut c_char,
+}
+
+extern "C" {
+    fn macos_ocr_preflight_screen_capture_access() -> c_int;
+    fn macos_ocr_request_screen_capture_access() -> c_int;
+    fn macos_ocr_capture_frontmost_window_text() -> *mut OCRTextResponse;
+    fn macos_ocr_free_response(response: *mut OCRTextResponse);
+}
+
+pub fn has_screen_capture_access() -> bool {
+    unsafe { macos_ocr_preflight_screen_capture_access() == 1 }
+}
+
+pub fn request_screen_capture_access() -> bool {
+    unsafe { macos_ocr_request_screen_capture_access() == 1 }
+}
+
+pub fn capture_frontmost_window_ocr_text() -> Result<String, String> {
+    let response_ptr = unsafe { macos_ocr_capture_frontmost_window_text() };
+
+    if response_ptr.is_null() {
+        return Err("Null response from macOS OCR bridge".to_string());
+    }
+
+    let response = unsafe { &*response_ptr };
+
+    let result = if response.success == 1 {
+        if response.text.is_null() {
+            Ok(String::new())
+        } else {
+            let text = unsafe { CStr::from_ptr(response.text) };
+            Ok(text.to_string_lossy().into_owned())
+        }
+    } else {
+        let error = if response.error_message.is_null() {
+            "Unknown macOS OCR error".to_string()
+        } else {
+            let c_error = unsafe { CStr::from_ptr(response.error_message) };
+            c_error.to_string_lossy().into_owned()
+        };
+        Err(error)
+    };
+
+    unsafe { macos_ocr_free_response(response_ptr) };
+    result
+}

--- a/src-tauri/src/windows_ocr.rs
+++ b/src-tauri/src/windows_ocr.rs
@@ -1,0 +1,158 @@
+use std::ffi::c_void;
+use windows::Graphics::Imaging::{BitmapAlphaMode, BitmapPixelFormat, SoftwareBitmap};
+use windows::Media::Ocr::OcrEngine;
+use windows::Security::Cryptography::CryptographicBuffer;
+use windows::Win32::Foundation::RECT;
+use windows::Win32::Graphics::Gdi::{
+    BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DeleteDC, DeleteObject, GetDIBits,
+    SelectObject, BITMAPINFO, BITMAPINFOHEADER, BI_RGB, CAPTUREBLT, DIB_RGB_COLORS, SRCCOPY,
+};
+use windows::Win32::Graphics::Gdi::{GetWindowDC, ReleaseDC};
+use windows::Win32::Storage::Xps::{PrintWindow, PRINT_WINDOW_FLAGS};
+use windows::Win32::System::Com::{CoInitializeEx, COINIT_MULTITHREADED};
+use windows::Win32::UI::WindowsAndMessaging::{GetForegroundWindow, GetWindowRect};
+
+const MIN_WINDOW_DIMENSION: i32 = 32;
+
+pub fn capture_frontmost_window_ocr_text() -> Result<String, String> {
+    let (pixels, width, height) = capture_frontmost_window_pixels()?;
+    recognize_text_from_bgra(&pixels, width, height)
+}
+
+fn capture_frontmost_window_pixels() -> Result<(Vec<u8>, i32, i32), String> {
+    let hwnd = unsafe { GetForegroundWindow() };
+    if hwnd.is_invalid() {
+        return Err("Unable to find foreground window.".to_string());
+    }
+
+    let mut rect = RECT::default();
+    if unsafe { GetWindowRect(hwnd, &mut rect) }.is_err() {
+        return Err("Failed to read foreground window bounds.".to_string());
+    }
+
+    let width = rect.right - rect.left;
+    let height = rect.bottom - rect.top;
+    if width < MIN_WINDOW_DIMENSION || height < MIN_WINDOW_DIMENSION {
+        return Err("Foreground window is too small for OCR.".to_string());
+    }
+
+    unsafe {
+        let window_dc = GetWindowDC(Some(hwnd));
+        if window_dc.is_invalid() {
+            return Err("Failed to acquire foreground window DC.".to_string());
+        }
+
+        let memory_dc = CreateCompatibleDC(Some(window_dc));
+        if memory_dc.is_invalid() {
+            let _ = ReleaseDC(Some(hwnd), window_dc);
+            return Err("Failed to create compatible memory DC.".to_string());
+        }
+
+        let bitmap = CreateCompatibleBitmap(window_dc, width, height);
+        if bitmap.is_invalid() {
+            let _ = DeleteDC(memory_dc);
+            let _ = ReleaseDC(Some(hwnd), window_dc);
+            return Err("Failed to create compatible bitmap.".to_string());
+        }
+
+        let old_object = SelectObject(memory_dc, bitmap.into());
+        if old_object.is_invalid() {
+            let _ = DeleteObject(bitmap.into());
+            let _ = DeleteDC(memory_dc);
+            let _ = ReleaseDC(Some(hwnd), window_dc);
+            return Err("Failed to select bitmap into memory DC.".to_string());
+        }
+
+        // Prefer full-window capture, including non-client area.
+        let mut captured = PrintWindow(hwnd, memory_dc, PRINT_WINDOW_FLAGS(0x0000_0002)).as_bool();
+        if !captured {
+            captured = BitBlt(
+                memory_dc,
+                0,
+                0,
+                width,
+                height,
+                Some(window_dc),
+                0,
+                0,
+                SRCCOPY | CAPTUREBLT,
+            )
+            .is_ok();
+        }
+
+        if !captured {
+            let _ = SelectObject(memory_dc, old_object);
+            let _ = DeleteObject(bitmap.into());
+            let _ = DeleteDC(memory_dc);
+            let _ = ReleaseDC(Some(hwnd), window_dc);
+            return Err("Failed to capture foreground window pixels.".to_string());
+        }
+
+        let mut bitmap_info = BITMAPINFO {
+            bmiHeader: BITMAPINFOHEADER {
+                biSize: std::mem::size_of::<BITMAPINFOHEADER>() as u32,
+                biWidth: width,
+                biHeight: -height,
+                biPlanes: 1,
+                biBitCount: 32,
+                biCompression: BI_RGB.0,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let mut bytes = vec![0_u8; (width as usize) * (height as usize) * 4];
+        let copied_scanlines = GetDIBits(
+            memory_dc,
+            bitmap,
+            0,
+            height as u32,
+            Some(bytes.as_mut_ptr().cast::<c_void>()),
+            &mut bitmap_info,
+            DIB_RGB_COLORS,
+        );
+
+        let _ = SelectObject(memory_dc, old_object);
+        let _ = DeleteObject(bitmap.into());
+        let _ = DeleteDC(memory_dc);
+        let _ = ReleaseDC(Some(hwnd), window_dc);
+
+        if copied_scanlines == 0 {
+            return Err("Failed to read captured bitmap pixels.".to_string());
+        }
+
+        Ok((bytes, width, height))
+    }
+}
+
+fn recognize_text_from_bgra(bytes: &[u8], width: i32, height: i32) -> Result<String, String> {
+    unsafe {
+        let _ = CoInitializeEx(None, COINIT_MULTITHREADED);
+    }
+
+    let ocr_engine = OcrEngine::TryCreateFromUserProfileLanguages()
+        .map_err(|e| format!("Failed to create OCR engine: {e}"))?;
+
+    let buffer = CryptographicBuffer::CreateFromByteArray(bytes)
+        .map_err(|e| format!("Failed to create OCR input buffer: {e}"))?;
+
+    let software_bitmap = SoftwareBitmap::CreateCopyWithAlphaFromBuffer(
+        &buffer,
+        BitmapPixelFormat::Bgra8,
+        width,
+        height,
+        BitmapAlphaMode::Ignore,
+    )
+    .map_err(|e| format!("Failed to create SoftwareBitmap for OCR: {e}"))?;
+
+    let ocr_result = ocr_engine
+        .RecognizeAsync(&software_bitmap)
+        .map_err(|e| format!("Failed to start OCR recognition: {e}"))?
+        .get()
+        .map_err(|e| format!("OCR recognition failed: {e}"))?;
+
+    ocr_result
+        .Text()
+        .map_err(|e| format!("Failed to read OCR result text: {e}"))
+        .map(|text| text.to_string())
+}

--- a/src-tauri/swift/macos_ocr.swift
+++ b/src-tauri/swift/macos_ocr.swift
@@ -1,0 +1,187 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import Vision
+
+public typealias OCRResponsePointer = UnsafeMutablePointer<OCRTextResponse>
+private let MIN_WINDOW_DIMENSION: CGFloat = 32.0
+
+private func duplicateCString(_ text: String) -> UnsafeMutablePointer<CChar>? {
+    return text.withCString { basePointer in
+        guard let duplicated = strdup(basePointer) else {
+            return nil
+        }
+        return duplicated
+    }
+}
+
+private func makeResponse(text: String) -> OCRResponsePointer {
+    let responsePtr = OCRResponsePointer.allocate(capacity: 1)
+    responsePtr.initialize(to: OCRTextResponse(text: nil, success: 0, error_message: nil))
+    responsePtr.pointee.success = 1
+    responsePtr.pointee.text = duplicateCString(text)
+    return responsePtr
+}
+
+private func makeErrorResponse(_ message: String) -> OCRResponsePointer {
+    let responsePtr = OCRResponsePointer.allocate(capacity: 1)
+    responsePtr.initialize(to: OCRTextResponse(text: nil, success: 0, error_message: nil))
+    responsePtr.pointee.error_message = duplicateCString(message)
+    return responsePtr
+}
+
+private func preflightScreenCaptureAccess() -> Bool {
+    guard #available(macOS 10.15, *) else {
+        return true
+    }
+    return CGPreflightScreenCaptureAccess()
+}
+
+private func requestScreenCaptureAccess() -> Bool {
+    guard #available(macOS 10.15, *) else {
+        return true
+    }
+    return CGRequestScreenCaptureAccess()
+}
+
+private func frontmostApplicationPID() -> pid_t? {
+    return NSWorkspace.shared.frontmostApplication?.processIdentifier
+}
+
+private func frontmostWindowID(for ownerPID: pid_t) -> CGWindowID? {
+    guard
+        let windowList = CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly, .excludeDesktopElements],
+            kCGNullWindowID
+        ) as? [[String: Any]]
+    else {
+        return nil
+    }
+
+    for window in windowList {
+        guard let windowPID = window[kCGWindowOwnerPID as String] as? pid_t else {
+            continue
+        }
+        guard windowPID == ownerPID else {
+            continue
+        }
+
+        let windowLayer = (window[kCGWindowLayer as String] as? Int) ?? 0
+        guard windowLayer == 0 else {
+            continue
+        }
+
+        let alpha = (window[kCGWindowAlpha as String] as? CGFloat) ?? 1.0
+        guard alpha > 0 else {
+            continue
+        }
+
+        guard let boundsDict = window[kCGWindowBounds as String] as? NSDictionary else {
+            continue
+        }
+        guard let bounds = CGRect(dictionaryRepresentation: boundsDict) else {
+            continue
+        }
+        guard bounds.width >= MIN_WINDOW_DIMENSION && bounds.height >= MIN_WINDOW_DIMENSION else {
+            continue
+        }
+
+        guard let windowNumber = window[kCGWindowNumber as String] as? UInt32 else {
+            continue
+        }
+
+        return CGWindowID(windowNumber)
+    }
+
+    return nil
+}
+
+private func captureWindowImage(windowID: CGWindowID) -> CGImage? {
+    return CGWindowListCreateImage(
+        CGRect.null,
+        .optionIncludingWindow,
+        windowID,
+        [.bestResolution, .boundsIgnoreFraming]
+    )
+}
+
+@available(macOS 10.15, *)
+private func recognizeText(in image: CGImage) throws -> String {
+    let request = VNRecognizeTextRequest()
+    request.recognitionLevel = .accurate
+    request.usesLanguageCorrection = true
+
+    let handler = VNImageRequestHandler(cgImage: image, options: [:])
+    try handler.perform([request])
+
+    guard let observations = request.results else {
+        return ""
+    }
+
+    let lines = observations.compactMap { observation -> String? in
+        guard let bestCandidate = observation.topCandidates(1).first else {
+            return nil
+        }
+        let text = bestCandidate.string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return text.isEmpty ? nil : text
+    }
+
+    return lines.joined(separator: "\n")
+}
+
+@_cdecl("macos_ocr_preflight_screen_capture_access")
+public func macosOCRPreflightScreenCaptureAccess() -> Int32 {
+    return preflightScreenCaptureAccess() ? 1 : 0
+}
+
+@_cdecl("macos_ocr_request_screen_capture_access")
+public func macosOCRRequestScreenCaptureAccess() -> Int32 {
+    return requestScreenCaptureAccess() ? 1 : 0
+}
+
+@_cdecl("macos_ocr_capture_frontmost_window_text")
+public func macosOCRCaptureFrontmostWindowText() -> OCRResponsePointer {
+    guard #available(macOS 10.15, *) else {
+        return makeErrorResponse("macOS OCR requires macOS 10.15 or newer.")
+    }
+
+    guard preflightScreenCaptureAccess() else {
+        return makeErrorResponse("Screen recording permission is not granted.")
+    }
+
+    guard let pid = frontmostApplicationPID() else {
+        return makeErrorResponse("Unable to determine the frontmost application.")
+    }
+
+    guard let windowID = frontmostWindowID(for: pid) else {
+        return makeErrorResponse("Unable to find a capturable frontmost window.")
+    }
+
+    guard let image = captureWindowImage(windowID: windowID) else {
+        return makeErrorResponse("Failed to capture the frontmost window image.")
+    }
+
+    do {
+        let text = try recognizeText(in: image)
+        return makeResponse(text: text)
+    } catch {
+        return makeErrorResponse("OCR text recognition failed: \(error.localizedDescription)")
+    }
+}
+
+@_cdecl("macos_ocr_free_response")
+public func macosOCRFreeResponse(_ response: OCRResponsePointer?) {
+    guard let response = response else {
+        return
+    }
+
+    if let text = response.pointee.text {
+        free(UnsafeMutablePointer(mutating: text))
+    }
+
+    if let errorMessage = response.pointee.error_message {
+        free(UnsafeMutablePointer(mutating: errorMessage))
+    }
+
+    response.deallocate()
+}

--- a/src-tauri/swift/macos_ocr_bridge.h
+++ b/src-tauri/swift/macos_ocr_bridge.h
@@ -1,0 +1,30 @@
+#ifndef macos_ocr_bridge_h
+#define macos_ocr_bridge_h
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    char* text;
+    int success; // 0 for failure, 1 for success
+    char* error_message; // Only valid when success = 0
+} OCRTextResponse;
+
+// Check whether screen capture permission is currently granted.
+int macos_ocr_preflight_screen_capture_access(void);
+
+// Prompt for screen capture permission (system prompt shown if needed).
+int macos_ocr_request_screen_capture_access(void);
+
+// Capture the frontmost window and return OCR text.
+OCRTextResponse* macos_ocr_capture_frontmost_window_text(void);
+
+// Free memory allocated by an OCR response.
+void macos_ocr_free_response(OCRTextResponse* response);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* macos_ocr_bridge_h */

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -57,7 +57,7 @@
     },
     "linux": {
       "deb": {
-        "depends": ["libgtk-layer-shell0"]
+        "depends": ["libgtk-layer-shell0", "tesseract-ocr"]
       },
       "rpm": {
         "compression": {


### PR DESCRIPTION
## Summary

This PR introduces an experimental OCR context path for post-processing prompts across supported desktop platforms.

When the selected post-processing prompt contains `${OCR}` or `${ocr}`, Handy captures text from the frontmost app context (OCR) and injects it into the prompt template before sending to the post-processing model.

This is intentionally a hidden/experimental feature for now:
- No UI changes
- No new settings UI
- No public frontend command/API changes

Note: If guided, I can make follow-up changes needed for merge readiness (including UI exposure if desired).

## Intent

The goal is to improve post-processing quality by adding optional visual context from the active window/screen, especially for fixing terminology and typo-like dictation misunderstandings.

I’m using the following addition to the default prompt and getting better results than non-OCR post-processing:

```text
Relevant context (OCR’ed from active window, use for fixing typos and terminology):
${OCR}
```

I intentionally kept scope minimal and hidden to validate usefulness first, without increasing UI complexity or feature surface.

## Architecture / Flow

- Existing backend/frontend architecture remains unchanged (Rust backend in `src-tauri`, React/TS frontend in `src`).
- Prompt template expansion in `src-tauri/src/actions.rs` now supports:
  - `${output}` (existing transcript variable)
  - `${OCR}` / `${ocr}` (new OCR context variable)
- OCR is attempted only when:
  1. OCR variable exists in the selected prompt
  2. Existing `experimental_enabled` setting is true
- OCR text is truncated to 8000 chars to limit prompt growth.
- On OCR failure, missing permission, or unsupported conditions, OCR resolves to an empty string and processing continues safely.

## Platform Notes

<details>
<summary><strong>macOS</strong></summary>

- Added:
  - `src-tauri/swift/macos_ocr.swift`
  - `src-tauri/swift/macos_ocr_bridge.h`
  - `src-tauri/src/macos_ocr.rs`
- Updated:
  - `src-tauri/build.rs` (bridge build/link wiring)
  - `src-tauri/src/lib.rs` (module registration, macOS-gated)
  - `src-tauri/src/actions.rs` (template expansion + OCR integration + tests)
- Frameworks linked:
  - Foundation
  - AppKit
  - CoreGraphics
  - Vision
- Permission behavior:
  - Screen recording permission requested on demand
  - Request-at-most-once per app run
  - Graceful fallback to empty OCR context if denied/unavailable

</details>

<details>
<summary><strong>Windows</strong></summary>

- Added Windows OCR provider integration for `${OCR}` / `${ocr}` in post-processing flow.
- Uses `src-tauri/src/windows_ocr.rs` for frontmost-window OCR capture on Windows.
- Wired into shared prompt-template expansion in `src-tauri/src/actions.rs`.
- Behavior is fail-safe: OCR errors resolve to empty context and do not break transcription/post-processing flow.

</details>

<details>
<summary><strong>Linux</strong></summary>

- Added:
  - `src-tauri/src/linux_ocr.rs`
- Linux OCR strategy:
  - X11 session: active-window X11 capture path (with root-window fallback), then Tesseract.
  - Wayland session: screenshot-tool fallback, then Tesseract.
- Wayland fallback tools:
  - GNOME preferred: `gnome-screenshot -f <temp.png>`
  - KDE preferred: `spectacle -b -n -o <temp.png>`
  - NOTE: Unlike other implementations, these cli tools take full-screen screenshots.
- Backend selection is detected once at app startup and cached.
- Packaging/build updates:
  - Install `tesseract-ocr` in Ubuntu CI jobs (`.github/workflows/build.yml`)
  - Add Debian runtime dependency `tesseract-ocr` (`src-tauri/tauri.conf.json`)
  - Add Linux `x11` crate dependency in `src-tauri/Cargo.toml`
- Current limitation:
  - Wayland path depends on screenshot tools being installed.
  - This is an interim pragmatic implementation; portal/D-Bus integration can improve this later.
  - GNOME’s `org.gnome.Shell.Screenshot` D-Bus path is noted as a potential follow-up for better window-targeted behavior.

</details>

## Cross-platform Safety

- OCR providers are OS-gated.
- Existing transcription and post-processing flows are preserved.
- Unsupported/failing OCR paths degrade gracefully to empty OCR context.

## Prior Art Check

I searched upstream issues/PRs for OCR-related work and did not find a matching implementation.

## Testing

- Added/updated unit tests in `src-tauri/src/actions.rs` for OCR template resolution and truncation behavior.
- Added Linux OCR unit tests in `src-tauri/src/linux_ocr.rs` for backend selection and parsing logic.
- Frontend build and tests pass locally.
- Linux build/test and AppImage build were verified in Ubuntu VM.
- Note: in CommandLineTools-only macOS environments, Apple Intelligence `@Generable` macro tooling may fail independently; this PR does not change Apple Intelligence behavior.

## AI Assistance Disclosure

- AI used: Yes
- Tools used: GPT-5 Codex
- Usage: Extensive assistance across implementation, debugging, build validation, and documentation
```