### PR TITLE
fix(macos): build Apple Intelligence bridge as library

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -186,6 +186,7 @@ fn build_apple_intelligence_bridge() {
             "-sdk",
             &sdk_path,
             "-O",
+            "-parse-as-library",
             "-import-objc-header",
             BRIDGE_HEADER,
             "-c",


### PR DESCRIPTION
This fixes a macOS build/runtime issue in the Apple Intelligence Swift bridge/stub by compiling it as a library (adds ).\n\nOn my machine this prevented Swift object code from exporting an entrypoint symbol that could interfere with the Rust/Tauri app entry.\n\nChanges:\n- Build Swift bridge/stub with  in .\n\nTested:\n- 
  VITE v6.4.1  ready in 157 ms

  ➜  Local:   http://localhost:1420/ on macOS.