### PR TITLE
fix(nix): address PR #778 review comments

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -96,11 +96,14 @@
             preBuild = ''
               cp -r ${bunDeps}/node_modules node_modules
               chmod -R +w node_modules
-              patchShebangs node_modules
+              substituteInPlace node_modules/.bin/{tsc,vite} \
+                --replace-fail "/usr/bin/env node" "${lib.getExe pkgs.bun}"
               export HOME=$TMPDIR
-              ${pkgs.bun}/bin/bun run build
+              bun run build
             '';
 
+            # Tests require runtime resources (audio devices, model files, GPU/Vulkan)
+            # not available in the Nix build sandbox
             doCheck = false;
 
             # The tauri hook's installPhase expects target/ in cwd, but our
@@ -118,7 +121,6 @@
               pkg-config
               wrapGAppsHook4
               bun
-              nodejs
               jq
               cmake
               llvmPackages.libclang


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Human Written Description

This addresses the review comments from @pinage404 on #778. The Nix build was using `patchShebangs` + `nodejs` when it only needed to fix two shebangs (`tsc` and `vite`), and was using the full store path for `bun`. Comments added for explanations in some areas too.

## Related Issues/Discussions

Follow-up to #778 (review comments)

## Community Feedback

@pinage404 left 5 review comments on #778 that were merged without being addressed. This PR resolves them:

1. ~~Add comment explaining platform restriction~~ — no longer applicable, PR #787 added `aarch64-linux` to `supportedSystems`
2. Remove `nodejs` dependency — replaced `patchShebangs` with targeted `substituteInPlace`
3. Use `bun` for shebangs instead of `node` — `tsc`/`vite` shebangs now point to `bun`
4. Use `bun run build` instead of `${pkgs.bun}/bin/bun run build` — `bun` is already on PATH
5. Add comment explaining `doCheck = false` — documents sandbox limitations

## Testing

- [x] `nix build .#handy` completes successfully
- [x] `result/bin/handy` binary exists and is executable
- [x] `ldd result/bin/handy` — all shared libraries resolve
- [x] `nix path-info -r .#handy | grep -i node` — returns nothing (nodejs not in closure)

## Screenshots/Videos (if applicable)

N/A

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: AI applied the changes to flake.nix and ran the nix build verification. Human directed which review comments to address and reviewed the approach.