### PR TITLE
fix: update nix hash for dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,7 @@
 
             outputHashAlgo = "sha256";
             outputHashMode = "recursive";
-            outputHash = "sha256-+hUANv0w3qnK5d2+4JW3XMazLRDhWCbOxUXQyTGta/0=";
+            outputHash = "sha256-6SvLw/8UBIHlcIY7jUJKv6DHPooP3aUz+4PvC7UNzv4=";
           };
         in
         {


### PR DESCRIPTION
## Summary
- Updates the `outputHash` in `flake.nix` to match the current dependency versions

## Context
The previous nix hash was outdated, causing build failures with `nix build`. This PR updates the hash to the correct value.

## Testing
- Verified the build works with `nix build` after the hash update

## AI Assistance
- Yes, AI was used for this PR
- Tool: Claude Code
- Usage: Helped with the workflow (commit, fork, push, PR creation)