### PR TITLE
feat: add per-entry post-process button and version history viewer

### DIFF
--- a/docs/plans/2026-02-18-version-history-viewer-design.md
+++ b/docs/plans/2026-02-18-version-history-viewer-design.md
@@ -1,0 +1,191 @@
+# Version History Viewer — Design Document
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Allow users to view the full timeline of post-processing enhancements for a history entry and restore any previous version.
+
+**Architecture:** Expandable accordion UI within each history card, backed by the existing `transcription_versions` table and a new `restore_version` command.
+
+**Tech Stack:** Rust/Tauri (backend command), React/TypeScript (frontend component), SQLite (existing schema)
+
+---
+
+## Context
+
+The post-process feature lets users enhance transcription text via an LLM. Each enhancement is recorded in the `transcription_versions` table with the result text, the prompt used, and a timestamp. The `get_transcription_versions` command already exists and returns versions ordered by timestamp ASC.
+
+Currently, users can toggle between "Show Original" and "Show Enhanced" but cannot see or restore intermediate versions. This design adds a version timeline with restore capability.
+
+## Design Decisions
+
+- **Original transcription is not stored as version 0.** The original lives in `transcription_text` on the history entry (immutable). The UI renders it as the bottom entry in the timeline. This avoids data duplication.
+- **Restore does not create new version rows.** It only updates `post_processed_text` and `post_process_prompt` on the history entry. The version timeline is append-only — nothing is ever deleted or modified in `transcription_versions`.
+- **"Show Original" toggle is kept.** It serves as a quick-peek shortcut for A/B comparison. The version history is for deeper exploration and restore.
+- **Versions are fetched lazily.** Only when the accordion is first expanded, not on every history page load.
+
+---
+
+## 1. Backend Changes
+
+### New Tauri Command: `restore_version`
+
+```rust
+#[tauri::command]
+#[specta::specta]
+pub async fn restore_version(
+    app: AppHandle,
+    history_manager: State<'_, Arc<HistoryManager>>,
+    entry_id: i64,
+    version_id: Option<i64>,
+) -> Result<(), String>
+```
+
+**Behavior:**
+
+- Enforces three-level feature gate (`experimental_enabled`, `post_process_enabled`, `history_post_process_enabled`). Returns `HISTORY_POST_PROCESS_DISABLED` if not met.
+- If `version_id` is `Some(id)`: looks up the version in `transcription_versions`, sets `post_processed_text` and `post_process_prompt` on the history entry to match.
+- If `version_id` is `None`: sets `post_processed_text = NULL` and `post_process_prompt = NULL` (restoring to original).
+- Returns `VERSION_NOT_FOUND` if the specified version doesn't exist.
+- Emits `history-updated` event on success.
+
+### New HistoryManager Method: `restore_version`
+
+```rust
+pub fn restore_version(&self, entry_id: i64, version_id: Option<i64>) -> Result<()>
+```
+
+- If `version_id` is `None`: `UPDATE transcription_history SET post_processed_text = NULL, post_process_prompt = NULL WHERE id = ?`
+- If `version_id` is `Some(id)`: query the version row, then update the history entry with the version's text and prompt.
+- No transaction needed — single UPDATE statement.
+
+### No New Migrations
+
+The existing schema supports everything. No changes to `transcription_versions` or `transcription_history`.
+
+---
+
+## 2. Frontend: VersionHistory Component
+
+### Location
+
+New component: `src/components/settings/history/VersionHistory.tsx`
+
+Rendered inside `HistoryEntryComponent`, between the transcription text and the audio player.
+
+### Render Conditions
+
+Only renders when `entry.post_processed_text != null` (at least one enhancement has been made).
+
+### Structure
+
+```
+[Version History Toggle Bar]
+  - Clock icon (pink accent)
+  - "Version History" label (pink accent)
+  - "(N versions)" count (muted)
+  - Chevron up/down (pink accent)
+
+[Expanded Timeline] (when open)
+  - Version N (Current) — pink border, "Active" badge, text, prompt
+  - Version N-1 — muted border, "Restore" button, text, prompt
+  - ...
+  - Original — muted border, mic icon, "Original transcription" label, "Restore" button
+```
+
+### State Management
+
+- `isExpanded: boolean` — controls accordion open/close
+- `versions: TranscriptionVersion[] | null` — null until first fetch
+- `loadingVersions: boolean` — loading state for fetch
+- Versions fetched via `commands.getTranscriptionVersions(entry.id)` on first expand
+- Cached in state; refreshed when `history-updated` event fires and accordion is open
+
+### Active Version Detection
+
+- Compare `entry.post_processed_text` against each version's `text`
+- If `entry.post_processed_text` is null, the original is active
+- The active version shows a pink "Active" pill badge instead of a "Restore" button
+
+---
+
+## 3. Restore Interaction Flow
+
+1. User clicks "Restore" on a version card
+2. Button text changes to "Confirm restore?" (pink accent, outlined button style)
+3. A 3-second timer starts
+4. **If clicked again within 3 seconds:**
+   - Calls `commands.restoreVersion(entry.id, version.id)` (or `null` for original)
+   - Shows spinner while in flight
+   - On success: `history-updated` event fires, parent refreshes, timeline updates
+   - On error: toast with i18n error message, button reverts to "Restore"
+5. **If 3 seconds pass:** button reverts to "Restore"
+
+### Post-Restore Behavior
+
+- Main transcription text at top of card updates (parent re-renders from event)
+- "Show Original" toggle reacts correctly (reads from `entry.post_processed_text`)
+- Timeline "Active" badge moves to the restored version
+- If original is restored, `post_processed_text` becomes null — but the version history toggle stays visible because versions still exist in the table. The "Show Original" toggle in the header disappears (no enhanced text to compare against).
+
+**Edge case — restore original when versions exist:** The accordion stays visible (versions still exist), but the "Show Original" toggle in the header disappears since `post_processed_text` is null. The user can still re-enhance via the sparkle button or restore a previous version from the timeline.
+
+---
+
+## 4. i18n Keys
+
+```json
+{
+  "settings": {
+    "history": {
+      "versionHistory": "Version History",
+      "versionCount": "({{count}} versions)",
+      "activeVersion": "Active",
+      "originalVersion": "Original transcription",
+      "restore": "Restore",
+      "confirmRestore": "Confirm restore?",
+      "restoreError": "Failed to restore version",
+      "versionNotFound": "Version not found"
+    }
+  }
+}
+```
+
+### Error Code Mapping
+
+| Backend Error Code              | i18n Key                                          |
+| ------------------------------- | ------------------------------------------------- |
+| `HISTORY_POST_PROCESS_DISABLED` | `settings.history.postProcessDisabled` (existing) |
+| `VERSION_NOT_FOUND`             | `settings.history.versionNotFound` (new)          |
+
+---
+
+## 5. Testing
+
+### Backend (Rust)
+
+- `restore_to_specific_version`: insert entry, create 2 versions, restore to version 1 — verify `post_processed_text` matches version 1's text
+- `restore_to_original`: insert entry, create version, restore to original (None) — verify `post_processed_text` is NULL
+- `versions_preserved_after_restore`: restore to any version — verify `transcription_versions` table is unchanged (same row count, same data)
+- `restore_nonexistent_version`: attempt to restore to a version ID that doesn't exist — verify error
+
+### Frontend (Manual)
+
+- Expand timeline on an entry with 2+ enhancements — verify all versions display with correct timestamps and prompts
+- Verify "Active" badge is on the correct version
+- Click "Restore" — verify inline confirmation appears
+- Wait 3 seconds — verify button reverts
+- Click "Restore" then "Confirm restore?" — verify card text updates, Active badge moves
+- Restore to original — verify "Show Original" toggle disappears from header, timeline stays visible
+- Re-enhance after restoring original — verify new version appears in timeline
+
+---
+
+## 6. Wireframe Reference
+
+See `version-history.pen` in the repository root for the visual design created in Pencil. Key visual elements:
+
+- Version timeline uses vertical connector lines between version cards
+- Active version: pink accent border + background, "Active" pill badge
+- Previous versions: subtle border, muted text, "Restore" outlined button
+- Original: mic icon label, same restore button pattern
+- Toggle bar: pink accent text with clock icon and chevron

--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -56,7 +56,7 @@ fn build_system_prompt(prompt_template: &str) -> String {
     prompt_template.replace("${output}", "").trim().to_string()
 }
 
-async fn post_process_transcription(settings: &AppSettings, transcription: &str) -> Option<String> {
+pub async fn post_process_transcription(settings: &AppSettings, transcription: &str) -> Option<String> {
     let provider = match settings.active_post_process_provider().cloned() {
         Some(provider) => provider,
         None => {

--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -56,7 +56,10 @@ fn build_system_prompt(prompt_template: &str) -> String {
     prompt_template.replace("${output}", "").trim().to_string()
 }
 
-pub async fn post_process_transcription(settings: &AppSettings, transcription: &str) -> Option<String> {
+pub async fn post_process_transcription(
+    settings: &AppSettings,
+    transcription: &str,
+) -> Option<String> {
     let provider = match settings.active_post_process_provider().cloned() {
         Some(provider) => provider,
         None => {

--- a/src-tauri/src/audio_toolkit/audio/recorder.rs
+++ b/src-tauri/src/audio_toolkit/audio/recorder.rs
@@ -287,12 +287,7 @@ fn run_consumer(
         }
     }
 
-    loop {
-        let raw = match sample_rx.recv() {
-            Ok(s) => s,
-            Err(_) => break, // stream closed
-        };
-
+    while let Ok(raw) = sample_rx.recv() {
         // ---------- spectrum processing ---------------------------------- //
         if let Some(buckets) = visualizer.feed(&raw) {
             if let Some(cb) = &level_cb {

--- a/src-tauri/src/audio_toolkit/text.rs
+++ b/src-tauri/src/audio_toolkit/text.rs
@@ -159,7 +159,7 @@ pub fn apply_custom_words(text: &str, custom_words: &[String], threshold: f64) -
 fn preserve_case_pattern(original: &str, replacement: &str) -> String {
     if original.chars().all(|c| c.is_uppercase()) {
         replacement.to_uppercase()
-    } else if original.chars().next().map_or(false, |c| c.is_uppercase()) {
+    } else if original.chars().next().is_some_and(|c| c.is_uppercase()) {
         let mut chars: Vec<char> = replacement.chars().collect();
         if let Some(first_char) = chars.get_mut(0) {
             *first_char = first_char.to_uppercase().next().unwrap_or(*first_char);

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -428,13 +428,12 @@ fn send_key_combo_via_wtype(paste_method: &PasteMethod) -> Result<(), String> {
 /// Send a key combination (e.g., Ctrl+V) via dotool.
 #[cfg(target_os = "linux")]
 fn send_key_combo_via_dotool(paste_method: &PasteMethod) -> Result<(), String> {
-    let command;
-    match paste_method {
-        PasteMethod::CtrlV => command = "echo key ctrl+v | dotool",
-        PasteMethod::ShiftInsert => command = "echo key shift+insert | dotool",
-        PasteMethod::CtrlShiftV => command = "echo key ctrl+shift+v | dotool",
+    let command = match paste_method {
+        PasteMethod::CtrlV => "echo key ctrl+v | dotool",
+        PasteMethod::ShiftInsert => "echo key shift+insert | dotool",
+        PasteMethod::CtrlShiftV => "echo key ctrl+shift+v | dotool",
         _ => return Err("Unsupported paste method".into()),
-    }
+    };
     use std::process::Stdio;
     let status = Command::new("sh")
         .arg("-c")

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -20,7 +20,7 @@ fn custom_sound_exists(app: &AppHandle, sound_type: &str) -> bool {
             format!("custom_{}.wav", sound_type),
             tauri::path::BaseDirectory::AppData,
         )
-        .map_or(false, |path| path.exists())
+        .is_ok_and(|path| path.exists())
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/history.rs
+++ b/src-tauri/src/commands/history.rs
@@ -153,14 +153,9 @@ pub async fn post_process_history_entry(
         })
         .unwrap_or_default();
 
-    // Save version
+    // Save version and update entry atomically
     history_manager
-        .save_version(id, &processed_text, Some(&prompt_text))
-        .map_err(|e| e.to_string())?;
-
-    // Update the entry's post_processed_text
-    history_manager
-        .update_post_processed_text(id, &processed_text, &prompt_text)
+        .save_version_and_update(id, &processed_text, &prompt_text)
         .map_err(|e| e.to_string())?;
 
     Ok(processed_text)

--- a/src-tauri/src/commands/history.rs
+++ b/src-tauri/src/commands/history.rs
@@ -1,5 +1,5 @@
 use crate::actions::post_process_transcription;
-use crate::managers::history::{HistoryEntry, HistoryManager};
+use crate::managers::history::{HistoryEntry, HistoryManager, TranscriptionVersion};
 use std::sync::Arc;
 use tauri::{AppHandle, State};
 
@@ -164,4 +164,16 @@ pub async fn post_process_history_entry(
         .map_err(|e| e.to_string())?;
 
     Ok(processed_text)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn get_transcription_versions(
+    _app: AppHandle,
+    history_manager: State<'_, Arc<HistoryManager>>,
+    entry_id: i64,
+) -> Result<Vec<TranscriptionVersion>, String> {
+    history_manager
+        .get_versions(entry_id)
+        .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/commands/history.rs
+++ b/src-tauri/src/commands/history.rs
@@ -99,3 +99,15 @@ pub async fn update_recording_retention_period(
 
     Ok(())
 }
+
+#[tauri::command]
+#[specta::specta]
+pub async fn change_history_post_process_enabled_setting(
+    app: AppHandle,
+    enabled: bool,
+) -> Result<(), String> {
+    let mut settings = crate::settings::get_settings(&app);
+    settings.history_post_process_enabled = enabled;
+    crate::settings::write_settings(&app, settings);
+    Ok(())
+}

--- a/src-tauri/src/commands/history.rs
+++ b/src-tauri/src/commands/history.rs
@@ -135,7 +135,10 @@ pub async fn post_process_history_entry(
     let settings = crate::settings::get_settings(&app);
     let processed_text = post_process_transcription(&settings, &entry.transcription_text)
         .await
-        .ok_or_else(|| "Post-processing failed. Check your provider, API key, and prompt configuration.".to_string())?;
+        .ok_or_else(|| {
+            "Post-processing failed. Check your provider, API key, and prompt configuration."
+                .to_string()
+        })?;
 
     // Get the prompt that was used
     let prompt_text = settings

--- a/src-tauri/src/commands/history.rs
+++ b/src-tauri/src/commands/history.rs
@@ -140,8 +140,7 @@ pub async fn post_process_history_entry(
         return Err("TRANSCRIPTION_EMPTY".to_string());
     }
 
-    // Get current settings and run post-processing
-    let settings = crate::settings::get_settings(&app);
+    // Run post-processing (reuses settings from feature gate check above)
     let processed_text = post_process_transcription(&settings, &entry.transcription_text)
         .await
         .ok_or_else(|| "POST_PROCESS_FAILED".to_string())?;

--- a/src-tauri/src/helpers/clamshell.rs
+++ b/src-tauri/src/helpers/clamshell.rs
@@ -63,6 +63,7 @@ pub fn is_laptop() -> Result<bool, String> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(target_os = "macos")]
     use super::*;
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -347,6 +347,7 @@ pub fn run(cli_args: CliArgs) {
         commands::history::change_history_post_process_enabled_setting,
         commands::history::post_process_history_entry,
         commands::history::get_transcription_versions,
+        commands::history::restore_version,
         helpers::clamshell::is_laptop,
     ]);
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -346,6 +346,7 @@ pub fn run(cli_args: CliArgs) {
         commands::history::update_recording_retention_period,
         commands::history::change_history_post_process_enabled_setting,
         commands::history::post_process_history_entry,
+        commands::history::get_transcription_versions,
         helpers::clamshell::is_laptop,
     ]);
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -345,6 +345,8 @@ pub fn run(cli_args: CliArgs) {
         commands::history::update_history_limit,
         commands::history::update_recording_retention_period,
         commands::history::change_history_post_process_enabled_setting,
+        commands::history::post_process_history_entry,
+        commands::history::get_transcription_versions,
         helpers::clamshell::is_laptop,
     ]);
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -346,7 +346,6 @@ pub fn run(cli_args: CliArgs) {
         commands::history::update_recording_retention_period,
         commands::history::change_history_post_process_enabled_setting,
         commands::history::post_process_history_entry,
-        commands::history::get_transcription_versions,
         helpers::clamshell::is_laptop,
     ]);
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -344,6 +344,7 @@ pub fn run(cli_args: CliArgs) {
         commands::history::delete_history_entry,
         commands::history::update_history_limit,
         commands::history::update_recording_retention_period,
+        commands::history::change_history_post_process_enabled_setting,
         helpers::clamshell::is_laptop,
     ]);
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -135,7 +135,7 @@ fn initialize_core_logic(app_handle: &AppHandle) {
     // This matches the pattern used for Enigo initialization.
 
     #[cfg(unix)]
-    let signals = Signals::new(&[SIGUSR1, SIGUSR2]).unwrap();
+    let signals = Signals::new([SIGUSR1, SIGUSR2]).unwrap();
     // Set up signal handlers for toggling transcription
     #[cfg(unix)]
     signal_handle::setup_signal_handler(app_handle.clone(), signals);
@@ -223,7 +223,7 @@ fn initialize_core_logic(app_handle: &AppHandle) {
 
     // Get the autostart manager and configure based on user setting
     let autostart_manager = app_handle.autolaunch();
-    let settings = settings::get_settings(&app_handle);
+    let settings = settings::get_settings(app_handle);
 
     if settings.autostart_enabled {
         // Enable autostart if user has opted in
@@ -358,7 +358,7 @@ pub fn run(cli_args: CliArgs) {
         )
         .expect("Failed to export typescript bindings");
 
-    let mut builder = tauri::Builder::default()
+    let builder = tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(
             LogBuilder::new()
@@ -416,7 +416,7 @@ pub fn run(cli_args: CliArgs) {
         ))
         .manage(cli_args.clone())
         .setup(move |app| {
-            let mut settings = get_settings(&app.handle());
+            let mut settings = get_settings(app.handle());
 
             // CLI --debug flag overrides debug_mode and log level (runtime-only, not persisted)
             if cli_args.debug {
@@ -452,7 +452,7 @@ pub fn run(cli_args: CliArgs) {
         })
         .on_window_event(|window, event| match event {
             tauri::WindowEvent::CloseRequested { api, .. } => {
-                let settings = get_settings(&window.app_handle());
+                let settings = get_settings(window.app_handle());
                 let cli = window.app_handle().state::<CliArgs>();
                 // If tray icon is hidden (via setting or --no-tray flag), quit the app
                 if !settings.show_tray_icon || cli.no_tray {
@@ -474,7 +474,7 @@ pub fn run(cli_args: CliArgs) {
             tauri::WindowEvent::ThemeChanged(theme) => {
                 log::info!("Theme changed to: {:?}", theme);
                 // Update tray icon to match new theme, maintaining idle state
-                utils::change_tray_icon(&window.app_handle(), utils::TrayIconState::Idle);
+                utils::change_tray_icon(window.app_handle(), utils::TrayIconState::Idle);
             }
             _ => {}
         })

--- a/src-tauri/src/managers/history.rs
+++ b/src-tauri/src/managers/history.rs
@@ -257,16 +257,16 @@ impl HistoryManager {
         match retention_period {
             crate::settings::RecordingRetentionPeriod::Never => {
                 // Don't delete anything
-                return Ok(());
+                Ok(())
             }
             crate::settings::RecordingRetentionPeriod::PreserveLimit => {
                 // Use the old count-based logic with history_limit
                 let limit = crate::settings::get_history_limit(&self.app_handle);
-                return self.cleanup_by_count(limit);
+                self.cleanup_by_count(limit)
             }
             _ => {
                 // Use time-based logic
-                return self.cleanup_by_time(retention_period);
+                self.cleanup_by_time(retention_period)
             }
         }
     }

--- a/src-tauri/src/managers/history.rs
+++ b/src-tauri/src/managers/history.rs
@@ -102,6 +102,7 @@ impl HistoryManager {
         info!("Initializing database at {:?}", self.db_path);
 
         let mut conn = Connection::open(&self.db_path)?;
+        conn.execute_batch("PRAGMA foreign_keys = ON;")?;
 
         // Handle migration from tauri-plugin-sql to rusqlite_migration
         // tauri-plugin-sql used _sqlx_migrations table, rusqlite_migration uses user_version pragma

--- a/src-tauri/src/managers/model.rs
+++ b/src-tauri/src/managers/model.rs
@@ -438,7 +438,7 @@ impl ModelManager {
 
         for filename in &bundled_models {
             let bundled_path = self.app_handle.path().resolve(
-                &format!("resources/models/{}", filename),
+                format!("resources/models/{}", filename),
                 tauri::path::BaseDirectory::Resource,
             );
 
@@ -834,15 +834,12 @@ impl ModelManager {
                 return Ok(());
             }
 
-            let chunk = chunk.map_err(|e| {
+            let chunk = chunk.inspect_err(|_| {
                 // Mark as not downloading on error
-                {
-                    let mut models = self.available_models.lock().unwrap();
-                    if let Some(model) = models.get_mut(model_id) {
-                        model.is_downloading = false;
-                    }
+                let mut models = self.available_models.lock().unwrap();
+                if let Some(model) = models.get_mut(model_id) {
+                    model.is_downloading = false;
                 }
-                e
             })?;
 
             file.write_all(&chunk)?;

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -491,7 +491,6 @@ impl TranscriptionManager {
                         LoadedEngine::Parakeet(parakeet_engine) => {
                             let params = ParakeetInferenceParams {
                                 timestamp_granularity: TimestampGranularity::Segment,
-                                ..Default::default()
                             };
                             parakeet_engine
                                 .transcribe_samples(audio, Some(params))

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -113,9 +113,10 @@ pub enum OverlayPosition {
     Bottom,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Type)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq, Eq, Type)]
 #[serde(rename_all = "snake_case")]
 pub enum ModelUnloadTimeout {
+    #[default]
     Never,
     Immediately,
     Min2,
@@ -136,9 +137,10 @@ pub enum PasteMethod {
     CtrlShiftV,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Type)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq, Eq, Type)]
 #[serde(rename_all = "snake_case")]
 pub enum ClipboardHandling {
+    #[default]
     DontModify,
     CopyToClipboard,
 }
@@ -179,12 +181,6 @@ impl Default for KeyboardImplementation {
     }
 }
 
-impl Default for ModelUnloadTimeout {
-    fn default() -> Self {
-        ModelUnloadTimeout::Never
-    }
-}
-
 impl Default for PasteMethod {
     fn default() -> Self {
         // Default to CtrlV for macOS and Windows, Direct for Linux
@@ -195,17 +191,12 @@ impl Default for PasteMethod {
     }
 }
 
-impl Default for ClipboardHandling {
-    fn default() -> Self {
-        ClipboardHandling::DontModify
-    }
-}
-
 impl Default for AutoSubmitKey {
     fn default() -> Self {
         AutoSubmitKey::Enter
     }
 }
+
 
 impl ModelUnloadTimeout {
     pub fn to_minutes(self) -> Option<u64> {
@@ -248,11 +239,11 @@ impl SoundTheme {
         }
     }
 
-    pub fn to_start_path(&self) -> String {
+    pub fn to_start_path(self) -> String {
         format!("resources/{}_start.wav", self.as_str())
     }
 
-    pub fn to_stop_path(&self) -> String {
+    pub fn to_stop_path(self) -> String {
         format!("resources/{}_stop.wav", self.as_str())
     }
 }
@@ -758,9 +749,10 @@ pub fn load_or_create_app_settings(app: &AppHandle) -> AppSettings {
 
                 // Merge default bindings into existing settings
                 for (key, value) in default_settings.bindings {
-                    if !settings.bindings.contains_key(&key) {
-                        debug!("Adding missing binding: {}", key);
-                        settings.bindings.insert(key, value);
+                    use std::collections::hash_map::Entry;
+                    if let Entry::Vacant(entry) = settings.bindings.entry(key) {
+                        debug!("Adding missing binding: {}", entry.key());
+                        entry.insert(value);
                         updated = true;
                     }
                 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -351,6 +351,8 @@ pub struct AppSettings {
     #[serde(default)]
     pub experimental_enabled: bool,
     #[serde(default)]
+    pub history_post_process_enabled: bool,
+    #[serde(default)]
     pub keyboard_implementation: KeyboardImplementation,
     #[serde(default = "default_show_tray_icon")]
     pub show_tray_icon: bool,
@@ -709,6 +711,7 @@ pub fn get_default_settings() -> AppSettings {
         append_trailing_space: false,
         app_language: default_app_language(),
         experimental_enabled: false,
+        history_post_process_enabled: false,
         keyboard_implementation: KeyboardImplementation::default(),
         show_tray_icon: default_show_tray_icon(),
         paste_delay_ms: default_paste_delay_ms(),

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -145,9 +145,10 @@ pub enum ClipboardHandling {
     CopyToClipboard,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Type)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Type, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum AutoSubmitKey {
+    #[default]
     Enter,
     CtrlEnter,
     CmdEnter,
@@ -190,13 +191,6 @@ impl Default for PasteMethod {
         return PasteMethod::CtrlV;
     }
 }
-
-impl Default for AutoSubmitKey {
-    fn default() -> Self {
-        AutoSubmitKey::Enter
-    }
-}
-
 
 impl ModelUnloadTimeout {
     pub fn to_minutes(self) -> Option<u64> {
@@ -248,21 +242,16 @@ impl SoundTheme {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Type)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Type, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum TypingTool {
+    #[default]
     Auto,
     Wtype,
     Kwtype,
     Dotool,
     Ydotool,
     Xdotool,
-}
-
-impl Default for TypingTool {
-    fn default() -> Self {
-        TypingTool::Auto
-    }
 }
 
 /* still handy for composing the initial JSON in the store ------------- */

--- a/src-tauri/src/shortcut/handy_keys.rs
+++ b/src-tauri/src/shortcut/handy_keys.rs
@@ -463,7 +463,6 @@ pub fn register_cancel_shortcut(app: &AppHandle) {
     #[cfg(target_os = "linux")]
     {
         let _ = app;
-        return;
     }
 
     #[cfg(not(target_os = "linux"))]
@@ -486,7 +485,6 @@ pub fn unregister_cancel_shortcut(app: &AppHandle) {
     #[cfg(target_os = "linux")]
     {
         let _ = app;
-        return;
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -281,14 +281,12 @@ pub fn change_keyboard_implementation_setting(
     settings::write_settings(&app, settings);
 
     // Initialize new implementation if needed (HandyKeys needs state)
-    if new_impl == KeyboardImplementation::HandyKeys {
-        if initialize_handy_keys_with_rollback(&app)? {
-            // Shortcuts already registered during init
-            return Ok(ImplementationChangeResult {
-                success: true,
-                reset_bindings: vec![],
-            });
-        }
+    if new_impl == KeyboardImplementation::HandyKeys && initialize_handy_keys_with_rollback(&app)? {
+        // Shortcuts already registered during init
+        return Ok(ImplementationChangeResult {
+            success: true,
+            reset_bindings: vec![],
+        });
     }
 
     // Register all shortcuts with new implementation, resetting invalid ones

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -22,7 +22,7 @@ use tauri_plugin_autostart::ManagerExt;
 use crate::settings::{
     self, get_settings, AutoSubmitKey, ClipboardHandling, KeyboardImplementation, LLMPrompt,
     OverlayPosition, PasteMethod, ShortcutBinding, SoundTheme, TypingTool,
-    APPLE_INTELLIGENCE_DEFAULT_MODEL_ID, APPLE_INTELLIGENCE_PROVIDER_ID,
+    APPLE_INTELLIGENCE_PROVIDER_ID,
 };
 use crate::tray;
 
@@ -965,7 +965,9 @@ pub async fn fetch_post_process_models(
     if provider.id == APPLE_INTELLIGENCE_PROVIDER_ID {
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
         {
-            return Ok(vec![APPLE_INTELLIGENCE_DEFAULT_MODEL_ID.to_string()]);
+            return Ok(vec![
+                crate::settings::APPLE_INTELLIGENCE_DEFAULT_MODEL_ID.to_string()
+            ]);
         }
 
         #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]

--- a/src-tauri/src/shortcut/tauri_impl.rs
+++ b/src-tauri/src/shortcut/tauri_impl.rs
@@ -7,7 +7,7 @@ use log::{error, warn};
 use tauri::AppHandle;
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutState};
 
-use crate::settings::{self, get_settings, ShortcutBinding};
+use crate::settings::{self, ShortcutBinding};
 
 use super::handler::handle_shortcut_event;
 
@@ -158,14 +158,17 @@ pub fn register_cancel_shortcut(app: &AppHandle) {
     #[cfg(target_os = "linux")]
     {
         let _ = app;
-        return;
     }
 
     #[cfg(not(target_os = "linux"))]
     {
         let app_clone = app.clone();
         tauri::async_runtime::spawn(async move {
-            if let Some(cancel_binding) = get_settings(&app_clone).bindings.get("cancel").cloned() {
+            if let Some(cancel_binding) = settings::get_settings(&app_clone)
+                .bindings
+                .get("cancel")
+                .cloned()
+            {
                 if let Err(e) = register_shortcut(&app_clone, cancel_binding) {
                     error!("Failed to register cancel shortcut: {}", e);
                 }
@@ -180,7 +183,6 @@ pub fn unregister_cancel_shortcut(app: &AppHandle) {
     #[cfg(target_os = "linux")]
     {
         let _ = app;
-        return;
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/src-tauri/src/transcription_coordinator.rs
+++ b/src-tauri/src/transcription_coordinator.rs
@@ -62,7 +62,7 @@ impl TranscriptionCoordinator {
                             // Releases always pass through for push-to-talk.
                             if is_pressed {
                                 let now = Instant::now();
-                                if last_press.map_or(false, |t| now.duration_since(t) < DEBOUNCE) {
+                                if last_press.is_some_and(|t| now.duration_since(t) < DEBOUNCE) {
                                     debug!("Debounced press for '{binding_id}'");
                                     continue;
                                 }
@@ -166,7 +166,7 @@ fn start(app: &AppHandle, stage: &mut Stage, binding_id: &str, hotkey_string: &s
     action.start(app, binding_id, hotkey_string);
     if app
         .try_state::<Arc<AudioRecordingManager>>()
-        .map_or(false, |a| a.is_recording())
+        .is_some_and(|a| a.is_recording())
     {
         *stage = Stage::Recording(binding_id.to_string());
     } else {

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -233,6 +233,7 @@ mod tests {
             transcription_text: transcription.to_string(),
             post_processed_text: post_processed.map(|text| text.to_string()),
             post_process_prompt: None,
+            version_count: 0,
         }
     }
 

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -730,8 +730,7 @@ async getTranscriptionVersions(entryId: number) : Promise<Result<TranscriptionVe
 },
 async restoreVersion(entryId: number, versionId: number | null) : Promise<Result<null, string>> {
     try {
-    await TAURI_INVOKE("restore_version", { entryId, versionId });
-    return { status: "ok", data: null };
+    return { status: "ok", data: await TAURI_INVOKE("restore_version", { entryId, versionId }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -768,7 +767,7 @@ export type BindingResponse = { success: boolean; binding: ShortcutBinding | nul
 export type ClipboardHandling = "dont_modify" | "copy_to_clipboard"
 export type CustomSounds = { start: boolean; stop: boolean }
 export type EngineType = "Whisper" | "Parakeet" | "Moonshine" | "MoonshineStreaming" | "SenseVoice"
-export type HistoryEntry = { id: number; file_name: string; timestamp: number; saved: boolean; title: string; transcription_text: string; post_processed_text: string | null; post_process_prompt: string | null }
+export type HistoryEntry = { id: number; file_name: string; timestamp: number; saved: boolean; title: string; transcription_text: string; post_processed_text: string | null; post_process_prompt: string | null; version_count: number }
 /**
  * Result of changing keyboard implementation
  */

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -720,14 +720,6 @@ async postProcessHistoryEntry(id: number) : Promise<Result<string, string>> {
     else return { status: "error", error: e  as any };
 }
 },
-async getTranscriptionVersions(entryId: number) : Promise<Result<TranscriptionVersion[], string>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("get_transcription_versions", { entryId }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
 /**
  * Checks if the Mac is a laptop by detecting battery presence
  * 

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -720,6 +720,14 @@ async postProcessHistoryEntry(id: number) : Promise<Result<string, string>> {
     else return { status: "error", error: e  as any };
 }
 },
+async getTranscriptionVersions(entryId: number) : Promise<Result<TranscriptionVersion[], string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_transcription_versions", { entryId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 /**
  * Checks if the Mac is a laptop by detecting battery presence
  * 

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -728,11 +728,18 @@ async getTranscriptionVersions(entryId: number) : Promise<Result<TranscriptionVe
     else return { status: "error", error: e  as any };
 }
 },
+async restoreVersion(entryId: number, versionId: number | null) : Promise<Result<null, string>> {
+    try {
+    await TAURI_INVOKE("restore_version", { entryId, versionId });
+    return { status: "ok", data: null };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 /**
- * Checks if the Mac is a laptop by detecting battery presence
- * 
- * This uses pmset to check for battery information.
- * Returns true if a battery is detected (laptop), false otherwise (desktop)
+ * Stub implementation for non-macOS platforms
+ * Always returns false since laptop detection is macOS-specific
  */
 async isLaptop() : Promise<Result<boolean, string>> {
     try {

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -704,6 +704,30 @@ async updateRecordingRetentionPeriod(period: string) : Promise<Result<null, stri
     else return { status: "error", error: e  as any };
 }
 },
+async changeHistoryPostProcessEnabledSetting(enabled: boolean) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("change_history_post_process_enabled_setting", { enabled }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async postProcessHistoryEntry(id: number) : Promise<Result<string, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("post_process_history_entry", { id }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async getTranscriptionVersions(entryId: number) : Promise<Result<TranscriptionVersion[], string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_transcription_versions", { entryId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 /**
  * Checks if the Mac is a laptop by detecting battery presence
  * 
@@ -730,7 +754,7 @@ async isLaptop() : Promise<Result<boolean, string>> {
 
 /** user-defined types **/
 
-export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk: boolean; audio_feedback: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; selected_model?: string; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: Partial<{ [key in string]: string }>; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; experimental_enabled?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool }
+export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk: boolean; audio_feedback: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; selected_model?: string; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: Partial<{ [key in string]: string }>; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; experimental_enabled?: boolean; history_post_process_enabled?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool }
 export type AudioDevice = { index: string; name: string; is_default: boolean }
 export type AutoSubmitKey = "enter" | "ctrl_enter" | "cmd_enter"
 export type BindingResponse = { success: boolean; binding: ShortcutBinding | null; error: string | null }
@@ -758,6 +782,7 @@ export type PostProcessProvider = { id: string; label: string; base_url: string;
 export type RecordingRetentionPeriod = "never" | "preserve_limit" | "days_3" | "weeks_2" | "months_3"
 export type ShortcutBinding = { id: string; name: string; description: string; default_binding: string; current_binding: string }
 export type SoundTheme = "marimba" | "pop" | "custom"
+export type TranscriptionVersion = { id: number; history_entry_id: number; text: string; prompt: string | null; timestamp: number }
 export type TypingTool = "auto" | "wtype" | "kwtype" | "dotool" | "ydotool" | "xdotool"
 
 /** tauri-specta globals **/

--- a/src/components/settings/HistoryPostProcessToggle.tsx
+++ b/src/components/settings/HistoryPostProcessToggle.tsx
@@ -18,8 +18,8 @@ export const HistoryPostProcessToggle: React.FC<HistoryPostProcessToggleProps> =
     return (
       <ToggleSwitch
         checked={enabled}
-        onChange={(enabled) =>
-          updateSetting("history_post_process_enabled", enabled)
+        onChange={(value) =>
+          updateSetting("history_post_process_enabled", value)
         }
         isUpdating={isUpdating("history_post_process_enabled")}
         label={t("settings.debug.historyPostProcessToggle.label")}
@@ -29,3 +29,5 @@ export const HistoryPostProcessToggle: React.FC<HistoryPostProcessToggleProps> =
       />
     );
   });
+
+HistoryPostProcessToggle.displayName = "HistoryPostProcessToggle";

--- a/src/components/settings/HistoryPostProcessToggle.tsx
+++ b/src/components/settings/HistoryPostProcessToggle.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { ToggleSwitch } from "../ui/ToggleSwitch";
+import { useSettings } from "../../hooks/useSettings";
+
+interface HistoryPostProcessToggleProps {
+  descriptionMode?: "inline" | "tooltip";
+  grouped?: boolean;
+}
+
+export const HistoryPostProcessToggle: React.FC<HistoryPostProcessToggleProps> =
+  React.memo(({ descriptionMode = "tooltip", grouped = false }) => {
+    const { t } = useTranslation();
+    const { getSetting, updateSetting, isUpdating } = useSettings();
+
+    const enabled = getSetting("history_post_process_enabled") || false;
+
+    return (
+      <ToggleSwitch
+        checked={enabled}
+        onChange={(enabled) =>
+          updateSetting("history_post_process_enabled", enabled)
+        }
+        isUpdating={isUpdating("history_post_process_enabled")}
+        label={t("settings.debug.historyPostProcessToggle.label")}
+        description={t("settings.debug.historyPostProcessToggle.description")}
+        descriptionMode={descriptionMode}
+        grouped={grouped}
+      />
+    );
+  });

--- a/src/components/settings/advanced/AdvancedSettings.tsx
+++ b/src/components/settings/advanced/AdvancedSettings.tsx
@@ -12,6 +12,7 @@ import { TypingToolSetting } from "../TypingTool";
 import { ClipboardHandlingSetting } from "../ClipboardHandling";
 import { AutoSubmit } from "../AutoSubmit";
 import { PostProcessingToggle } from "../PostProcessingToggle";
+import { HistoryPostProcessToggle } from "../HistoryPostProcessToggle";
 import { AppendTrailingSpace } from "../AppendTrailingSpace";
 import { HistoryLimit } from "../HistoryLimit";
 import { RecordingRetentionPeriodSelector } from "../RecordingRetentionPeriod";
@@ -23,6 +24,7 @@ export const AdvancedSettings: React.FC = () => {
   const { t } = useTranslation();
   const { getSetting } = useSettings();
   const experimentalEnabled = getSetting("experimental_enabled") || false;
+  const postProcessEnabled = getSetting("post_process_enabled") || false;
 
   return (
     <div className="max-w-3xl w-full mx-auto space-y-6">
@@ -58,6 +60,12 @@ export const AdvancedSettings: React.FC = () => {
       {experimentalEnabled && (
         <SettingsGroup title={t("settings.advanced.groups.experimental")}>
           <PostProcessingToggle descriptionMode="tooltip" grouped={true} />
+          {postProcessEnabled && (
+            <HistoryPostProcessToggle
+              descriptionMode="tooltip"
+              grouped={true}
+            />
+          )}
           <KeyboardImplementationSelector
             descriptionMode="tooltip"
             grouped={true}

--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -100,14 +100,6 @@ export const HistorySettings: React.FC = () => {
     }
   };
 
-  const copyToClipboard = async (text: string) => {
-    try {
-      await navigator.clipboard.writeText(text);
-    } catch (error) {
-      console.error("Failed to copy to clipboard:", error);
-    }
-  };
-
   const getAudioUrl = useCallback(
     async (fileName: string) => {
       try {

--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -19,6 +19,7 @@ import { formatDateTime } from "@/utils/dateFormat";
 import { useOsType } from "@/hooks/useOsType";
 import { toast } from "sonner";
 import { useSettings } from "@/hooks/useSettings";
+import { VersionHistory } from "./VersionHistory";
 
 interface OpenRecordingsButtonProps {
   onClick: () => void;
@@ -392,6 +393,7 @@ const HistoryEntryComponent: React.FC<HistoryEntryProps> = ({
       <p className="italic text-text/90 text-sm pb-2 select-text cursor-text">
         {displayText}
       </p>
+      {hasEnhancedText && <VersionHistory entry={entry} />}
       <AudioPlayer onLoadRequest={handleLoadAudio} className="w-full" />
     </div>
   );

--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -2,7 +2,15 @@ import React, { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { AudioPlayer } from "../../ui/AudioPlayer";
 import { Button } from "../../ui/Button";
-import { Copy, Star, Check, Trash2, FolderOpen, Sparkles, Loader2 } from "lucide-react";
+import {
+  Copy,
+  Star,
+  Check,
+  Trash2,
+  FolderOpen,
+  Sparkles,
+  Loader2,
+} from "lucide-react";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { readFile } from "@tauri-apps/plugin-fs";

--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -53,14 +53,14 @@ export const HistorySettings: React.FC = () => {
     (getSetting("post_process_enabled") || false) &&
     (getSetting("history_post_process_enabled") || false);
 
-  const postProcessConfigured = useMemo(() => {
-    const providerId = getSetting("post_process_provider_id");
-    const apiKeys = getSetting("post_process_api_keys");
-    const selectedPromptId = getSetting("post_process_selected_prompt_id");
-    return (
-      !!providerId && !!(apiKeys && apiKeys[providerId]) && !!selectedPromptId
-    );
-  }, [getSetting]);
+  const providerId = getSetting("post_process_provider_id");
+  const apiKeys = getSetting("post_process_api_keys");
+  const selectedPromptId = getSetting("post_process_selected_prompt_id");
+  const postProcessConfigured = useMemo(
+    () =>
+      !!providerId && !!(apiKeys && apiKeys[providerId]) && !!selectedPromptId,
+    [providerId, apiKeys, selectedPromptId],
+  );
 
   const loadHistoryEntries = useCallback(async () => {
     try {

--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -54,12 +54,10 @@ export const HistorySettings: React.FC = () => {
     (getSetting("history_post_process_enabled") || false);
 
   const providerId = getSetting("post_process_provider_id");
-  const apiKeys = getSetting("post_process_api_keys");
   const selectedPromptId = getSetting("post_process_selected_prompt_id");
   const postProcessConfigured = useMemo(
-    () =>
-      !!providerId && !!(apiKeys && apiKeys[providerId]) && !!selectedPromptId,
-    [providerId, apiKeys, selectedPromptId],
+    () => !!providerId && !!selectedPromptId,
+    [providerId, selectedPromptId],
   );
 
   const loadHistoryEntries = useCallback(async () => {
@@ -313,6 +311,16 @@ const HistoryEntryComponent: React.FC<HistoryEntryProps> = ({
     <div className="px-4 py-2 pb-5 flex flex-col gap-3">
       <div className="flex justify-between items-center">
         <p className="text-sm font-medium">{formattedDate}</p>
+        {hasEnhancedText && (
+          <button
+            onClick={() => setShowOriginal(!showOriginal)}
+            className="text-xs px-2 py-1 border border-text/20 rounded text-text/50 hover:text-logo-primary hover:border-logo-primary transition-colors cursor-pointer"
+          >
+            {showOriginal
+              ? t("settings.history.showEnhanced")
+              : t("settings.history.showOriginal")}
+          </button>
+        )}
         <div className="flex items-center gap-1">
           {showPostProcess && (
             <button
@@ -322,7 +330,7 @@ const HistoryEntryComponent: React.FC<HistoryEntryProps> = ({
                 !postProcessConfigured ||
                 entry.transcription_text.trim().length === 0
               }
-              className="text-text/50 hover:text-logo-primary transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed"
+              className="p-2 rounded-md text-text/50 hover:text-logo-primary transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed"
               title={
                 postProcessConfigured
                   ? t("settings.history.postProcess")
@@ -384,16 +392,6 @@ const HistoryEntryComponent: React.FC<HistoryEntryProps> = ({
       <p className="italic text-text/90 text-sm pb-2 select-text cursor-text">
         {displayText}
       </p>
-      {hasEnhancedText && (
-        <button
-          onClick={() => setShowOriginal(!showOriginal)}
-          className="text-xs text-text/50 hover:text-logo-primary transition-colors cursor-pointer self-start"
-        >
-          {showOriginal
-            ? t("settings.history.showEnhanced")
-            : t("settings.history.showOriginal")}
-        </button>
-      )}
       <AudioPlayer onLoadRequest={handleLoadAudio} className="w-full" />
     </div>
   );

--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -393,7 +393,7 @@ const HistoryEntryComponent: React.FC<HistoryEntryProps> = ({
       <p className="italic text-text/90 text-sm pb-2 select-text cursor-text">
         {displayText}
       </p>
-      {hasEnhancedText && <VersionHistory entry={entry} />}
+      {entry.version_count > 0 && <VersionHistory entry={entry} />}
       <AudioPlayer onLoadRequest={handleLoadAudio} className="w-full" />
     </div>
   );

--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -339,7 +339,13 @@ const HistoryEntryComponent: React.FC<HistoryEntryProps> = ({
           <button
             onClick={handleCopyText}
             className="text-text/50 hover:text-logo-primary hover:border-logo-primary transition-colors cursor-pointer"
-            title={t("settings.history.copyToClipboard")}
+            title={
+              hasEnhancedText
+                ? showOriginal
+                  ? t("settings.history.copyOriginal")
+                  : t("settings.history.copyEnhanced")
+                : t("settings.history.copyToClipboard")
+            }
           >
             {showCopied ? (
               <Check width={16} height={16} />

--- a/src/components/settings/history/VersionHistory.tsx
+++ b/src/components/settings/history/VersionHistory.tsx
@@ -185,6 +185,43 @@ export const VersionHistory: React.FC<VersionHistoryProps> = ({ entry }) => {
 
 VersionHistory.displayName = "VersionHistory";
 
+interface ExpandableTextProps {
+  text: string;
+  limit: number;
+  className?: string;
+}
+
+const ExpandableText: React.FC<ExpandableTextProps> = ({
+  text,
+  limit,
+  className,
+}) => {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+  const needsTruncation = text.length > limit;
+
+  return (
+    <span className={className}>
+      {needsTruncation && !expanded ? `${text.substring(0, limit)}...` : text}
+      {needsTruncation && (
+        <>
+          {" "}
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="text-logo-primary hover:text-logo-primary/80 transition-colors cursor-pointer"
+          >
+            {expanded
+              ? t("settings.history.showLess")
+              : t("settings.history.showMore")}
+          </button>
+        </>
+      )}
+    </span>
+  );
+};
+
+ExpandableText.displayName = "ExpandableText";
+
 const VersionConnector: React.FC = () => (
   <div className="flex pl-4">
     <div className="w-0.5 h-4 bg-mid-gray/20" />
@@ -245,18 +282,16 @@ const VersionCard: React.FC<VersionCardProps> = ({
       <p
         className={`text-xs leading-relaxed mb-2 ${isActive ? "text-text/80" : "text-text/50"}`}
       >
-        {version.text.length > 200
-          ? `${version.text.substring(0, 200)}...`
-          : version.text}
+        <ExpandableText text={version.text} limit={200} />
       </p>
       {version.prompt && (
         <div className="flex items-center gap-1">
           <Sparkles width={10} height={10} className="text-text/30" />
-          <span className="text-[11px] text-text/30">
-            {version.prompt.length > 60
-              ? `${version.prompt.substring(0, 60)}...`
-              : version.prompt}
-          </span>
+          <ExpandableText
+            text={version.prompt}
+            limit={60}
+            className="text-[11px] text-text/30"
+          />
         </div>
       )}
     </div>
@@ -313,9 +348,7 @@ const OriginalCard: React.FC<OriginalCardProps> = ({
       <p
         className={`text-xs leading-relaxed mb-2 ${isActive ? "text-text/80" : "text-text/50"}`}
       >
-        {entry.transcription_text.length > 200
-          ? `${entry.transcription_text.substring(0, 200)}...`
-          : entry.transcription_text}
+        <ExpandableText text={entry.transcription_text} limit={200} />
       </p>
       <div className="flex items-center gap-1">
         <Mic width={10} height={10} className="text-text/30" />

--- a/src/components/settings/history/VersionHistory.tsx
+++ b/src/components/settings/history/VersionHistory.tsx
@@ -285,12 +285,17 @@ const VersionCard: React.FC<VersionCardProps> = ({
         <ExpandableText text={version.text} limit={200} />
       </p>
       {version.prompt && (
-        <div className="flex items-center gap-1">
-          <Sparkles width={10} height={10} className="text-text/30" />
+        <div className="rounded bg-text/5 border border-text/10 px-2.5 py-2">
+          <div className="flex items-center gap-1 mb-1">
+            <Sparkles width={10} height={10} className="text-text/30" />
+            <span className="text-[10px] font-medium text-text/30 uppercase tracking-wide">
+              {t("settings.history.promptLabel")}
+            </span>
+          </div>
           <ExpandableText
             text={version.prompt}
-            limit={60}
-            className="text-[11px] text-text/30"
+            limit={80}
+            className="text-[11px] leading-relaxed text-text/40 italic"
           />
         </div>
       )}

--- a/src/components/settings/history/VersionHistory.tsx
+++ b/src/components/settings/history/VersionHistory.tsx
@@ -286,7 +286,11 @@ const VersionCard: React.FC<VersionCardProps> = ({
       </p>
       {version.prompt && (
         <div className="flex items-start gap-1">
-          <Sparkles width={10} height={10} className="text-text/30 mt-1 shrink-0" />
+          <Sparkles
+            width={10}
+            height={10}
+            className="text-text/30 mt-1 shrink-0"
+          />
           <ExpandableText
             text={version.prompt}
             limit={80}

--- a/src/components/settings/history/VersionHistory.tsx
+++ b/src/components/settings/history/VersionHistory.tsx
@@ -295,7 +295,7 @@ const VersionCard: React.FC<VersionCardProps> = ({
           <ExpandableText
             text={version.prompt}
             limit={80}
-            className="text-[11px] leading-relaxed text-text/40 italic"
+            className="text-[11px] leading-relaxed text-text/40 italic whitespace-pre-wrap"
           />
         </div>
       )}

--- a/src/components/settings/history/VersionHistory.tsx
+++ b/src/components/settings/history/VersionHistory.tsx
@@ -1,0 +1,375 @@
+import React, { useState, useCallback, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  ChevronUp,
+  ChevronDown,
+  History,
+  Sparkles,
+  Mic,
+  RotateCcw,
+  Loader2,
+} from "lucide-react";
+import {
+  commands,
+  type TranscriptionVersion,
+  type HistoryEntry,
+} from "@/bindings";
+import { formatDateTime } from "@/utils/dateFormat";
+import { toast } from "sonner";
+import { listen } from "@tauri-apps/api/event";
+
+interface VersionHistoryProps {
+  entry: HistoryEntry;
+}
+
+export const VersionHistory: React.FC<VersionHistoryProps> = ({ entry }) => {
+  const { t, i18n } = useTranslation();
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [versions, setVersions] = useState<TranscriptionVersion[] | null>(null);
+  const [loadingVersions, setLoadingVersions] = useState(false);
+  const hasFetched = useRef(false);
+
+  const fetchVersions = useCallback(async () => {
+    setLoadingVersions(true);
+    try {
+      const result = await commands.getTranscriptionVersions(entry.id);
+      if (result.status === "ok") {
+        setVersions(result.data);
+      }
+    } catch (error) {
+      console.error("Failed to fetch versions:", error);
+    } finally {
+      setLoadingVersions(false);
+    }
+  }, [entry.id]);
+
+  // Fetch on first expand
+  const handleToggle = useCallback(() => {
+    const willExpand = !isExpanded;
+    setIsExpanded(willExpand);
+    if (willExpand && !hasFetched.current) {
+      hasFetched.current = true;
+      fetchVersions();
+    }
+  }, [isExpanded, fetchVersions]);
+
+  // Refresh versions when history updates (if expanded)
+  useEffect(() => {
+    if (!isExpanded) return;
+
+    const setupListener = async () => {
+      const unlisten = await listen("history-updated", () => {
+        fetchVersions();
+      });
+      return unlisten;
+    };
+
+    const unlistenPromise = setupListener();
+    return () => {
+      unlistenPromise.then((unlisten) => {
+        if (unlisten) unlisten();
+      });
+    };
+  }, [isExpanded, fetchVersions]);
+
+  const versionCount = versions ? versions.length + 1 : null; // +1 for original
+  const isOriginalActive = entry.post_processed_text == null;
+
+  return (
+    <div className="border-t border-mid-gray/20">
+      {/* Toggle Bar */}
+      <button
+        onClick={handleToggle}
+        className="w-full flex items-center gap-2 px-4 py-2 text-logo-primary hover:bg-logo-primary/5 transition-colors cursor-pointer"
+      >
+        <History width={14} height={14} />
+        <span className="text-xs font-medium">
+          {t("settings.history.versionHistory")}
+        </span>
+        {versionCount != null && (
+          <span className="text-xs text-text/50">
+            {t("settings.history.versionCount", { count: versionCount })}
+          </span>
+        )}
+        <span className="ml-auto">
+          {isExpanded ? (
+            <ChevronUp width={14} height={14} />
+          ) : (
+            <ChevronDown width={14} height={14} />
+          )}
+        </span>
+      </button>
+
+      {/* Expanded Timeline */}
+      {isExpanded && (
+        <div className="px-4 pb-3">
+          {loadingVersions && versions == null ? (
+            <div className="flex items-center justify-center py-4 text-text/50">
+              <Loader2 width={16} height={16} className="animate-spin" />
+            </div>
+          ) : versions != null ? (
+            <div className="flex flex-col">
+              {/* Versions in reverse chronological order (newest first) */}
+              {[...versions].reverse().map((version, index) => {
+                const isActive = entry.post_processed_text === version.text;
+                const isFirst = index === 0;
+                return (
+                  <div key={version.id}>
+                    {index > 0 && <VersionConnector />}
+                    <VersionCard
+                      version={version}
+                      entryId={entry.id}
+                      isActive={isActive}
+                      isLatest={isFirst}
+                      language={i18n.language}
+                    />
+                  </div>
+                );
+              })}
+              {/* Original transcription */}
+              {versions.length > 0 && <VersionConnector />}
+              <OriginalCard
+                entry={entry}
+                isActive={isOriginalActive}
+                language={i18n.language}
+              />
+            </div>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+};
+
+VersionHistory.displayName = "VersionHistory";
+
+const VersionConnector: React.FC = () => (
+  <div className="flex pl-4">
+    <div className="w-0.5 h-4 bg-mid-gray/20" />
+  </div>
+);
+
+interface VersionCardProps {
+  version: TranscriptionVersion;
+  entryId: number;
+  isActive: boolean;
+  isLatest: boolean;
+  language: string;
+}
+
+const VersionCard: React.FC<VersionCardProps> = ({
+  version,
+  entryId,
+  isActive,
+  isLatest,
+  language,
+}) => {
+  const { t } = useTranslation();
+
+  const formattedTime = formatDateTime(String(version.timestamp), language);
+  const label = isLatest ? `${formattedTime}` : formattedTime;
+
+  return (
+    <div
+      className={`rounded-md border p-3 ${
+        isActive
+          ? "border-logo-primary/50 bg-logo-primary/10"
+          : "border-mid-gray/20"
+      }`}
+    >
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <div
+            className={`w-2 h-2 rounded-full ${
+              isActive ? "bg-logo-primary" : "bg-text/30"
+            }`}
+          />
+          <span
+            className={`text-xs font-medium ${
+              isActive ? "text-logo-primary" : "text-text/60"
+            }`}
+          >
+            {label}
+          </span>
+        </div>
+        {isActive ? (
+          <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full bg-logo-primary text-white">
+            {t("settings.history.activeVersion")}
+          </span>
+        ) : (
+          <RestoreButton entryId={entryId} versionId={version.id} />
+        )}
+      </div>
+      <p
+        className={`text-xs leading-relaxed mb-2 ${isActive ? "text-text/80" : "text-text/50"}`}
+      >
+        {version.text.length > 200
+          ? `${version.text.substring(0, 200)}...`
+          : version.text}
+      </p>
+      {version.prompt && (
+        <div className="flex items-center gap-1">
+          <Sparkles width={10} height={10} className="text-text/30" />
+          <span className="text-[11px] text-text/30">
+            {version.prompt.length > 60
+              ? `${version.prompt.substring(0, 60)}...`
+              : version.prompt}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+VersionCard.displayName = "VersionCard";
+
+interface OriginalCardProps {
+  entry: HistoryEntry;
+  isActive: boolean;
+  language: string;
+}
+
+const OriginalCard: React.FC<OriginalCardProps> = ({
+  entry,
+  isActive,
+  language,
+}) => {
+  const { t } = useTranslation();
+  const formattedTime = formatDateTime(String(entry.timestamp), language);
+
+  return (
+    <div
+      className={`rounded-md border p-3 ${
+        isActive
+          ? "border-logo-primary/50 bg-logo-primary/10"
+          : "border-mid-gray/20"
+      }`}
+    >
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <div
+            className={`w-2 h-2 rounded-full ${
+              isActive ? "bg-logo-primary" : "bg-text/30"
+            }`}
+          />
+          <span
+            className={`text-xs font-medium ${
+              isActive ? "text-logo-primary" : "text-text/60"
+            }`}
+          >
+            {formattedTime}
+          </span>
+        </div>
+        {isActive ? (
+          <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full bg-logo-primary text-white">
+            {t("settings.history.activeVersion")}
+          </span>
+        ) : (
+          <RestoreButton entryId={entry.id} versionId={null} />
+        )}
+      </div>
+      <p
+        className={`text-xs leading-relaxed mb-2 ${isActive ? "text-text/80" : "text-text/50"}`}
+      >
+        {entry.transcription_text.length > 200
+          ? `${entry.transcription_text.substring(0, 200)}...`
+          : entry.transcription_text}
+      </p>
+      <div className="flex items-center gap-1">
+        <Mic width={10} height={10} className="text-text/30" />
+        <span className="text-[11px] text-text/30">
+          {t("settings.history.originalVersion")}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+OriginalCard.displayName = "OriginalCard";
+
+interface RestoreButtonProps {
+  entryId: number;
+  versionId: number | null;
+}
+
+const RestoreButton: React.FC<RestoreButtonProps> = ({
+  entryId,
+  versionId,
+}) => {
+  const { t } = useTranslation();
+  const [confirming, setConfirming] = useState(false);
+  const [restoring, setRestoring] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleClick = async () => {
+    if (!confirming) {
+      setConfirming(true);
+      timeoutRef.current = setTimeout(() => {
+        setConfirming(false);
+      }, 3000);
+      return;
+    }
+
+    // Second click — do the restore
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    setConfirming(false);
+    setRestoring(true);
+
+    try {
+      const result = await commands.restoreVersion(entryId, versionId);
+      if (result.status === "error") {
+        const errorKey: Record<string, string> = {
+          HISTORY_POST_PROCESS_DISABLED: "settings.history.postProcessDisabled",
+          VERSION_NOT_FOUND: "settings.history.versionNotFound",
+        };
+        const key = errorKey[result.error] ?? "settings.history.restoreError";
+        toast.error(t(key));
+      }
+    } catch (error) {
+      toast.error(t("settings.history.restoreError"));
+      console.error("Failed to restore version:", error);
+    } finally {
+      setRestoring(false);
+    }
+  };
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  if (restoring) {
+    return (
+      <span className="p-1">
+        <Loader2 width={12} height={12} className="animate-spin text-text/50" />
+      </span>
+    );
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      className={`flex items-center gap-1 text-[10px] font-medium px-2 py-0.5 rounded border transition-colors cursor-pointer ${
+        confirming
+          ? "border-logo-primary text-logo-primary"
+          : "border-text/20 text-text/50 hover:text-logo-primary hover:border-logo-primary"
+      }`}
+    >
+      {!confirming && <RotateCcw width={10} height={10} />}
+      <span>
+        {confirming
+          ? t("settings.history.confirmRestore")
+          : t("settings.history.restore")}
+      </span>
+    </button>
+  );
+};
+
+RestoreButton.displayName = "RestoreButton";

--- a/src/components/settings/history/VersionHistory.tsx
+++ b/src/components/settings/history/VersionHistory.tsx
@@ -285,17 +285,12 @@ const VersionCard: React.FC<VersionCardProps> = ({
         <ExpandableText text={version.text} limit={200} />
       </p>
       {version.prompt && (
-        <div className="rounded bg-text/5 border border-text/10 px-2.5 py-2">
-          <div className="flex items-center gap-1 mb-1">
-            <Sparkles width={10} height={10} className="text-text/30" />
-            <span className="text-[10px] font-medium text-text/30 uppercase tracking-wide">
-              {t("settings.history.promptLabel")}
-            </span>
-          </div>
+        <div className="flex items-start gap-1">
+          <Sparkles width={10} height={10} className="text-text/30 mt-0.5 shrink-0" />
           <ExpandableText
             text={version.prompt}
             limit={80}
-            className="text-[11px] leading-relaxed text-text/40 italic whitespace-pre-wrap"
+            className="text-[11px] leading-relaxed text-text/30 whitespace-pre-wrap"
           />
         </div>
       )}

--- a/src/components/settings/history/VersionHistory.tsx
+++ b/src/components/settings/history/VersionHistory.tsx
@@ -286,7 +286,7 @@ const VersionCard: React.FC<VersionCardProps> = ({
       </p>
       {version.prompt && (
         <div className="flex items-start gap-1">
-          <Sparkles width={10} height={10} className="text-text/30 mt-0.5 shrink-0" />
+          <Sparkles width={10} height={10} className="text-text/30 mt-1 shrink-0" />
           <ExpandableText
             text={version.prompt}
             limit={80}

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -361,10 +361,30 @@
       "loading": "...جاري تحميل السجل",
       "empty": "!لا يوجد تفريغ صوتي بعد. ابدأ التسجيل لبناء سجلك",
       "copyToClipboard": "نسخ التفريغ إلى الحافظة",
+      "copyOriginal": "Copy original transcription",
+      "copyEnhanced": "Copy enhanced transcription",
       "save": "حفظ التفريغ",
       "unsave": "إزالة من المحفوظات",
       "delete": "حذف الإدخال",
-      "deleteError": ".فشل حذف الإدخال. يرجى المحاولة مرة أخرى"
+      "deleteError": ".فشل حذف الإدخال. يرجى المحاولة مرة أخرى",
+      "postProcess": "Enhance transcription",
+      "postProcessError": "Post-processing failed. Check your provider settings.",
+      "postProcessDisabled": "History post-processing is not enabled.",
+      "postProcessEmptyText": "Transcription text is empty.",
+      "postProcessNotConfigured": "Set up post-processing in settings first",
+      "showOriginal": "Show original",
+      "showEnhanced": "Show enhanced",
+      "versionHistory": "Version History",
+      "versionCount": "({{count}} versions)",
+      "activeVersion": "Active",
+      "originalVersion": "Original transcription",
+      "restore": "Restore",
+      "confirmRestore": "Confirm restore?",
+      "restoreError": "Failed to restore version",
+      "versionNotFound": "Version not found",
+      "showMore": "Show more",
+      "showLess": "Show less",
+      "promptLabel": "Prompt"
     },
     "debug": {
       "title": "تصحيح الأخطاء",
@@ -414,6 +434,10 @@
       "postProcessingToggle": {
         "label": "معالجة لاحقة",
         "description": "تمكين تحسين النص المدعوم بالذكاء الاصطناعي بعد التفريغ الصوتي"
+      },
+      "historyPostProcessToggle": {
+        "label": "Post-process History",
+        "description": "Add a button to enhance past transcriptions from the History tab"
       },
       "muteWhileRecording": {
         "label": "كتم الصوت أثناء التسجيل",

--- a/src/i18n/locales/cs/translation.json
+++ b/src/i18n/locales/cs/translation.json
@@ -383,10 +383,30 @@
       "loading": "Načítám historii...",
       "empty": "Zatím žádné přepisy. Začněte nahrávat a vytvořte si historii!",
       "copyToClipboard": "Kopírovat přepis do schránky",
+      "copyOriginal": "Copy original transcription",
+      "copyEnhanced": "Copy enhanced transcription",
       "save": "Uložit přepis",
       "unsave": "Odebrat z uložených",
       "delete": "Smazat záznam",
-      "deleteError": "Nepodařilo se smazat záznam. Zkuste to prosím znovu."
+      "deleteError": "Nepodařilo se smazat záznam. Zkuste to prosím znovu.",
+      "postProcess": "Enhance transcription",
+      "postProcessError": "Post-processing failed. Check your provider settings.",
+      "postProcessDisabled": "History post-processing is not enabled.",
+      "postProcessEmptyText": "Transcription text is empty.",
+      "postProcessNotConfigured": "Set up post-processing in settings first",
+      "showOriginal": "Show original",
+      "showEnhanced": "Show enhanced",
+      "versionHistory": "Version History",
+      "versionCount": "({{count}} versions)",
+      "activeVersion": "Active",
+      "originalVersion": "Original transcription",
+      "restore": "Restore",
+      "confirmRestore": "Confirm restore?",
+      "restoreError": "Failed to restore version",
+      "versionNotFound": "Version not found",
+      "showMore": "Show more",
+      "showLess": "Show less",
+      "promptLabel": "Prompt"
     },
     "debug": {
       "title": "Ladění",
@@ -436,6 +456,10 @@
       "postProcessingToggle": {
         "label": "Následné zpracování",
         "description": "Povolit AI vylepšení textu po přepisu"
+      },
+      "historyPostProcessToggle": {
+        "label": "Post-process History",
+        "description": "Add a button to enhance past transcriptions from the History tab"
       },
       "muteWhileRecording": {
         "label": "Ztlumit při nahrávání",

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -383,10 +383,30 @@
       "loading": "Verlauf wird geladen...",
       "empty": "Noch keine Transkriptionen. Starte eine Aufnahme, um deinen Verlauf aufzubauen!",
       "copyToClipboard": "Transkription in Zwischenablage kopieren",
+      "copyOriginal": "Copy original transcription",
+      "copyEnhanced": "Copy enhanced transcription",
       "save": "Transkription speichern",
       "unsave": "Aus Gespeicherten entfernen",
       "delete": "Eintrag löschen",
-      "deleteError": "Eintrag konnte nicht gelöscht werden. Bitte versuche es erneut."
+      "deleteError": "Eintrag konnte nicht gelöscht werden. Bitte versuche es erneut.",
+      "postProcess": "Enhance transcription",
+      "postProcessError": "Post-processing failed. Check your provider settings.",
+      "postProcessDisabled": "History post-processing is not enabled.",
+      "postProcessEmptyText": "Transcription text is empty.",
+      "postProcessNotConfigured": "Set up post-processing in settings first",
+      "showOriginal": "Show original",
+      "showEnhanced": "Show enhanced",
+      "versionHistory": "Version History",
+      "versionCount": "({{count}} versions)",
+      "activeVersion": "Active",
+      "originalVersion": "Original transcription",
+      "restore": "Restore",
+      "confirmRestore": "Confirm restore?",
+      "restoreError": "Failed to restore version",
+      "versionNotFound": "Version not found",
+      "showMore": "Show more",
+      "showLess": "Show less",
+      "promptLabel": "Prompt"
     },
     "debug": {
       "title": "Debug",
@@ -436,6 +456,10 @@
       "postProcessingToggle": {
         "label": "Nachbearbeitung",
         "description": "KI-gestützte Textverfeinerung nach der Transkription aktivieren"
+      },
+      "historyPostProcessToggle": {
+        "label": "Post-process History",
+        "description": "Add a button to enhance past transcriptions from the History tab"
       },
       "muteWhileRecording": {
         "label": "Während Aufnahme stummschalten",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -405,7 +405,8 @@
       "restoreError": "Failed to restore version",
       "versionNotFound": "Version not found",
       "showMore": "Show more",
-      "showLess": "Show less"
+      "showLess": "Show less",
+      "promptLabel": "Prompt"
     },
     "debug": {
       "title": "Debug",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -389,6 +389,8 @@
       "deleteError": "Failed to delete entry. Please try again.",
       "postProcess": "Enhance transcription",
       "postProcessError": "Post-processing failed. Check your provider settings.",
+      "postProcessDisabled": "History post-processing is not enabled.",
+      "postProcessEmptyText": "Transcription text is empty.",
       "postProcessNotConfigured": "Set up post-processing in settings first",
       "showOriginal": "Show original",
       "showEnhanced": "Show enhanced"

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -383,6 +383,8 @@
       "loading": "Loading history...",
       "empty": "No transcriptions yet. Start recording to build your history!",
       "copyToClipboard": "Copy transcription to clipboard",
+      "copyOriginal": "Copy original transcription",
+      "copyEnhanced": "Copy enhanced transcription",
       "save": "Save transcription",
       "unsave": "Remove from saved",
       "delete": "Delete entry",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -395,7 +395,15 @@
       "postProcessEmptyText": "Transcription text is empty.",
       "postProcessNotConfigured": "Set up post-processing in settings first",
       "showOriginal": "Show original",
-      "showEnhanced": "Show enhanced"
+      "showEnhanced": "Show enhanced",
+      "versionHistory": "Version History",
+      "versionCount": "({{count}} versions)",
+      "activeVersion": "Active",
+      "originalVersion": "Original transcription",
+      "restore": "Restore",
+      "confirmRestore": "Confirm restore?",
+      "restoreError": "Failed to restore version",
+      "versionNotFound": "Version not found"
     },
     "debug": {
       "title": "Debug",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -388,9 +388,7 @@
       "delete": "Delete entry",
       "deleteError": "Failed to delete entry. Please try again.",
       "postProcess": "Enhance transcription",
-      "postProcessing": "Enhancing...",
       "postProcessError": "Post-processing failed. Check your provider settings.",
-      "postProcessNotConfigured": "Set up post-processing in settings first",
       "showOriginal": "Show original",
       "showEnhanced": "Show enhanced"
     },

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -389,6 +389,7 @@
       "deleteError": "Failed to delete entry. Please try again.",
       "postProcess": "Enhance transcription",
       "postProcessError": "Post-processing failed. Check your provider settings.",
+      "postProcessNotConfigured": "Set up post-processing in settings first",
       "showOriginal": "Show original",
       "showEnhanced": "Show enhanced"
     },

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -386,7 +386,13 @@
       "save": "Save transcription",
       "unsave": "Remove from saved",
       "delete": "Delete entry",
-      "deleteError": "Failed to delete entry. Please try again."
+      "deleteError": "Failed to delete entry. Please try again.",
+      "postProcess": "Enhance transcription",
+      "postProcessing": "Enhancing...",
+      "postProcessError": "Post-processing failed. Check your provider settings.",
+      "postProcessNotConfigured": "Set up post-processing in settings first",
+      "showOriginal": "Show original",
+      "showEnhanced": "Show enhanced"
     },
     "debug": {
       "title": "Debug",
@@ -436,6 +442,10 @@
       "postProcessingToggle": {
         "label": "Post Processing",
         "description": "Enable AI-powered text refinement after transcription"
+      },
+      "historyPostProcessToggle": {
+        "label": "Post-process History",
+        "description": "Add a button to enhance past transcriptions from the History tab"
       },
       "muteWhileRecording": {
         "label": "Mute While Recording",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -403,7 +403,9 @@
       "restore": "Restore",
       "confirmRestore": "Confirm restore?",
       "restoreError": "Failed to restore version",
-      "versionNotFound": "Version not found"
+      "versionNotFound": "Version not found",
+      "showMore": "Show more",
+      "showLess": "Show less"
     },
     "debug": {
       "title": "Debug",

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -383,10 +383,30 @@
       "loading": "Cargando historial...",
       "empty": "Aún no hay transcripciones. ¡Comienza a grabar para crear tu historial!",
       "copyToClipboard": "Copiar transcripción al portapapeles",
+      "copyOriginal": "Copy original transcription",
+      "copyEnhanced": "Copy enhanced transcription",
       "save": "Guardar transcripción",
       "unsave": "Eliminar de guardados",
       "delete": "Eliminar entrada",
-      "deleteError": "Error al eliminar la entrada. Por favor, intenta de nuevo."
+      "deleteError": "Error al eliminar la entrada. Por favor, intenta de nuevo.",
+      "postProcess": "Enhance transcription",
+      "postProcessError": "Post-processing failed. Check your provider settings.",
+      "postProcessDisabled": "History post-processing is not enabled.",
+      "postProcessEmptyText": "Transcription text is empty.",
+      "postProcessNotConfigured": "Set up post-processing in settings first",
+      "showOriginal": "Show original",
+      "showEnhanced": "Show enhanced",
+      "versionHistory": "Version History",
+      "versionCount": "({{count}} versions)",
+      "activeVersion": "Active",
+      "originalVersion": "Original transcription",
+      "restore": "Restore",
+      "confirmRestore": "Confirm restore?",
+      "restoreError": "Failed to restore version",
+      "versionNotFound": "Version not found",
+      "showMore": "Show more",
+      "showLess": "Show less",
+      "promptLabel": "Prompt"
     },
     "debug": {
       "title": "Depuración",
@@ -436,6 +456,10 @@
       "postProcessingToggle": {
         "label": "Post Procesamiento",
         "description": "Habilitar refinamiento de texto impulsado por IA después de la transcripción"
+      },
+      "historyPostProcessToggle": {
+        "label": "Post-process History",
+        "description": "Add a button to enhance past transcriptions from the History tab"
       },
       "muteWhileRecording": {
         "label": "Silenciar Durante la Grabación",

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -383,10 +383,30 @@
       "loading": "Chargement de l'historique...",
       "empty": "Pas encore de transcriptions. Commencez à enregistrer pour créer votre historique !",
       "copyToClipboard": "Copier la transcription dans le presse-papiers",
+      "copyOriginal": "Copy original transcription",
+      "copyEnhanced": "Copy enhanced transcription",
       "save": "Enregistrer la transcription",
       "unsave": "Retirer des favoris",
       "delete": "Supprimer l'entrée",
-      "deleteError": "Échec de la suppression de l'entrée. Veuillez réessayer."
+      "deleteError": "Échec de la suppression de l'entrée. Veuillez réessayer.",
+      "postProcess": "Enhance transcription",
+      "postProcessError": "Post-processing failed. Check your provider settings.",
+      "postProcessDisabled": "History post-processing is not enabled.",
+      "postProcessEmptyText": "Transcription text is empty.",
+      "postProcessNotConfigured": "Set up post-processing in settings first",
+      "showOriginal": "Show original",
+      "showEnhanced": "Show enhanced",
+      "versionHistory": "Version History",
+      "versionCount": "({{count}} versions)",
+      "activeVersion": "Active",
+      "originalVersion": "Original transcription",
+      "restore": "Restore",
+      "confirmRestore": "Confirm restore?",
+      "restoreError": "Failed to restore version",
+      "versionNotFound": "Version not found",
+      "showMore": "Show more",
+      "showLess": "Show less",
+      "promptLabel": "Prompt"
     },
     "debug": {
       "title": "Débogage",
@@ -436,6 +456,10 @@
       "postProcessingToggle": {
         "label": "Post-traitement",
         "description": "Activer l'affinage du texte par IA après la transcription"
+      },
+      "historyPostProcessToggle": {
+        "label": "Post-process History",
+        "description": "Add a button to enhance past transcriptions from the History tab"
       },
       "muteWhileRecording": {
         "label": "Muet pendant l'enregistrement",

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -383,10 +383,30 @@
       "loading": "Caricamento cronologia...",
       "empty": "Non ci sono ancora trascrizioni. Comincia a registrare per costruire la tua cronologia!",
       "copyToClipboard": "Copia la trascrizione negli appunti",
+      "copyOriginal": "Copy original transcription",
+      "copyEnhanced": "Copy enhanced transcription",
       "save": "Salva la trascrizione",
       "unsave": "Rimuovi dai salvataggi",
       "delete": "Elimina elemento",
-      "deleteError": "Errore nell'eliminazione dell'elemento. Per favore, prova di nuovo."
+      "deleteError": "Errore nell'eliminazione dell'elemento. Per favore, prova di nuovo.",
+      "postProcess": "Enhance transcription",
+      "postProcessError": "Post-processing failed. Check your provider settings.",
+      "postProcessDisabled": "History post-processing is not enabled.",
+      "postProcessEmptyText": "Transcription text is empty.",
+      "postProcessNotConfigured": "Set up post-processing in settings first",
+      "showOriginal": "Show original",
+      "showEnhanced": "Show enhanced",
+      "versionHistory": "Version History",
+      "versionCount": "({{count}} versions)",
+      "activeVersion": "Active",
+      "originalVersion": "Original transcription",
+      "restore": "Restore",
+      "confirmRestore": "Confirm restore?",
+      "restoreError": "Failed to restore version",
+      "versionNotFound": "Version not found",
+      "showMore": "Show more",
+      "showLess": "Show less",
+      "promptLabel": "Prompt"
     },
     "debug": {
       "title": "Debug",
@@ -436,6 +456,10 @@
       "postProcessingToggle": {
         "label": "Post-Elaborazione",
         "description": "Abilita il miglioramento della trascrizione con IA"
+      },
+      "historyPostProcessToggle": {
+        "label": "Post-process History",
+        "description": "Add a button to enhance past transcriptions from the History tab"
       },
       "muteWhileRecording": {
         "label": "Silenzia durante la registrazione",

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -383,10 +383,30 @@
       "loading": "履歴を読み込み中...",
       "empty": "まだ文字起こしがありません。録音を開始して履歴を作成しましょう！",
       "copyToClipboard": "文字起こしをクリップボードにコピー",
+      "copyOriginal": "Copy original transcription",
+      "copyEnhanced": "Copy enhanced transcription",
       "save": "文字起こしを保存",
       "unsave": "保存から削除",
       "delete": "エントリーを削除",
-      "deleteError": "エントリーの削除に失敗しました。もう一度お試しください。"
+      "deleteError": "エントリーの削除に失敗しました。もう一度お試しください。",
+      "postProcess": "Enhance transcription",
+      "postProcessError": "Post-processing failed. Check your provider settings.",
+      "postProcessDisabled": "History post-processing is not enabled.",
+      "postProcessEmptyText": "Transcription text is empty.",
+      "postProcessNotConfigured": "Set up post-processing in settings first",
+      "showOriginal": "Show original",
+      "showEnhanced": "Show enhanced",
+      "versionHistory": "Version History",
+      "versionCount": "({{count}} versions)",
+      "activeVersion": "Active",
+      "originalVersion": "Original transcription",
+      "restore": "Restore",
+      "confirmRestore": "Confirm restore?",
+      "restoreError": "Failed to restore version",
+      "versionNotFound": "Version not found",
+      "showMore": "Show more",
+      "showLess": "Show less",
+      "promptLabel": "Prompt"
     },
     "debug": {
       "title": "デバッグ",
@@ -436,6 +456,10 @@
       "postProcessingToggle": {
         "label": "後処理",
         "description": "文字起こし後のAIによるテキスト改善を有効化"
+      },
+      "historyPostProcessToggle": {
+        "label": "Post-process History",
+        "description": "Add a button to enhance past transcriptions from the History tab"
       },
       "muteWhileRecording": {
         "label": "録音中にミュート",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -383,10 +383,30 @@
       "loading": "히스토리 로딩 중...",
       "empty": "아직 변환된 내용이 없습니다. 녹음을 시작하여 히스토리를 만드세요!",
       "copyToClipboard": "녹음 내용을 클립보드에 복사",
+      "copyOriginal": "Copy original transcription",
+      "copyEnhanced": "Copy enhanced transcription",
       "save": "변환된 텍스트 저장",
       "unsave": "저장에서 제거",
       "delete": "항목 삭제",
-      "deleteError": "항목 삭제에 실패했습니다. 다시 시도해주세요."
+      "deleteError": "항목 삭제에 실패했습니다. 다시 시도해주세요.",
+      "postProcess": "Enhance transcription",
+      "postProcessError": "Post-processing failed. Check your provider settings.",
+      "postProcessDisabled": "History post-processing is not enabled.",
+      "postProcessEmptyText": "Transcription text is empty.",
+      "postProcessNotConfigured": "Set up post-processing in settings first",
+      "showOriginal": "Show original",
+      "showEnhanced": "Show enhanced",
+      "versionHistory": "Version History",
+      "versionCount": "({{count}} versions)",
+      "activeVersion": "Active",
+      "originalVersion": "Original transcription",
+      "restore": "Restore",
+      "confirmRestore": "Confirm restore?",
+      "restoreError": "Failed to restore version",
+      "versionNotFound": "Version not found",
+      "showMore": "Show more",
+      "showLess": "Show less",
+      "promptLabel": "Prompt"
     },
     "debug": {
       "title": "디버그",
@@ -437,6 +457,10 @@
         "label": "후처리",
         "description": "텍스트 변환 후 AI 기반 텍스트 개선 활성화"
       },
+      "historyPostProcessToggle": {
+        "label": "Post-process History",
+        "description": "Add a button to enhance past transcriptions from the History tab"
+      },
       "muteWhileRecording": {
         "label": "녹음 중 음소거",
         "description": "녹음 중 시스템 오디오 음소거"
@@ -450,14 +474,14 @@
         "description": "키보드 단축키 백엔드를 선택하세요.",
         "bindingsReset": "키보드 단축키가 호환되지 않아 기본값으로 재설정되었습니다"
       },
-      "pasteDelay": {
-        "title": "붙여넣기 지연",
-        "description": "붙여넣기 키 입력을 보내기 전 지연 시간(밀리초). 잘못된 텍스트가 붙여넣어지면 늘리세요."
-      },
       "paths": {
         "appData": "앱 데이터:",
         "models": "모델:",
         "settings": "설정:"
+      },
+      "pasteDelay": {
+        "title": "붙여넣기 지연",
+        "description": "붙여넣기 키 입력을 보내기 전 지연 시간(밀리초). 잘못된 텍스트가 붙여넣어지면 늘리세요."
       }
     },
     "about": {

--- a/src/i18n/locales/pl/translation.json
+++ b/src/i18n/locales/pl/translation.json
@@ -383,10 +383,30 @@
       "loading": "Wczytywanie historii...",
       "empty": "Brak transkrypcji. Rozpocznij nagrywanie, aby zbudować historię!",
       "copyToClipboard": "Kopiuj transkrypcję do schowka",
+      "copyOriginal": "Copy original transcription",
+      "copyEnhanced": "Copy enhanced transcription",
       "save": "Zapisz transkrypcję",
       "unsave": "Usuń z zapisanych",
       "delete": "Usuń wpis",
-      "deleteError": "Nie udało się usunąć wpisu. Spróbuj ponownie."
+      "deleteError": "Nie udało się usunąć wpisu. Spróbuj ponownie.",
+      "postProcess": "Enhance transcription",
+      "postProcessError": "Post-processing failed. Check your provider settings.",
+      "postProcessDisabled": "History post-processing is not enabled.",
+      "postProcessEmptyText": "Transcription text is empty.",
+      "postProcessNotConfigured": "Set up post-processing in settings first",
+      "showOriginal": "Show original",
+      "showEnhanced": "Show enhanced",
+      "versionHistory": "Version History",
+      "versionCount": "({{count}} versions)",
+      "activeVersion": "Active",
+      "originalVersion": "Original transcription",
+      "restore": "Restore",
+      "confirmRestore": "Confirm restore?",
+      "restoreError": "Failed to restore version",
+      "versionNotFound": "Version not found",
+      "showMore": "Show more",
+      "showLess": "Show less",
+      "promptLabel": "Prompt"
     },
     "debug": {
       "title": "Debugowanie",
@@ -436,6 +456,10 @@
       "postProcessingToggle": {
         "label": "Postprocess",
         "description": "Włącz AI do ulepszania tekstu po transkrypcji"
+      },
+      "historyPostProcessToggle": {
+        "label": "Post-process History",
+        "description": "Add a button to enhance past transcriptions from the History tab"
       },
       "muteWhileRecording": {
         "label": "Wycisz podczas nagrywania",

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -383,10 +383,30 @@
       "loading": "Carregando histórico...",
       "empty": "Nenhuma transcrição ainda. Comece a gravar para construir seu histórico!",
       "copyToClipboard": "Copiar transcrição para área de transferência",
+      "copyOriginal": "Copy original transcription",
+      "copyEnhanced": "Copy enhanced transcription",
       "save": "Salvar transcrição",
       "unsave": "Remover dos salvos",
       "delete": "Excluir entrada",
-      "deleteError": "Falha ao excluir entrada. Por favor, tente novamente."
+      "deleteError": "Falha ao excluir entrada. Por favor, tente novamente.",
+      "postProcess": "Enhance transcription",
+      "postProcessError": "Post-processing failed. Check your provider settings.",
+      "postProcessDisabled": "History post-processing is not enabled.",
+      "postProcessEmptyText": "Transcription text is empty.",
+      "postProcessNotConfigured": "Set up post-processing in settings first",
+      "showOriginal": "Show original",
+      "showEnhanced": "Show enhanced",
+      "versionHistory": "Version History",
+      "versionCount": "({{count}} versions)",
+      "activeVersion": "Active",
+      "originalVersion": "Original transcription",
+      "restore": "Restore",
+      "confirmRestore": "Confirm restore?",
+      "restoreError": "Failed to restore version",
+      "versionNotFound": "Version not found",
+      "showMore": "Show more",
+      "showLess": "Show less",
+      "promptLabel": "Prompt"
     },
     "debug": {
       "title": "Depuração",
@@ -436,6 +456,10 @@
       "postProcessingToggle": {
         "label": "Pós-Processamento",
         "description": "Habilitar refinamento de texto com IA após a transcrição"
+      },
+      "historyPostProcessToggle": {
+        "label": "Post-process History",
+        "description": "Add a button to enhance past transcriptions from the History tab"
       },
       "muteWhileRecording": {
         "label": "Silenciar Durante Gravação",

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -383,10 +383,30 @@
       "loading": "Загрузка истории...",
       "empty": "Транскрипций пока нет. Начните запись, чтобы создать свою историю!",
       "copyToClipboard": "Скопировать транскрипцию в буфер обмена",
+      "copyOriginal": "Copy original transcription",
+      "copyEnhanced": "Copy enhanced transcription",
       "save": "Сохранить транскрипцию",
       "unsave": "Удалить из сохраненных",
       "delete": "Удалить запись",
-      "deleteError": "Не удалось удалить запись. Пожалуйста, попробуйте еще раз."
+      "deleteError": "Не удалось удалить запись. Пожалуйста, попробуйте еще раз.",
+      "postProcess": "Enhance transcription",
+      "postProcessError": "Post-processing failed. Check your provider settings.",
+      "postProcessDisabled": "History post-processing is not enabled.",
+      "postProcessEmptyText": "Transcription text is empty.",
+      "postProcessNotConfigured": "Set up post-processing in settings first",
+      "showOriginal": "Show original",
+      "showEnhanced": "Show enhanced",
+      "versionHistory": "Version History",
+      "versionCount": "({{count}} versions)",
+      "activeVersion": "Active",
+      "originalVersion": "Original transcription",
+      "restore": "Restore",
+      "confirmRestore": "Confirm restore?",
+      "restoreError": "Failed to restore version",
+      "versionNotFound": "Version not found",
+      "showMore": "Show more",
+      "showLess": "Show less",
+      "promptLabel": "Prompt"
     },
     "debug": {
       "title": "Отлаживать",
@@ -436,6 +456,10 @@
       "postProcessingToggle": {
         "label": "Постобработка",
         "description": "Включить уточнение текста с помощью искусственного интеллекта после транскрипции"
+      },
+      "historyPostProcessToggle": {
+        "label": "Post-process History",
+        "description": "Add a button to enhance past transcriptions from the History tab"
       },
       "muteWhileRecording": {
         "label": "Отключить звук во время записи",

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -383,10 +383,30 @@
       "loading": "Geçmiş yükleniyor...",
       "empty": "Henüz transkripsiyon yok. Geçmişinizi oluşturmak için kayda başlayın!",
       "copyToClipboard": "Transkripsiyonu panoya kopyala",
+      "copyOriginal": "Copy original transcription",
+      "copyEnhanced": "Copy enhanced transcription",
       "save": "Transkripsiyonu kaydet",
       "unsave": "Kaydedilenlerden kaldır",
       "delete": "Kaydı sil",
-      "deleteError": "Kayıt silinemedi. Lütfen tekrar deneyin."
+      "deleteError": "Kayıt silinemedi. Lütfen tekrar deneyin.",
+      "postProcess": "Enhance transcription",
+      "postProcessError": "Post-processing failed. Check your provider settings.",
+      "postProcessDisabled": "History post-processing is not enabled.",
+      "postProcessEmptyText": "Transcription text is empty.",
+      "postProcessNotConfigured": "Set up post-processing in settings first",
+      "showOriginal": "Show original",
+      "showEnhanced": "Show enhanced",
+      "versionHistory": "Version History",
+      "versionCount": "({{count}} versions)",
+      "activeVersion": "Active",
+      "originalVersion": "Original transcription",
+      "restore": "Restore",
+      "confirmRestore": "Confirm restore?",
+      "restoreError": "Failed to restore version",
+      "versionNotFound": "Version not found",
+      "showMore": "Show more",
+      "showLess": "Show less",
+      "promptLabel": "Prompt"
     },
     "debug": {
       "title": "Hata Ayıklama",
@@ -436,6 +456,10 @@
       "postProcessingToggle": {
         "label": "Son İşlem",
         "description": "Transkripsiyon sonrası yapay zekâ destekli metin iyileştirmeyi etkinleştirir"
+      },
+      "historyPostProcessToggle": {
+        "label": "Post-process History",
+        "description": "Add a button to enhance past transcriptions from the History tab"
       },
       "muteWhileRecording": {
         "label": "Kayıt Sırasında Sessize Al",

--- a/src/i18n/locales/uk/translation.json
+++ b/src/i18n/locales/uk/translation.json
@@ -383,10 +383,30 @@
       "loading": "Завантаження історії...",
       "empty": "Транскрипцій поки немає. Почніть запис, щоб створити історію!",
       "copyToClipboard": "Копіювати транскрипцію в буфер обміну",
+      "copyOriginal": "Copy original transcription",
+      "copyEnhanced": "Copy enhanced transcription",
       "save": "Зберегти транскрипцію",
       "unsave": "Видалити зі збережених",
       "delete": "Видалити запис",
-      "deleteError": "Не вдалося видалити запис. Спробуйте ще раз."
+      "deleteError": "Не вдалося видалити запис. Спробуйте ще раз.",
+      "postProcess": "Enhance transcription",
+      "postProcessError": "Post-processing failed. Check your provider settings.",
+      "postProcessDisabled": "History post-processing is not enabled.",
+      "postProcessEmptyText": "Transcription text is empty.",
+      "postProcessNotConfigured": "Set up post-processing in settings first",
+      "showOriginal": "Show original",
+      "showEnhanced": "Show enhanced",
+      "versionHistory": "Version History",
+      "versionCount": "({{count}} versions)",
+      "activeVersion": "Active",
+      "originalVersion": "Original transcription",
+      "restore": "Restore",
+      "confirmRestore": "Confirm restore?",
+      "restoreError": "Failed to restore version",
+      "versionNotFound": "Version not found",
+      "showMore": "Show more",
+      "showLess": "Show less",
+      "promptLabel": "Prompt"
     },
     "debug": {
       "title": "Дебаг",
@@ -436,6 +456,10 @@
       "postProcessingToggle": {
         "label": "Постобробка",
         "description": "Увімкнути покращення тексту за допомогою AI після транскрипції"
+      },
+      "historyPostProcessToggle": {
+        "label": "Post-process History",
+        "description": "Add a button to enhance past transcriptions from the History tab"
       },
       "muteWhileRecording": {
         "label": "Вимкнути звук під час запису",

--- a/src/i18n/locales/vi/translation.json
+++ b/src/i18n/locales/vi/translation.json
@@ -383,10 +383,30 @@
       "loading": "Đang tải lịch sử...",
       "empty": "Chưa có bản ghi nào. Bắt đầu ghi âm để xây dựng lịch sử của bạn!",
       "copyToClipboard": "Sao chép bản ghi vào clipboard",
+      "copyOriginal": "Copy original transcription",
+      "copyEnhanced": "Copy enhanced transcription",
       "save": "Lưu bản ghi",
       "unsave": "Xóa khỏi đã lưu",
       "delete": "Xóa mục",
-      "deleteError": "Không thể xóa mục. Vui lòng thử lại."
+      "deleteError": "Không thể xóa mục. Vui lòng thử lại.",
+      "postProcess": "Enhance transcription",
+      "postProcessError": "Post-processing failed. Check your provider settings.",
+      "postProcessDisabled": "History post-processing is not enabled.",
+      "postProcessEmptyText": "Transcription text is empty.",
+      "postProcessNotConfigured": "Set up post-processing in settings first",
+      "showOriginal": "Show original",
+      "showEnhanced": "Show enhanced",
+      "versionHistory": "Version History",
+      "versionCount": "({{count}} versions)",
+      "activeVersion": "Active",
+      "originalVersion": "Original transcription",
+      "restore": "Restore",
+      "confirmRestore": "Confirm restore?",
+      "restoreError": "Failed to restore version",
+      "versionNotFound": "Version not found",
+      "showMore": "Show more",
+      "showLess": "Show less",
+      "promptLabel": "Prompt"
     },
     "debug": {
       "title": "Gỡ lỗi",
@@ -436,6 +456,10 @@
       "postProcessingToggle": {
         "label": "Xử lý sau",
         "description": "Bật tinh chỉnh văn bản bằng AI sau khi chuyển đổi"
+      },
+      "historyPostProcessToggle": {
+        "label": "Post-process History",
+        "description": "Add a button to enhance past transcriptions from the History tab"
       },
       "muteWhileRecording": {
         "label": "Tắt tiếng khi ghi âm",

--- a/src/i18n/locales/zh-TW/translation.json
+++ b/src/i18n/locales/zh-TW/translation.json
@@ -383,10 +383,30 @@
       "loading": "載入歷史紀錄中...",
       "empty": "還沒有轉錄紀錄。開始錄製以建立您的歷史紀錄！",
       "copyToClipboard": "複製轉錄到剪貼簿",
+      "copyOriginal": "Copy original transcription",
+      "copyEnhanced": "Copy enhanced transcription",
       "save": "儲存轉錄",
       "unsave": "從已儲存中移除",
       "delete": "刪除條目",
-      "deleteError": "刪除條目失敗，請重試"
+      "deleteError": "刪除條目失敗，請重試",
+      "postProcess": "Enhance transcription",
+      "postProcessError": "Post-processing failed. Check your provider settings.",
+      "postProcessDisabled": "History post-processing is not enabled.",
+      "postProcessEmptyText": "Transcription text is empty.",
+      "postProcessNotConfigured": "Set up post-processing in settings first",
+      "showOriginal": "Show original",
+      "showEnhanced": "Show enhanced",
+      "versionHistory": "Version History",
+      "versionCount": "({{count}} versions)",
+      "activeVersion": "Active",
+      "originalVersion": "Original transcription",
+      "restore": "Restore",
+      "confirmRestore": "Confirm restore?",
+      "restoreError": "Failed to restore version",
+      "versionNotFound": "Version not found",
+      "showMore": "Show more",
+      "showLess": "Show less",
+      "promptLabel": "Prompt"
     },
     "debug": {
       "title": "偵錯",
@@ -436,6 +456,10 @@
       "postProcessingToggle": {
         "label": "後處理",
         "description": "啟用轉錄後的 AI 文字最佳化"
+      },
+      "historyPostProcessToggle": {
+        "label": "Post-process History",
+        "description": "Add a button to enhance past transcriptions from the History tab"
       },
       "muteWhileRecording": {
         "label": "錄製時靜音",

--- a/src/i18n/locales/zh/translation.json
+++ b/src/i18n/locales/zh/translation.json
@@ -383,10 +383,30 @@
       "loading": "加载历史记录中...",
       "empty": "还没有转录记录。开始录制以建立您的历史记录！",
       "copyToClipboard": "复制转录到剪贴板",
+      "copyOriginal": "Copy original transcription",
+      "copyEnhanced": "Copy enhanced transcription",
       "save": "保存转录",
       "unsave": "从已保存中移除",
       "delete": "删除条目",
-      "deleteError": "删除条目失败，请重试。"
+      "deleteError": "删除条目失败，请重试。",
+      "postProcess": "Enhance transcription",
+      "postProcessError": "Post-processing failed. Check your provider settings.",
+      "postProcessDisabled": "History post-processing is not enabled.",
+      "postProcessEmptyText": "Transcription text is empty.",
+      "postProcessNotConfigured": "Set up post-processing in settings first",
+      "showOriginal": "Show original",
+      "showEnhanced": "Show enhanced",
+      "versionHistory": "Version History",
+      "versionCount": "({{count}} versions)",
+      "activeVersion": "Active",
+      "originalVersion": "Original transcription",
+      "restore": "Restore",
+      "confirmRestore": "Confirm restore?",
+      "restoreError": "Failed to restore version",
+      "versionNotFound": "Version not found",
+      "showMore": "Show more",
+      "showLess": "Show less",
+      "promptLabel": "Prompt"
     },
     "debug": {
       "title": "调试",
@@ -436,6 +456,10 @@
       "postProcessingToggle": {
         "label": "后处理",
         "description": "启用转录后的 AI 文本优化"
+      },
+      "historyPostProcessToggle": {
+        "label": "Post-process History",
+        "description": "Add a button to enhance past transcriptions from the History tab"
       },
       "muteWhileRecording": {
         "label": "录制时静音",

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -121,6 +121,8 @@ const settingUpdaters: {
   history_limit: (value) => commands.updateHistoryLimit(value as number),
   post_process_enabled: (value) =>
     commands.changePostProcessEnabledSetting(value as boolean),
+  history_post_process_enabled: (value) =>
+    commands.changeHistoryPostProcessEnabledSetting(value as boolean),
   post_process_selected_prompt_id: (value) =>
     commands.setPostProcessSelectedPrompt(value as string),
   mute_while_recording: (value) =>


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Human Written Description

I wanted to be able to enhance my transcriptions directly within Handy — my spoken words tend to include filler words and pauses, and I didn't want to have to open a separate app or keep an AI side-by-side just to clean things up. On Linux, key binding issues made the one-shot post-processing flow unreliable for me, so having a per-entry enhance button in the history tab was the natural solution. This PR adds that button along with a full version history viewer, so you can see every enhancement, what prompt was used, and restore any previous version. It closes the loop on enhancement within an already great tool.

## Related Issues/Discussions

Discussion: https://github.com/cjpais/Handy/discussions/826

## Community Feedback

This implements the feature requested in Discussion #826 — per-entry post-processing from the history tab. The discussion received community interest as a natural complement to the existing global post-process flow.

## Changes

### Backend (Rust)
- **New setting:** `history_post_process_enabled` behind experimental + post-process feature gates
- **Version tracking:** New `transcription_versions` table records every enhancement (text, prompt, timestamp) via migration
- **New commands:** `post_process_history_entry`, `get_transcription_versions`, `restore_version`, `toggle_history_post_process`
- **Restore logic:** Updates `post_processed_text`/`post_process_prompt` on the history entry without deleting version rows (append-only history)
- **`version_count` subquery:** Added to `HistoryEntry` so the frontend knows whether to show version history even when restored to original
- **42 tests passing** including 4 new restore tests and existing version tracking tests

### Frontend (React/TypeScript)
- **Post-process button** (sparkle icon) on each history entry — disabled when no provider configured or text is empty
- **Show Original / Show Enhanced toggle** for quick A/B comparison
- **VersionHistory accordion component** — expandable timeline showing all enhancement versions with:
  - Active version detection (text + prompt + timestamp matching)
  - Restore button with inline 3-second confirmation
  - Expandable text ("Show more/less") for both version content and prompts
  - Prompt text preserves line breaks (`whitespace-pre-wrap`)
  - Lazy-loading on first expand, stale cache invalidation on `history-updated` events
- **HistoryPostProcessToggle** in experimental settings

### i18n
- 20 new translation keys added to all 17 locale files

## Testing

- **Rust tests:** 42/42 passing (includes `restore_to_specific_version`, `restore_to_original`, `versions_preserved_after_restore`, `restore_nonexistent_version_fails`)
- **Clippy:** 0 warnings with `-D warnings`
- **ESLint:** Clean
- **Prettier + cargo fmt:** Clean
- **Translation consistency:** All 16 non-English locales pass
- **Manual testing:** Verified on Linux — enhance, restore, version history expand/collapse, stale cache refresh, restore-to-original edge case, show more/less on long prompts

## Screenshots

**Experimental settings toggle:**

![Screenshot_2026-02-19_00-51-20](https://github.com/user-attachments/assets/e65014d4-5a92-482f-bbf0-1194287a2a1b)

**History entry with enhance button and Show Original toggle:**

![Screenshot_2026-02-19_00-51-44](https://github.com/user-attachments/assets/6f19eea6-7675-4e84-b565-79339aa4008a)

**Version history expanded with active version and restore:**

![Screenshot_2026-02-19_00-52-38](https://github.com/user-attachments/assets/d5a6f9a3-6333-41bb-9f06-e658d639a5a9)

**Expanded prompt text with line breaks preserved:**

![Screenshot_2026-02-19_00-52-51](https://github.com/user-attachments/assets/cb4e2e77-432b-4037-9095-9355cd2e452d)

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Claude Opus 4.6)
- How extensively: Claude Code was used extensively throughout — from brainstorming and design (including a Pencil wireframe), through implementation of all backend and frontend code, to bug fixing (3 bugs found during manual testing and fixed iteratively). The human contributor directed all design decisions, tested locally, and identified the bugs. All code was reviewed and approved by the contributor before committing.