### PR TITLE
feat: add streaming transcription preview to recording overlay

### DIFF
--- a/src-tauri/src/managers/audio.rs
+++ b/src-tauri/src/managers/audio.rs
@@ -421,6 +421,19 @@ impl AudioRecordingManager {
         )
     }
 
+    /// Returns a clone of the accumulated audio samples without stopping recording.
+    /// Returns `None` if not currently recording or if the snapshot fails.
+    pub fn get_accumulated_samples(&self) -> Option<Vec<f32>> {
+        if !self.is_recording() {
+            return None;
+        }
+        if let Some(rec) = self.recorder.lock().unwrap().as_ref() {
+            rec.snapshot().ok()
+        } else {
+            None
+        }
+    }
+
     /// Cancel any ongoing recording without returning audio samples
     pub fn cancel_recording(&self) {
         let mut state = self.state.lock().unwrap();

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -30,8 +30,8 @@ tauri_panel! {
     })
 }
 
-const OVERLAY_WIDTH: f64 = 172.0;
-const OVERLAY_HEIGHT: f64 = 36.0;
+const OVERLAY_WIDTH: f64 = 400.0;
+const OVERLAY_HEIGHT: f64 = 300.0; // leave some space for the overlay to expand with streaming transcript.
 
 #[cfg(target_os = "macos")]
 const OVERLAY_TOP_OFFSET: f64 = 46.0;
@@ -351,6 +351,13 @@ pub fn hide_recording_overlay(app_handle: &AppHandle) {
             std::thread::sleep(std::time::Duration::from_millis(300));
             let _ = window_clone.hide();
         });
+    }
+}
+
+/// Emits a streaming transcript update to the recording overlay
+pub fn emit_streaming_transcript(app_handle: &AppHandle, text: &str) {
+    if let Some(overlay_window) = app_handle.get_webview_window("recording_overlay") {
+        let _ = overlay_window.emit("streaming-transcript", text);
     }
 }
 

--- a/src/overlay/RecordingOverlay.css
+++ b/src/overlay/RecordingOverlay.css
@@ -1,10 +1,11 @@
+
 .recording-overlay {
-  height: 36px;
-  width: 172px;
+  min-height: 52px;
+  width: 400px;
   display: grid;
   grid-template-columns: auto 1fr auto;
-  align-items: center;
-  padding: 6px;
+  align-items: start;
+  padding: 12px 12px;
   background: #000000cc;
   border-radius: 18px;
   opacity: 0;
@@ -21,6 +22,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.recording-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
 }
 
 .overlay-right {


### PR DESCRIPTION
Show a live transcript preview in the recording overlay while audio is being captured. A background thread periodically snapshots accumulated audio samples and runs them through the transcription engine, emitting updates to the overlay UI in real time.

It also requires no VAD compared to your @cjpais PR from three days ago.

I find this very helpful feedback to see which text is going to be entered.

This is much simpler than live inputting text into a real application because this has zero quality loss (no chunking) - it retroactively changes when the audio changes by simply processing the full thing in a 500ms loop ("fake" incremental processing).

This has basically no disadvantages apart from CPU use during talking.

Video:


https://github.com/user-attachments/assets/24d83ed7-357c-47e7-bda4-6adfb0e6cf6a



## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [kinda] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)
## Human Written Description

## Related Issues/Discussions

<!-- Link to related issues, discussions, or previous PRs -->
<!-- If reopening something previously closed, explain why this should be reconsidered -->

Fixes #
- https://github.com/cjpais/transcribe-rs/issues/4
- https://github.com/cjpais/Handy/issues/130
- https://github.com/cjpais/Handy/discussions/179
- https://github.com/cjpais/Handy/pull/832
Discussion: 
https://github.com/cjpais/Handy/discussions/179

## Community Feedback

## AI Assistance


- [ ] No AI was used in this PR
- [x] AI was used (please describe below)
- [ ] 
- Tools used: Claude Opus 4.6

In total this was around ~60mins of human effort. I did a bunch of manual changes to simplify and because AI could not figure out the CSS.

AI Disclosure Summary:
The core feature was implemented across three sessions. The initial prompt was to show a live streaming transcript in the recording overlay popup. The AI planned the architecture, then implemented it end-to-end: a `snapshot()` method on the recorder to clone accumulated audio mid-recording, a background thread that periodically transcribes the snapshot and emits events, and a React frontend that listens and displays the live text. Subsequent prompts were iterative refinements — fixing layout issues, debugging a race condition, and simplifying the code.

| Prompt (paraphrased) | AI Action |
|---------------------|-----------|
| "Implement a feature where the small popup shown during recording shows a streaming transcript" | Planned the full architecture, then implemented across 8 files: `snapshot()` on the recorder, streaming loop in `actions.rs`, event emission to overlay, React listener + display |
| "The text gets cut off when too long. Also do it 1/second" | Changed interval from 3s to 1s, added CSS word-wrap with auto-scroll |
| (Reported race condition with logs showing concurrent transcription access) | Added a serialization lock to prevent streaming and final transcriptions from colliding |
| "Transparency gets darker when new text appears" | Abandoned dynamic window resizing (caused compositing artifacts on GTK). Switched to fixed-size transparent window where content grows via CSS |
| "Make it so that the transcript and the bars both show — bars below text" | Modified overlay to show both transcript text AND audio bars simultaneously |
| "Can we simplify the transcription lock?" | Removed the separate lock, consolidated engine lock to be held for the full transcription duration |
| "Why did you change some of the comments?" | Acknowledged over-editing mistake, restored original comments |

**Files:** `actions.rs`, `recorder.rs`, `audio.rs`, `transcription.rs`, `overlay.rs`, `RecordingOverlay.tsx`, `RecordingOverlay.css`, `index.html`
