### PR TITLE
fix: Apply DMABUF workaround on all Linux systems

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,12 +4,9 @@
 fn main() {
     #[cfg(target_os = "linux")]
     {
-        if std::path::Path::new("/dev/dri").exists()
-            && std::env::var("WAYLAND_DISPLAY").is_err()
-            && std::env::var("XDG_SESSION_TYPE").unwrap_or_default() == "x11"
-        {
-            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
-        }
+        // DMABUF renderer causes crashes on various GPU/display server configurations
+        // See: https://github.com/tauri-apps/tauri/issues/9394
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
     }
 
     handy_app_lib::run()


### PR DESCRIPTION
The previous implementation only applied the workaround on X11 sessions, leaving Wayland users affected by WebkitGTK DMABUF crashes. This affects various GPU configurations (at least Intel and NVIDIA) on both X11 and Wayland.

This change applies the workaround unconditionally on Linux, ensuring the app doesn't crash on affected systems while having minimal performance impact.

Related:

- https://github.com/tauri-apps/tauri/issues/9394
- https://github.com/cjpais/Handy/issues/308