### PR TITLE
feat: add writing style personalization for post-processing

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -100,6 +100,16 @@ async fn post_process_transcription(settings: &AppSettings, transcription: &str)
 
     // Replace ${output} variable in the prompt with the actual text
     let processed_prompt = prompt.replace("${output}", transcription);
+    // Append writing style instructions if configured
+    let processed_prompt = if !settings.writing_style.trim().is_empty() {
+        format!(
+            "Writing style rules (apply silently, do NOT mention or repeat these rules in your output):\n{}\n\n{}\n\nRemember: Output ONLY the processed text. Do not include any commentary, labels, or the rules themselves.",
+            settings.writing_style.trim(),
+            processed_prompt
+        )
+    } else {
+        processed_prompt
+    };
     debug!("Processed prompt length: {} chars", processed_prompt.len());
 
     if provider.id == APPLE_INTELLIGENCE_PROVIDER_ID {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -287,6 +287,7 @@ pub fn run() {
         shortcut::suspend_binding,
         shortcut::resume_binding,
         shortcut::change_mute_while_recording_setting,
+        shortcut::change_writing_style_setting,
         shortcut::change_append_trailing_space_setting,
         shortcut::change_app_language_setting,
         shortcut::change_update_checks_setting,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -341,6 +341,8 @@ pub struct AppSettings {
     #[serde(default)]
     pub post_process_selected_prompt_id: Option<String>,
     #[serde(default)]
+    pub writing_style: String,
+    #[serde(default)]
     pub mute_while_recording: bool,
     #[serde(default)]
     pub append_trailing_space: bool,
@@ -679,6 +681,7 @@ pub fn get_default_settings() -> AppSettings {
         post_process_models: default_post_process_models(),
         post_process_prompts: default_post_process_prompts(),
         post_process_selected_prompt_id: None,
+        writing_style: String::new(),
         mute_while_recording: false,
         append_trailing_space: false,
         app_language: default_app_language(),

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -1020,6 +1020,18 @@ pub fn change_mute_while_recording_setting(app: AppHandle, enabled: bool) -> Res
 
 #[tauri::command]
 #[specta::specta]
+pub fn change_writing_style_setting(
+    app: AppHandle,
+    writing_style: String,
+) -> Result<(), String> {
+    let mut settings = settings::get_settings(&app);
+    settings.writing_style = writing_style;
+    settings::write_settings(&app, settings);
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
 pub fn change_append_trailing_space_setting(app: AppHandle, enabled: bool) -> Result<(), String> {
     let mut settings = settings::get_settings(&app);
     settings.append_trailing_space = enabled;

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -279,6 +279,14 @@ async changeMuteWhileRecordingSetting(enabled: boolean) : Promise<Result<null, s
     else return { status: "error", error: e  as any };
 }
 },
+async changeWritingStyleSetting(writingStyle: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("change_writing_style_setting", { writingStyle }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async changeAppendTrailingSpaceSetting(enabled: boolean) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("change_append_trailing_space_setting", { enabled }) };
@@ -730,7 +738,7 @@ async isLaptop() : Promise<Result<boolean, string>> {
 
 /** user-defined types **/
 
-export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk: boolean; audio_feedback: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; selected_model?: string; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: Partial<{ [key in string]: string }>; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; experimental_enabled?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool }
+export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk: boolean; audio_feedback: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; selected_model?: string; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: Partial<{ [key in string]: string }>; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; writing_style?: string; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; experimental_enabled?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool }
 export type AudioDevice = { index: string; name: string; is_default: boolean }
 export type AutoSubmitKey = "enter" | "ctrl_enter" | "cmd_enter"
 export type BindingResponse = { success: boolean; binding: ShortcutBinding | null; error: string | null }

--- a/src/components/settings/post-processing/PostProcessingSettings.tsx
+++ b/src/components/settings/post-processing/PostProcessingSettings.tsx
@@ -423,6 +423,25 @@ export const PostProcessingSettingsPrompts = React.memo(
 );
 PostProcessingSettingsPrompts.displayName = "PostProcessingSettingsPrompts";
 
+const WritingStyleSection: React.FC = () => {
+  const { t } = useTranslation();
+  const { getSetting, updateSetting } = useSettings();
+  const writingStyle = (getSetting("writing_style") as string) || "";
+
+  return (
+    <SettingContainer
+      title={t("settings.postProcessing.writingStyle.label")}
+      description={t("settings.postProcessing.writingStyle.description")}
+    >
+      <Textarea
+        value={writingStyle}
+        onChange={(e) => updateSetting("writing_style", e.target.value)}
+        placeholder={t("settings.postProcessing.writingStyle.placeholder")}
+      />
+    </SettingContainer>
+  );
+};
+
 export const PostProcessingSettings: React.FC = () => {
   const { t } = useTranslation();
 
@@ -442,6 +461,12 @@ export const PostProcessingSettings: React.FC = () => {
 
       <SettingsGroup title={t("settings.postProcessing.prompts.title")}>
         <PostProcessingSettingsPrompts />
+      </SettingsGroup>
+
+      <SettingsGroup
+        title={t("settings.postProcessing.writingStyle.title")}
+      >
+        <WritingStyleSection />
       </SettingsGroup>
     </div>
   );

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -355,6 +355,12 @@
         "cancel": "Cancel",
         "selectToEdit": "Select a prompt above to view and edit its details.",
         "createFirst": "Click 'Create New Prompt' above to create your first post-processing prompt."
+      },
+      "writingStyle": {
+        "title": "Writing Style",
+        "label": "Your Writing Style",
+        "description": "Describe your personal writing style. This is automatically applied to all post-processing prompts.",
+        "placeholder": "Examples:\n- i only type in lowercase\n- I use lots of exclamation points!\n- I write casually with abbreviations like 'u' and 'ur'\n- I keep things short and direct"
       }
     },
     "history": {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -123,6 +123,8 @@ const settingUpdaters: {
     commands.changePostProcessEnabledSetting(value as boolean),
   post_process_selected_prompt_id: (value) =>
     commands.setPostProcessSelectedPrompt(value as string),
+  writing_style: (value) =>
+    commands.changeWritingStyleSetting(value as string),
   mute_while_recording: (value) =>
     commands.changeMuteWhileRecordingSetting(value as boolean),
   append_trailing_space: (value) =>


### PR DESCRIPTION
## Summary
- Adds a **Writing Style** field to Post Processing settings where users can describe their personal writing preferences (e.g. "i only type in lowercase", "I keep things short and casual")
- The writing style is automatically injected into all post-processing prompts, so every transcription adapts to the user's voice without modifying individual prompt templates
- Works with all providers (OpenAI, OpenRouter, Apple Intelligence, custom) and all prompt templates

## Test plan
- [ ] Open Settings > Advanced > Enable Post Processing
- [ ] Navigate to Post Process tab
- [ ] Verify "Writing Style" section appears below the Prompt section
- [ ] Enter a writing style (e.g. "i only type in lowercase")
- [ ] Use the post-processing hotkey to transcribe
- [ ] Verify the output follows the specified writing style
- [ ] Verify it works with different prompt templates
- [ ] Run `cargo check` — passes
- [ ] Run `bun run lint` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)