### PR TITLE
fix(nix): update bunDeps outputHash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
       ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
       # Read version from Cargo.toml
-      cargoToml = builtins.fromTOML (builtins.readFile ./src-tauri/Cargo.toml);
+      cargoToml = fromTOML (builtins.readFile ./src-tauri/Cargo.toml);
       version = cargoToml.package.version;
     in
     {
@@ -51,7 +51,7 @@
 
             outputHashAlgo = "sha256";
             outputHashMode = "recursive";
-            outputHash = "sha256-6SvLw/8UBIHlcIY7jUJKv6DHPooP3aUz+4PvC7UNzv4=";
+            outputHash = "sha256-+hUANv0w3qnK5d2+4JW3XMazLRDhWCbOxUXQyTGta/0=";
           };
         in
         {


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Human Written Description

Commit [cbc8080](https://github.com/cjpais/Handy/commit/cbc80802cbf1e313136e585c44f61e91cee470f0) update the wrong hash causing this build failure on nix:

```
error: hash mismatch in fixed-output derivation '/nix/store/kzj7qsf9jm4l3l3aarhyz19n0mx3lkd1-handy-bun-deps-0.7.6.drv':
         specified: sha256-6SvLw/8UBIHlcIY7jUJKv6DHPooP3aUz+4PvC7UNzv4=
            got:    sha256-+hUANv0w3qnK5d2+4JW3XMazLRDhWCbOxUXQyTGta/0=
error: Cannot build '/nix/store/05j5wnkvc19r1qzvc3swdcrrvjpls3f2-handy-0.7.6.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/cm7rxsfjli45xvfbprxjxfgqrcx0jn7v-handy-0.7.6
```
## AI Assistance

- [x] No AI was used in this PR
