### PR TITLE
Bump macOS minimum version to 10.15 (Catalina)

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -51,7 +51,7 @@
     "macOS": {
       "files": {},
       "hardenedRuntime": true,
-      "minimumSystemVersion": "10.13",
+      "minimumSystemVersion": "10.15",
       "signingIdentity": "-",
       "entitlements": "Entitlements.plist"
     },


### PR DESCRIPTION
## Summary
- Bumps `minimumSystemVersion` from 10.13 (High Sierra) to 10.15 (Catalina)

## Motivation

This is a prerequisite for upgrading transcribe-rs, which bumps whisper-rs to 0.15.1. The newer whisper.cpp (v1.7.4) uses `std::filesystem::path` in `ggml-backend-reg.cpp`, which requires macOS 10.15+.

macOS 10.13 (High Sierra) has been EOL since November 2020, and Apple Silicon Macs all ship with 10.15+, so this shouldn't affect any active users.

Related: https://github.com/cjpais/transcribe-rs/pull/37

## Test plan
- [x] Full `cargo tauri build` succeeds on macOS with this change
- [ ] Verify app launches on macOS 10.15+

🤖 Generated with [Claude Code](https://claude.com/claude-code)