### PR TITLE
feat: add audio speed control for faster transcription

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -292,6 +292,7 @@ pub fn run(cli_args: CliArgs) {
         shortcut::change_mute_while_recording_setting,
         shortcut::change_append_trailing_space_setting,
         shortcut::change_app_language_setting,
+        shortcut::change_audio_speed_setting,
         shortcut::change_update_checks_setting,
         shortcut::change_keyboard_implementation_setting,
         shortcut::get_keyboard_implementation,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -358,6 +358,8 @@ pub struct AppSettings {
     pub paste_delay_ms: u64,
     #[serde(default = "default_typing_tool")]
     pub typing_tool: TypingTool,
+    #[serde(default = "default_audio_speed")]
+    pub audio_speed: f32,
 }
 
 fn default_model() -> String {
@@ -560,6 +562,10 @@ fn default_typing_tool() -> TypingTool {
     TypingTool::Auto
 }
 
+fn default_audio_speed() -> f32 {
+    1.0
+}
+
 fn ensure_post_process_defaults(settings: &mut AppSettings) -> bool {
     let mut changed = false;
     for provider in default_post_process_providers() {
@@ -713,6 +719,7 @@ pub fn get_default_settings() -> AppSettings {
         show_tray_icon: default_show_tray_icon(),
         paste_delay_ms: default_paste_delay_ms(),
         typing_tool: default_typing_tool(),
+        audio_speed: default_audio_speed(),
     }
 }
 

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -1052,3 +1052,16 @@ pub fn change_show_tray_icon_setting(app: AppHandle, enabled: bool) -> Result<()
 
     Ok(())
 }
+
+#[tauri::command]
+#[specta::specta]
+pub fn change_audio_speed_setting(app: AppHandle, speed: f32) -> Result<(), String> {
+    // Validate speed is in reasonable range (1.0 to 3.0)
+    if speed < 1.0 || speed > 3.0 {
+        return Err("Audio speed must be between 1.0 and 3.0".to_string());
+    }
+    let mut settings = settings::get_settings(&app);
+    settings.audio_speed = speed;
+    settings::write_settings(&app, settings);
+    Ok(())
+}

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -295,6 +295,14 @@ async changeAppLanguageSetting(language: string) : Promise<Result<null, string>>
     else return { status: "error", error: e  as any };
 }
 },
+async changeAudioSpeedSetting(speed: number) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("change_audio_speed_setting", { speed }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async changeUpdateChecksSetting(enabled: boolean) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("change_update_checks_setting", { enabled }) };
@@ -705,10 +713,8 @@ async updateRecordingRetentionPeriod(period: string) : Promise<Result<null, stri
 }
 },
 /**
- * Checks if the Mac is a laptop by detecting battery presence
- * 
- * This uses pmset to check for battery information.
- * Returns true if a battery is detected (laptop), false otherwise (desktop)
+ * Stub implementation for non-macOS platforms
+ * Always returns false since laptop detection is macOS-specific
  */
 async isLaptop() : Promise<Result<boolean, string>> {
     try {
@@ -730,7 +736,7 @@ async isLaptop() : Promise<Result<boolean, string>> {
 
 /** user-defined types **/
 
-export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk: boolean; audio_feedback: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; selected_model?: string; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: Partial<{ [key in string]: string }>; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; experimental_enabled?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool }
+export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk: boolean; audio_feedback: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; selected_model?: string; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: Partial<{ [key in string]: string }>; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; experimental_enabled?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool; audio_speed?: number }
 export type AudioDevice = { index: string; name: string; is_default: boolean }
 export type AutoSubmitKey = "enter" | "ctrl_enter" | "cmd_enter"
 export type BindingResponse = { success: boolean; binding: ShortcutBinding | null; error: string | null }

--- a/src/components/settings/AudioSpeed.tsx
+++ b/src/components/settings/AudioSpeed.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { Slider } from "../ui/Slider";
+import { useSettings } from "../../hooks/useSettings";
+
+export const AudioSpeed: React.FC<{ disabled?: boolean; grouped?: boolean }> = ({
+  disabled = false,
+  grouped = false,
+}) => {
+  const { t } = useTranslation();
+  const { getSetting, updateSetting } = useSettings();
+  const audioSpeed = getSetting("audio_speed") ?? 1.0;
+
+  // Warning shown only when speed > 1.0
+  const showWarning = audioSpeed > 1.0;
+
+  return (
+    <div className="space-y-2">
+      <Slider
+        value={audioSpeed}
+        onChange={(value: number) => updateSetting("audio_speed", value)}
+        min={1.0}
+        max={2.0}
+        step={0.1}
+        label={t("settings.sound.audioSpeed.title")}
+        description={t("settings.sound.audioSpeed.description")}
+        descriptionMode="tooltip"
+        grouped={grouped}
+        formatValue={(value) => `${value.toFixed(1)}x`}
+        disabled={disabled}
+      />
+      {showWarning && (
+        <p className="text-xs text-yellow-500 px-3">
+          {t("settings.sound.audioSpeed.warning")}
+        </p>
+      )}
+    </div>
+  );
+};

--- a/src/components/settings/general/GeneralSettings.tsx
+++ b/src/components/settings/general/GeneralSettings.tsx
@@ -10,6 +10,7 @@ import { useSettings } from "../../../hooks/useSettings";
 import { VolumeSlider } from "../VolumeSlider";
 import { MuteWhileRecording } from "../MuteWhileRecording";
 import { ModelSettingsCard } from "./ModelSettingsCard";
+import { AudioSpeed } from "../AudioSpeed";
 
 export const GeneralSettings: React.FC = () => {
   const { t } = useTranslation();
@@ -31,6 +32,7 @@ export const GeneralSettings: React.FC = () => {
           disabled={!audioFeedbackEnabled}
         />
         <VolumeSlider disabled={!audioFeedbackEnabled} />
+        <AudioSpeed grouped={true} />
       </SettingsGroup>
     </div>
   );

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -217,6 +217,11 @@
       "volume": {
         "title": "Volume",
         "description": "Adjust the volume of audio feedback sounds"
+      },
+      "audioSpeed": {
+        "title": "Audio Speed",
+        "description": "Speed up audio before transcription to make it faster on slow hardware. Higher speeds reduce quality but improve performance.",
+        "warning": "Higher speeds may reduce transcription accuracy. Test to find the best value for your speaking style."
       }
     },
     "advanced": {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -76,6 +76,8 @@ const settingUpdaters: {
     commands.changeAudioFeedbackSetting(value as boolean),
   audio_feedback_volume: (value) =>
     commands.changeAudioFeedbackVolumeSetting(value as number),
+  audio_speed: (value) =>
+    commands.changeAudioSpeedSetting(value as number),
   sound_theme: (value) => commands.changeSoundThemeSetting(value as string),
   start_hidden: (value) => commands.changeStartHiddenSetting(value as boolean),
   autostart_enabled: (value) =>


### PR DESCRIPTION
## Summary
Add an audio speed control setting that allows users to speed up audio before transcription. This enables users with slower hardware to use larger, more accurate models without sacrificing speed.

## Context
Many users, especially in regions where high-end hardware is expensive, struggle with slow transcription times. Additionally, language learners who speak at a slow pace (like non-native speakers practicing English, like me) often have slower speech patterns. 

This feature speeds up the audio before it reaches the transcription engine, reducing processing time while maintaining reasonable accuracy. 
So user don't need to choose a smaller model, it can choose a better one and the optimization is on input (user recording).

  ## Use cases
  - Users with slower CPUs/GPUs who want to use larger models
  - Language learners who speak at a natural pace
  - Anyone who wants faster transcription
  
  ## What to test before you use it
  - [x] Test with different speed settings (1.0x - 2.0x). 
      - In my use case 1.7x works perfectly like 1x.

  ## Notes
  - Default is 1.0x (no speed change)
  - Higher speeds can reduce accuracy