### PR TITLE
feat: add Z.AI post-process provider

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -460,6 +460,14 @@ fn default_post_process_providers() -> Vec<PostProcessProvider> {
             supports_structured_output: true,
         },
         PostProcessProvider {
+            id: "zai".to_string(),
+            label: "Z.AI".to_string(),
+            base_url: "https://api.z.ai/api/paas/v4".to_string(),
+            allow_base_url_edit: false,
+            models_endpoint: Some("/models".to_string()),
+            supports_structured_output: true,
+        },
+        PostProcessProvider {
             id: "openrouter".to_string(),
             label: "OpenRouter".to_string(),
             base_url: "https://openrouter.ai/api/v1".to_string(),


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [X] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [X] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [X] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

I wanted to use Z.AI for transcript post-processing in Handy, but it was not available in the built-in provider list. This is available via the custom provider but I feel a native integration is easier. This change adds Z.AI as a default post-process provider using the standard OpenAI-compatible endpoint so users with a Z.AI plan can configure their API key and model directly in settings.

## Related Issues/Discussions

Fixes #
Discussion: N/A

## Community Feedback

No public discussion.

## Testing

- `cargo check --manifest-path src-tauri/Cargo.toml`
- Manual verification of provider registration in `src-tauri/src/settings.rs`

## Screenshots/Videos (if applicable)

<!-- Add screenshots or videos demonstrating the change -->

<img width="866" height="756" alt="CleanShot 2026-02-18 at 14 26 54" src="https://github.com/user-attachments/assets/32eca662-416f-4c8f-aba2-7726945a5355" />

## AI Assistance

<!-- AI-assisted PRs are welcome! Just let us know so we can review appropriately. -->

- [ ] No AI was used in this PR
- [X] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenCode (GPT-5.3-Codex)
- How extensively: Helped understanding the code, run checks, and prepare PR content.