### PR TITLE
fix(nix): fix ALSA mismatch, add GStreamer plugins, and repair UI environment

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767892417,
-        "narHash": "sha256-dhhvQY67aboBk8b0/u0XB6vwHdgbROZT3fJAjyNh5Ww=",
+        "lastModified": 1770562336,
+        "narHash": "sha256-ub1gpAONMFsT/GU2hV6ZWJjur8rJ6kKxdm9IlCT0j84=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
+        "rev": "d6c71932130818840fc8fe9509cf50be8c64634f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,10 @@
       nixpkgs,
     }:
     let
-      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
       # Read version from Cargo.toml
       cargoToml = builtins.fromTOML (builtins.readFile ./src-tauri/Cargo.toml);
@@ -132,13 +135,20 @@
               onnxruntime
               libayatana-appindicator
               libevdev
-              xorg.libX11
-              xorg.libXtst
+              libx11
+              libxtst
               gtk-layer-shell
               openssl
               vulkan-loader
               vulkan-headers
               shaderc
+
+              # Required for WebKitGTK audio/video
+              gst_all_1.gstreamer
+              gst_all_1.gst-plugins-base
+              gst_all_1.gst-plugins-good
+              gst_all_1.gst-plugins-bad
+              gst_all_1.gst-plugins-ugly
             ];
 
             env = {
@@ -146,15 +156,29 @@
               BINDGEN_EXTRA_CLANG_ARGS = "-isystem ${pkgs.llvmPackages.libclang.lib}/lib/clang/${lib.getVersion pkgs.llvmPackages.libclang}/include -isystem ${pkgs.glibc.dev}/include";
               ORT_LIB_LOCATION = "${pkgs.onnxruntime}/lib";
               OPENSSL_NO_VENDOR = "1";
+
+              # Tell Gstreamer where to find plugins
+              GST_PLUGIN_SYSTEM_PATH_1_0 = "${pkgs.lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" (
+                with pkgs.gst_all_1;
+                [
+                  gstreamer
+                  gst-plugins-base
+                  gst-plugins-good
+                  gst-plugins-bad
+                  gst-plugins-ugly
+                ]
+              )}";
             };
 
             preFixup = ''
               gappsWrapperArgs+=(
                 --set WEBKIT_DISABLE_DMABUF_RENDERER 1
-                --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [
-                  pkgs.vulkan-loader
-                  pkgs.onnxruntime
-                ]}"
+                --prefix LD_LIBRARY_PATH : "${
+                  lib.makeLibraryPath [
+                    pkgs.vulkan-loader
+                    pkgs.onnxruntime
+                  ]
+                }"
               )
             '';
 
@@ -163,7 +187,7 @@
               homepage = "https://github.com/cjpais/Handy";
               license = lib.licenses.mit;
               mainProgram = "handy";
-              platforms = [ "x86_64-linux" ];
+              platforms = supportedSystems;
             };
           };
 
@@ -175,7 +199,9 @@
       devShells = forAllSystems (
         system:
         let
-          pkgs = nixpkgs.legacyPackages.${system};
+          pkgs = import nixpkgs {
+            inherit system;
+          };
         in
         {
           default = pkgs.mkShell {
@@ -211,6 +237,19 @@
 
             LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
             LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath [ pkgs.libappindicator ]}";
+            GST_PLUGIN_SYSTEM_PATH_1_0 = "${pkgs.lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" (
+              with pkgs.gst_all_1;
+              [
+                gstreamer
+                gst-plugins-base
+                gst-plugins-good
+                gst-plugins-bad
+                gst-plugins-ugly
+              ]
+            )}";
+
+            # Same as wrapGAppsHook4
+            XDG_DATA_DIRS = "${pkgs.gsettings-desktop-schemas}/share/gsettings-schemas/${pkgs.gsettings-desktop-schemas.name}:${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}:${pkgs.hicolor-icon-theme}/share";
 
             shellHook = ''
               echo "Handy development environment"


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Human Written Description

I've encountered this issue:
```
ALSA lib pcm.c:2713:(snd_pcm_open_conf) Either /nix/store/z8pz8hz2psggqsws4n7mzbbdghpcxm71-pipewire-1.4.9/lib/alsa-lib/libasound_module_pcm_pipewire.so cannot be opened or _snd_pcm_pipewire_open was not defined inside
ALSA lib pcm.c:2713:(snd_pcm_open_conf) Either /nix/store/szmfcymkkxkfb6yrg2mg9h4g9lsh80b2-pipewire-1.4.9/lib/alsa-lib/libasound_module_pcm_pipewire.so cannot be opened or _snd_pcm_pipewire_open was not defined inside
ALSA lib pcm.c:2713:(snd_pcm_open_conf) Either /nix/store/z8pz8hz2psggqsws4n7mzbbdghpcxm71-pipewire-1.4.9/lib/alsa-lib/libasound_module_pcm_pipewire.so cannot be opened or _snd_pcm_pipewire_open was not defined inside
ALSA lib pcm.c:2713:(snd_pcm_open_conf) Either /nix/store/szmfcymkkxkfb6yrg2mg9h4g9lsh80b2-pipewire-1.4.9/lib/alsa-lib/libasound_module_pcm_pipewire.so cannot be opened or _snd_pcm_pipewire_open was not defined inside
ALSA lib pcm.c:2713:(snd_pcm_open_conf) Either /nix/store/z8pz8hz2psggqsws4n7mzbbdghpcxm71-pipewire-1.4.9/lib/alsa-lib/libasound_module_pcm_pipewire.so cannot be opened or _snd_pcm_pipewire_open was not defined inside
ALSA lib pcm.c:2713:(snd_pcm_open_conf) Either /nix/store/szmfcymkkxkfb6yrg2mg9h4g9lsh80b2-pipewire-1.4.9/lib/alsa-lib/libasound_module_pcm_pipewire.so cannot be opened or _snd_pcm_pipewire_open was not defined inside
ALSA lib pcm.c:2713:(snd_pcm_open_conf) Either /nix/store/z8pz8hz2psggqsws4n7mzbbdghpcxm71-pipewire-1.4.9/lib/alsa-lib/libasound_module_pcm_pipewire.so cannot be opened or _snd_pcm_pipewire_open was not defined inside
ALSA lib pcm.c:2713:(snd_pcm_open_conf) Either /nix/store/szmfcymkkxkfb6yrg2mg9h4g9lsh80b2-pipewire-1.4.9/lib/alsa-lib/libasound_module_pcm_pipewire.so cannot be opened or _snd_pcm_pipewire_open was not defined inside
```

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Gemini 3.0
- How extensively: 
  - Use it to summarize the commit
  - Use it to find out why GTK is not function correctly in the devshell
