### PR TITLE
fix: auto-refresh model list when switching post-processing providers

### DIFF
--- a/src/components/settings/PostProcessingSettingsApi/usePostProcessProviderState.ts
+++ b/src/components/settings/PostProcessingSettingsApi/usePostProcessProviderState.ts
@@ -107,7 +107,13 @@ export const usePostProcessProviderState = (): PostProcessProviderState => {
         }
       }
     },
-    [selectedProviderId, setPostProcessProvider, fetchPostProcessModels, providers, settings],
+    [
+      selectedProviderId,
+      setPostProcessProvider,
+      fetchPostProcessModels,
+      providers,
+      settings,
+    ],
   );
 
   const handleBaseUrlChange = useCallback(


### PR DESCRIPTION
## Summary

- Auto-fetch available models when switching post-processing providers, so the model dropdown immediately reflects what's valid for the new provider
- Clear cached model options and reset the stored model when the Custom provider's base URL changes
- Clear cached model options on any provider switch to prevent stale entries from lingering

## Problem

When a user switches post-processing providers (or changes the Custom provider's base URL), the previously stored model value persists without validation. If that model doesn't exist on the new provider's API, the post-processing request silently 404s at runtime. The user receives no feedback — their transcription is pasted without post-processing, and there's no indication anything went wrong.

This is particularly likely with the Custom provider, where a user might point the base URL at different APIs over time (e.g., Groq → Cerebras), each with different model naming conventions (`openai/gpt-oss-120b` vs `gpt-oss-120b`).

## Changes

1. **`usePostProcessProviderState.ts`** — `handleProviderSelect` now awaits the provider switch and auto-fetches models for the new provider, so the dropdown is immediately populated with valid options.
2. **`settingsStore.ts` (`setPostProcessProvider`)** — Clears cached model options when switching providers, preventing stale entries from a previous fetch.
3. **`settingsStore.ts` (`updatePostProcessBaseUrl`)** — Clears cached models and resets the stored model to empty when the base URL changes, since the previous model is almost certainly invalid for the new endpoint.

## Note

This doesn't address the broader issue that post-processing failures are completely silent to the user — a toast or overlay notification on API errors would be a valuable follow-up. This PR reduces the likelihood of hitting that silent failure by keeping the model dropdown in sync with the active provider.

## Origin story

This was discovered while setting up a debug workflow for transcript optimization prompts. The goal was to have two prompts in Handy: one using the Cerebras provider (structured output, clean text pasted) and a second using a Custom provider pointed at the same Cerebras API (legacy mode, JSON output with both original and improved text for comparison).

With structured-output providers (OpenAI, Cerebras, OpenRouter, etc.), Handy strips `${output}` from the prompt, sends the transcript as the user message, and forces a `{"transcription": "..."}` response schema — so there's no way to get custom JSON output for debugging. The Custom provider uses the legacy path (single user message, no schema), which allows full control over the output format.

After switching the Custom provider's base URL to Cerebras and selecting a debug prompt, post-processing silently failed. The cause: the model dropdown retained `openai/gpt-oss-120b` (valid for the previous endpoint) instead of `gpt-oss-120b` (what Cerebras expects), resulting in a 404 with no user-facing error.
