### PR TITLE
feat(local-api): add experimental localhost OpenAI + Wyoming endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,53 @@ handy --start-hidden --no-tray
 > /Applications/Handy.app/Contents/MacOS/Handy --toggle-transcription
 > ```
 
+### Local Programmatic STT APIs (Experimental)
+
+Handy can expose local speech-to-text endpoints so other tools can call the same model instance.
+
+Enable it in **Settings > Advanced > Experimental**:
+
+- Turn on **Experimental Features**
+- Turn on **Local API Service**
+- Choose **API Network Access**:
+  - `This computer only (127.0.0.1)` (recommended default)
+  - `Local network (0.0.0.0)`
+- Optional: set **API Access Token** to require `Authorization: Bearer <token>`
+
+Current default ports:
+
+- OpenAI-style HTTP API: `5500` (`/v1/audio/transcriptions`)
+- Wyoming TCP API: `10300`
+
+OpenAI-style endpoint (JSON mode):
+
+```bash
+curl -s http://127.0.0.1:5500/v1/audio/transcriptions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "audio_base64": "<BASE64_AUDIO>",
+    "encoding": "pcm_s16le",
+    "sample_rate": 16000
+  }'
+```
+
+OpenAI-style endpoint (multipart mode, compatible shape):
+
+```bash
+curl -s http://127.0.0.1:5500/v1/audio/transcriptions \
+  -H "Authorization: Bearer <token-if-configured>" \
+  -F "file=@sample.wav" \
+  -F "model=whisper-1" \
+  -F "response_format=json"
+```
+
+Wyoming flow:
+
+1. Send `{"type":"describe"}` to receive `info`
+2. Send `audio-start`
+3. Stream one or more `audio-chunk` events with `payload_length` + raw PCM16 payload
+4. Send `audio-stop` and read a `transcript` event response
+
 ## Known Issues & Current Limitations
 
 This project is actively being developed and has some [known issues](https://github.com/cjpais/Handy/issues). We believe in transparency about the current state:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -133,7 +133,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -144,7 +144,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -188,6 +188,12 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "ashpd"
@@ -800,6 +806,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,7 +1418,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1672,7 +1684,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2444,6 +2456,7 @@ name = "handy"
 version = "0.7.8"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "cpal",
@@ -2492,6 +2505,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tauri-specta",
  "tempfile",
+ "tiny_http",
  "tokio",
  "transcribe-rs",
  "vad-rs",
@@ -2576,11 +2590,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
-version = "0.5.12"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2646,6 +2660,12 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
@@ -2997,7 +3017,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4125,7 +4145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -5231,7 +5251,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6714,7 +6734,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6822,6 +6842,18 @@ checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
 ]
 
 [[package]]
@@ -7801,7 +7833,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,6 +47,7 @@ rusqlite_migration = "2.3"
 tauri-plugin-fs = "2.4.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+base64 = "0.22"
 rdev = { git = "https://github.com/rustdesk-org/rdev" }
 cpal = "0.16.0"
 anyhow = "1.0.95"
@@ -76,6 +77,7 @@ specta = "=2.0.0-rc.22"
 specta-typescript = "0.0.9"
 tauri-specta = { version = "=2.0.0-rc.21", features = ["derive", "typescript"] }
 tauri-plugin-dialog = "2"
+tiny_http = "0.12"
 
 [target.'cfg(unix)'.dependencies]
 signal-hook = "0.3"

--- a/src-tauri/src/api_server.rs
+++ b/src-tauri/src/api_server.rs
@@ -1,0 +1,1334 @@
+use crate::managers::transcription::TranscriptionManager;
+use crate::settings::{ApiNetworkScope, AppSettings};
+use anyhow::{anyhow, Context, Result};
+use base64::Engine as _;
+use log::{error, info, warn};
+use reqwest::Url;
+use rodio::{Decoder, Source};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, BufWriter, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+use tauri::AppHandle;
+use tiny_http::{Header, Method, Request, Response, Server, StatusCode};
+
+const HTTP_PORT: u16 = 5500;
+const WYOMING_PORT: u16 = 10300;
+const REQUIRED_SAMPLE_RATE: u32 = 16_000;
+
+trait Transcriber: Send + Sync {
+    fn transcribe(&self, samples: Vec<f32>) -> Result<String>;
+}
+
+struct ManagerTranscriber {
+    manager: Arc<TranscriptionManager>,
+}
+
+impl Transcriber for ManagerTranscriber {
+    fn transcribe(&self, samples: Vec<f32>) -> Result<String> {
+        self.manager.initiate_model_load();
+        self.manager.transcribe(samples)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct LocalApiRuntimeConfig {
+    enabled: bool,
+    scope: ApiNetworkScope,
+    token: Option<String>,
+}
+
+impl LocalApiRuntimeConfig {
+    fn from_settings(settings: &AppSettings) -> Self {
+        Self {
+            enabled: settings.local_api_enabled,
+            scope: settings.local_api_network_scope,
+            token: settings.local_api_token.as_ref().and_then(|token| {
+                let trimmed = token.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_string())
+                }
+            }),
+        }
+    }
+
+    fn host(&self) -> &'static str {
+        match self.scope {
+            ApiNetworkScope::Loopback => "127.0.0.1",
+            ApiNetworkScope::LocalNetwork => "0.0.0.0",
+        }
+    }
+
+    fn http_addr(&self) -> String {
+        format!("{}:{}", self.host(), HTTP_PORT)
+    }
+
+    fn wyoming_addr(&self) -> String {
+        format!("{}:{}", self.host(), WYOMING_PORT)
+    }
+}
+
+struct ServerWorker {
+    shutdown: Arc<AtomicBool>,
+    handle: thread::JoinHandle<()>,
+}
+
+impl ServerWorker {
+    fn stop(self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+        if let Err(err) = self.handle.join() {
+            warn!("Failed to join API server thread: {:?}", err);
+        }
+    }
+}
+
+pub struct ApiServerManager {
+    transcriber: Arc<dyn Transcriber>,
+    current_config: Mutex<Option<LocalApiRuntimeConfig>>,
+    http_worker: Mutex<Option<ServerWorker>>,
+    wyoming_worker: Mutex<Option<ServerWorker>>,
+}
+
+impl ApiServerManager {
+    pub fn new(app_handle: &AppHandle, transcription_manager: Arc<TranscriptionManager>) -> Self {
+        let transcriber: Arc<dyn Transcriber> = Arc::new(ManagerTranscriber {
+            manager: transcription_manager,
+        });
+
+        let manager = Self {
+            transcriber,
+            current_config: Mutex::new(None),
+            http_worker: Mutex::new(None),
+            wyoming_worker: Mutex::new(None),
+        };
+
+        let settings = crate::settings::get_settings(app_handle);
+        manager.apply_settings(&settings);
+
+        manager
+    }
+
+    pub fn apply_settings(&self, settings: &AppSettings) {
+        let next = LocalApiRuntimeConfig::from_settings(settings);
+        let mut current = self.current_config.lock().unwrap();
+
+        if current.as_ref() == Some(&next) {
+            return;
+        }
+
+        self.stop_all_workers();
+
+        if next.enabled {
+            self.start_workers(next.clone());
+            info!(
+                "Local API service enabled ({:?}); HTTP={}, Wyoming={}, auth={}",
+                next.scope,
+                next.http_addr(),
+                next.wyoming_addr(),
+                if next.token.is_some() { "on" } else { "off" }
+            );
+        } else {
+            info!("Local API service disabled");
+        }
+
+        *current = Some(next);
+    }
+
+    fn start_workers(&self, config: LocalApiRuntimeConfig) {
+        let http_shutdown = Arc::new(AtomicBool::new(false));
+        let wyoming_shutdown = Arc::new(AtomicBool::new(false));
+
+        let http_addr = config.http_addr();
+        let wyoming_addr = config.wyoming_addr();
+        let transcriber_for_http = self.transcriber.clone();
+        let transcriber_for_wyoming = self.transcriber.clone();
+        let http_config = config.clone();
+        let wyoming_config = config;
+
+        let http_shutdown_clone = http_shutdown.clone();
+        let http_handle = thread::spawn(move || {
+            run_http_server(
+                &http_addr,
+                transcriber_for_http,
+                http_config,
+                http_shutdown_clone,
+            );
+        });
+
+        let wyoming_shutdown_clone = wyoming_shutdown.clone();
+        let wyoming_handle = thread::spawn(move || {
+            run_wyoming_server(
+                &wyoming_addr,
+                transcriber_for_wyoming,
+                wyoming_config,
+                wyoming_shutdown_clone,
+            );
+        });
+
+        *self.http_worker.lock().unwrap() = Some(ServerWorker {
+            shutdown: http_shutdown,
+            handle: http_handle,
+        });
+
+        *self.wyoming_worker.lock().unwrap() = Some(ServerWorker {
+            shutdown: wyoming_shutdown,
+            handle: wyoming_handle,
+        });
+    }
+
+    fn stop_all_workers(&self) {
+        if let Some(worker) = self.http_worker.lock().unwrap().take() {
+            worker.stop();
+        }
+        if let Some(worker) = self.wyoming_worker.lock().unwrap().take() {
+            worker.stop();
+        }
+    }
+}
+
+impl Drop for ApiServerManager {
+    fn drop(&mut self) {
+        self.stop_all_workers();
+    }
+}
+
+#[derive(Deserialize)]
+struct JsonTranscriptionRequest {
+    audio_base64: String,
+    #[serde(default = "default_encoding")]
+    encoding: String,
+    sample_rate: Option<u32>,
+    response_format: Option<String>,
+}
+
+fn default_encoding() -> String {
+    "pcm_s16le".to_string()
+}
+
+#[derive(Clone, Copy)]
+enum HttpResponseFormat {
+    Json,
+    Text,
+    VerboseJson,
+}
+
+impl HttpResponseFormat {
+    fn parse(value: Option<&str>) -> Self {
+        match value.unwrap_or("json").to_ascii_lowercase().as_str() {
+            "text" => Self::Text,
+            "verbose_json" => Self::VerboseJson,
+            _ => Self::Json,
+        }
+    }
+}
+
+#[derive(Default)]
+struct ParsedHttpTranscriptionRequest {
+    samples: Vec<f32>,
+    response_format: HttpResponseFormat,
+    timestamp_granularities: Vec<String>,
+}
+
+impl Default for HttpResponseFormat {
+    fn default() -> Self {
+        HttpResponseFormat::Json
+    }
+}
+
+#[derive(Serialize)]
+struct HttpTranscriptionResponse {
+    text: String,
+}
+
+fn run_http_server(
+    addr: &str,
+    transcriber: Arc<dyn Transcriber>,
+    config: LocalApiRuntimeConfig,
+    shutdown: Arc<AtomicBool>,
+) {
+    let server = match Server::http(addr) {
+        Ok(server) => {
+            info!(
+                "Local OpenAI-style STT API listening on http://{}/v1/audio/transcriptions",
+                addr
+            );
+            server
+        }
+        Err(err) => {
+            error!("Failed to start local API server on {}: {}", addr, err);
+            return;
+        }
+    };
+
+    while !shutdown.load(Ordering::Relaxed) {
+        match server.recv_timeout(Duration::from_millis(250)) {
+            Ok(Some(request)) => handle_http_request(request, &transcriber, &config),
+            Ok(None) => continue,
+            Err(err) => {
+                warn!("Local API server receive error: {}", err);
+                thread::sleep(Duration::from_millis(100));
+            }
+        }
+    }
+}
+
+fn handle_http_request(
+    mut request: Request,
+    transcriber: &Arc<dyn Transcriber>,
+    config: &LocalApiRuntimeConfig,
+) {
+    let method = request.method().clone();
+    let url = request.url().to_string();
+    let origin = get_header_value(&request, "Origin");
+
+    let cors_origin = match evaluate_cors_origin(config.scope, origin.as_deref()) {
+        Ok(value) => value,
+        Err(err) => {
+            respond_error(request, StatusCode(403), &err.to_string(), None, false);
+            return;
+        }
+    };
+
+    if method == Method::Options {
+        respond(
+            request,
+            StatusCode(204),
+            "{}",
+            Some("application/json"),
+            cors_origin.as_deref(),
+            true,
+        );
+        return;
+    }
+
+    if method != Method::Post || url != "/v1/audio/transcriptions" {
+        respond(
+            request,
+            StatusCode(404),
+            "{\"error\":\"not found\"}",
+            Some("application/json"),
+            cors_origin.as_deref(),
+            false,
+        );
+        return;
+    }
+
+    if let Err(err) = authorize_http_request(&request, config.token.as_deref()) {
+        respond_error(
+            request,
+            StatusCode(401),
+            &err.to_string(),
+            cors_origin.as_deref(),
+            false,
+        );
+        return;
+    }
+
+    let mut body = Vec::new();
+    if let Err(err) = request.as_reader().read_to_end(&mut body) {
+        respond_error(
+            request,
+            StatusCode(400),
+            &format!("failed to read body: {}", err),
+            cors_origin.as_deref(),
+            false,
+        );
+        return;
+    }
+
+    let content_type = get_header_value(&request, "Content-Type").unwrap_or_default();
+    let parsed = match parse_http_transcription_request(&body, &content_type) {
+        Ok(parsed) => parsed,
+        Err(err) => {
+            respond_error(
+                request,
+                StatusCode(400),
+                &err.to_string(),
+                cors_origin.as_deref(),
+                false,
+            );
+            return;
+        }
+    };
+
+    let transcript = match transcriber.transcribe(parsed.samples) {
+        Ok(text) => text,
+        Err(err) => {
+            respond_error(
+                request,
+                StatusCode(500),
+                &err.to_string(),
+                cors_origin.as_deref(),
+                false,
+            );
+            return;
+        }
+    };
+
+    let body = match parsed.response_format {
+        HttpResponseFormat::Text => transcript.clone(),
+        HttpResponseFormat::VerboseJson => {
+            let include_segments = parsed
+                .timestamp_granularities
+                .iter()
+                .any(|value| value == "segment");
+
+            if include_segments {
+                json!({
+                    "task": "transcribe",
+                    "language": "unknown",
+                    "duration": 0.0,
+                    "text": transcript,
+                    "segments": [
+                        {
+                            "id": 0,
+                            "start": 0.0,
+                            "end": 0.0,
+                            "text": transcript,
+                            "tokens": []
+                        }
+                    ]
+                })
+                .to_string()
+            } else {
+                json!({
+                    "task": "transcribe",
+                    "language": "unknown",
+                    "duration": 0.0,
+                    "text": transcript
+                })
+                .to_string()
+            }
+        }
+        HttpResponseFormat::Json => {
+            serde_json::to_string(&HttpTranscriptionResponse { text: transcript })
+                .unwrap_or_else(|_| "{\"text\":\"\"}".to_string())
+        }
+    };
+
+    let content_type = match parsed.response_format {
+        HttpResponseFormat::Text => Some("text/plain; charset=utf-8"),
+        _ => Some("application/json"),
+    };
+
+    respond(
+        request,
+        StatusCode(200),
+        &body,
+        content_type,
+        cors_origin.as_deref(),
+        false,
+    );
+}
+
+fn parse_http_transcription_request(
+    body: &[u8],
+    content_type: &str,
+) -> Result<ParsedHttpTranscriptionRequest> {
+    if let Some(boundary) = parse_multipart_boundary(content_type) {
+        parse_multipart_transcription_request(body, &boundary)
+    } else {
+        parse_json_transcription_request(body)
+    }
+}
+
+fn parse_json_transcription_request(body: &[u8]) -> Result<ParsedHttpTranscriptionRequest> {
+    let payload: JsonTranscriptionRequest = serde_json::from_slice(body)
+        .context("request must be JSON with audio_base64 and optional encoding/sample_rate")?;
+
+    let audio_bytes = base64::engine::general_purpose::STANDARD
+        .decode(payload.audio_base64.as_bytes())
+        .context("invalid base64 audio payload")?;
+
+    let samples = decode_samples(&audio_bytes, &payload.encoding, payload.sample_rate)?;
+
+    Ok(ParsedHttpTranscriptionRequest {
+        samples,
+        response_format: HttpResponseFormat::parse(payload.response_format.as_deref()),
+        timestamp_granularities: Vec::new(),
+    })
+}
+
+#[derive(Default)]
+struct MultipartFile {
+    data: Vec<u8>,
+}
+
+#[derive(Default)]
+struct MultipartFormData {
+    file: Option<MultipartFile>,
+    fields: HashMap<String, Vec<String>>,
+}
+
+impl MultipartFormData {
+    fn push_field(&mut self, name: String, value: String) {
+        self.fields.entry(name).or_default().push(value);
+    }
+
+    fn first_value(&self, name: &str) -> Option<&str> {
+        self.fields
+            .get(name)
+            .and_then(|values| values.first().map(String::as_str))
+    }
+}
+
+fn parse_multipart_transcription_request(
+    body: &[u8],
+    boundary: &str,
+) -> Result<ParsedHttpTranscriptionRequest> {
+    let form = parse_multipart_form_data(body, boundary)?;
+    let file_data = form
+        .file
+        .as_ref()
+        .ok_or_else(|| anyhow!("multipart request must include a 'file' field"))?;
+
+    let samples = decode_audio_unknown(&file_data.data)?;
+    let timestamp_granularities = form
+        .fields
+        .get("timestamp_granularities[]")
+        .cloned()
+        .unwrap_or_default();
+
+    Ok(ParsedHttpTranscriptionRequest {
+        samples,
+        response_format: HttpResponseFormat::parse(form.first_value("response_format")),
+        timestamp_granularities,
+    })
+}
+
+fn parse_multipart_boundary(content_type: &str) -> Option<String> {
+    let lowered = content_type.to_ascii_lowercase();
+    if !lowered.starts_with("multipart/form-data") {
+        return None;
+    }
+
+    for part in content_type.split(';').map(str::trim) {
+        if let Some(value) = part.strip_prefix("boundary=") {
+            let trimmed = value.trim_matches('"').trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
+
+    None
+}
+
+fn parse_multipart_form_data(body: &[u8], boundary: &str) -> Result<MultipartFormData> {
+    let delimiter = format!("--{}", boundary).into_bytes();
+    let mut marker = Vec::with_capacity(2 + boundary.len());
+    marker.extend_from_slice(b"\r\n--");
+    marker.extend_from_slice(boundary.as_bytes());
+
+    let mut position = find_subslice_from(body, &delimiter, 0)
+        .ok_or_else(|| anyhow!("invalid multipart body: boundary not found"))?;
+    let mut form = MultipartFormData::default();
+
+    loop {
+        position += delimiter.len();
+
+        if body.get(position..position + 2) == Some(b"--") {
+            break;
+        }
+
+        if body.get(position..position + 2) != Some(b"\r\n") {
+            return Err(anyhow!("invalid multipart body framing"));
+        }
+        position += 2;
+
+        let header_end = find_subslice_from(body, b"\r\n\r\n", position)
+            .ok_or_else(|| anyhow!("invalid multipart part headers"))?;
+        let header_bytes = &body[position..header_end];
+        let headers = parse_part_headers(header_bytes)?;
+        let part_start = header_end + 4;
+        let part_end = find_subslice_from(body, &marker, part_start)
+            .ok_or_else(|| anyhow!("multipart part missing trailing boundary"))?;
+        let part_data = &body[part_start..part_end];
+
+        let disposition = headers
+            .get("content-disposition")
+            .ok_or_else(|| anyhow!("multipart part missing Content-Disposition header"))?;
+        let name = parse_content_disposition_name(disposition)
+            .ok_or_else(|| anyhow!("multipart part missing field name"))?;
+
+        if name == "file" {
+            form.file = Some(MultipartFile {
+                data: part_data.to_vec(),
+            });
+        } else {
+            let value = String::from_utf8(part_data.to_vec())
+                .context("multipart text fields must be valid UTF-8")?;
+            form.push_field(name, value);
+        }
+
+        position = part_end + 2;
+    }
+
+    Ok(form)
+}
+
+fn parse_part_headers(header_bytes: &[u8]) -> Result<HashMap<String, String>> {
+    let mut headers = HashMap::new();
+    for line in header_bytes.split(|byte| *byte == b'\n') {
+        let line = String::from_utf8(line.to_vec())?.trim().to_string();
+        if line.is_empty() {
+            continue;
+        }
+
+        let (name, value) = line
+            .split_once(':')
+            .ok_or_else(|| anyhow!("invalid multipart part header"))?;
+        headers.insert(name.trim().to_ascii_lowercase(), value.trim().to_string());
+    }
+    Ok(headers)
+}
+
+fn parse_content_disposition_name(value: &str) -> Option<String> {
+    for part in value.split(';').map(str::trim) {
+        if let Some(name) = part.strip_prefix("name=") {
+            return Some(name.trim_matches('"').to_string());
+        }
+    }
+    None
+}
+
+fn find_subslice_from(haystack: &[u8], needle: &[u8], from: usize) -> Option<usize> {
+    if needle.is_empty() || from >= haystack.len() {
+        return None;
+    }
+
+    haystack[from..]
+        .windows(needle.len())
+        .position(|window| window == needle)
+        .map(|offset| from + offset)
+}
+
+fn decode_samples(bytes: &[u8], encoding: &str, sample_rate: Option<u32>) -> Result<Vec<f32>> {
+    match encoding.to_ascii_lowercase().as_str() {
+        "pcm_s16le" => decode_pcm_s16le(bytes, sample_rate),
+        "wav" => decode_wav(bytes),
+        _ => Err(anyhow!(
+            "unsupported encoding '{}'; expected pcm_s16le or wav",
+            encoding
+        )),
+    }
+}
+
+fn decode_audio_unknown(bytes: &[u8]) -> Result<Vec<f32>> {
+    if let Ok(wav) = decode_wav(bytes) {
+        return Ok(wav);
+    }
+
+    decode_with_rodio(bytes)
+}
+
+fn decode_with_rodio(bytes: &[u8]) -> Result<Vec<f32>> {
+    let cursor = std::io::Cursor::new(bytes.to_vec());
+    let decoder = Decoder::new(cursor).context("unsupported or invalid audio format")?;
+    let input_rate = decoder.sample_rate();
+    let channels = usize::from(decoder.channels().max(1));
+    let interleaved: Vec<f32> = decoder.collect();
+
+    if interleaved.is_empty() {
+        return Err(anyhow!("audio payload is empty"));
+    }
+
+    let mono = if channels == 1 {
+        interleaved
+    } else {
+        interleaved
+            .chunks(channels)
+            .map(|frame| {
+                let sum: f32 = frame.iter().copied().sum();
+                sum / frame.len() as f32
+            })
+            .collect()
+    };
+
+    if input_rate == REQUIRED_SAMPLE_RATE {
+        Ok(mono)
+    } else {
+        Ok(resample_linear(&mono, input_rate, REQUIRED_SAMPLE_RATE))
+    }
+}
+
+fn resample_linear(samples: &[f32], in_rate: u32, out_rate: u32) -> Vec<f32> {
+    if samples.is_empty() || in_rate == 0 || out_rate == 0 || in_rate == out_rate {
+        return samples.to_vec();
+    }
+
+    let ratio = out_rate as f64 / in_rate as f64;
+    let out_len = ((samples.len() as f64) * ratio).round().max(1.0) as usize;
+    let mut out = Vec::with_capacity(out_len);
+
+    for idx in 0..out_len {
+        let src = idx as f64 / ratio;
+        let left = src.floor() as usize;
+        let right = (left + 1).min(samples.len() - 1);
+        let frac = (src - left as f64) as f32;
+        let value = samples[left] + (samples[right] - samples[left]) * frac;
+        out.push(value);
+    }
+
+    out
+}
+
+fn decode_pcm_s16le(bytes: &[u8], sample_rate: Option<u32>) -> Result<Vec<f32>> {
+    if sample_rate.unwrap_or(REQUIRED_SAMPLE_RATE) != REQUIRED_SAMPLE_RATE {
+        return Err(anyhow!(
+            "unsupported sample_rate (expected {} Hz)",
+            REQUIRED_SAMPLE_RATE
+        ));
+    }
+
+    if bytes.len() % 2 != 0 {
+        return Err(anyhow!("pcm_s16le payload must have even byte length"));
+    }
+
+    Ok(bytes
+        .chunks_exact(2)
+        .map(|chunk| i16::from_le_bytes([chunk[0], chunk[1]]) as f32 / i16::MAX as f32)
+        .collect())
+}
+
+fn decode_wav(bytes: &[u8]) -> Result<Vec<f32>> {
+    let cursor = std::io::Cursor::new(bytes.to_vec());
+    let mut reader = hound::WavReader::new(cursor).context("invalid WAV payload")?;
+    let spec = reader.spec();
+
+    if spec.channels != 1 {
+        return Err(anyhow!("WAV payload must be mono"));
+    }
+
+    if spec.sample_rate != REQUIRED_SAMPLE_RATE {
+        return Err(anyhow!("WAV payload must be {} Hz", REQUIRED_SAMPLE_RATE));
+    }
+
+    match (spec.sample_format, spec.bits_per_sample) {
+        (hound::SampleFormat::Int, 16) => Ok(reader
+            .samples::<i16>()
+            .collect::<std::result::Result<Vec<_>, _>>()?
+            .into_iter()
+            .map(|sample| sample as f32 / i16::MAX as f32)
+            .collect()),
+        (hound::SampleFormat::Float, 32) => Ok(reader
+            .samples::<f32>()
+            .collect::<std::result::Result<Vec<_>, _>>()?),
+        _ => Err(anyhow!(
+            "unsupported WAV format; expected 16-bit PCM or 32-bit float"
+        )),
+    }
+}
+
+fn get_header_value(request: &Request, name: &str) -> Option<String> {
+    request
+        .headers()
+        .iter()
+        .find(|header| header.field.as_str().to_string().eq_ignore_ascii_case(name))
+        .map(|header| header.value.as_str().to_string())
+}
+
+fn authorize_http_request(request: &Request, required_token: Option<&str>) -> Result<()> {
+    let Some(required_token) = required_token else {
+        return Ok(());
+    };
+
+    let auth_header = get_header_value(request, "Authorization")
+        .ok_or_else(|| anyhow!("missing Authorization header"))?;
+    let provided = auth_header
+        .strip_prefix("Bearer ")
+        .ok_or_else(|| anyhow!("Authorization header must use Bearer token"))?;
+
+    if provided == required_token {
+        Ok(())
+    } else {
+        Err(anyhow!("invalid API token"))
+    }
+}
+
+fn evaluate_cors_origin(scope: ApiNetworkScope, origin: Option<&str>) -> Result<Option<String>> {
+    let Some(origin) = origin else {
+        return Ok(None);
+    };
+
+    match scope {
+        ApiNetworkScope::Loopback => {
+            let parsed = Url::parse(origin).context("invalid Origin header")?;
+            let host = parsed.host_str().unwrap_or_default();
+
+            if host.eq_ignore_ascii_case("localhost") || host == "127.0.0.1" || host == "::1" {
+                Ok(Some(origin.to_string()))
+            } else {
+                Err(anyhow!(
+                    "Origin not allowed in loopback mode (use localhost/127.0.0.1)"
+                ))
+            }
+        }
+        ApiNetworkScope::LocalNetwork => Err(anyhow!(
+            "browser cross-origin access is disabled in local network mode"
+        )),
+    }
+}
+
+fn respond(
+    request: Request,
+    status: StatusCode,
+    body: &str,
+    content_type: Option<&str>,
+    cors_origin: Option<&str>,
+    is_preflight: bool,
+) {
+    let mut response = Response::from_string(body.to_string()).with_status_code(status);
+
+    if let Some(content_type) = content_type {
+        if let Ok(header) = Header::from_bytes("Content-Type", content_type) {
+            response.add_header(header);
+        }
+    }
+
+    if let Some(origin) = cors_origin {
+        if let Ok(header) = Header::from_bytes("Access-Control-Allow-Origin", origin) {
+            response.add_header(header);
+        }
+        if let Ok(header) = Header::from_bytes("Vary", "Origin") {
+            response.add_header(header);
+        }
+        if let Ok(header) = Header::from_bytes(
+            "Access-Control-Allow-Headers",
+            "Content-Type, Authorization",
+        ) {
+            response.add_header(header);
+        }
+        if let Ok(header) = Header::from_bytes("Access-Control-Allow-Methods", "POST, OPTIONS") {
+            response.add_header(header);
+        }
+        if is_preflight {
+            if let Ok(header) = Header::from_bytes("Access-Control-Max-Age", "600") {
+                response.add_header(header);
+            }
+        }
+    }
+
+    if let Err(err) = request.respond(response) {
+        warn!("Failed to send local API response: {}", err);
+    }
+}
+
+fn respond_error(
+    request: Request,
+    status: StatusCode,
+    message: &str,
+    cors_origin: Option<&str>,
+    is_preflight: bool,
+) {
+    let body = json!({
+        "error": {
+            "code": status.0,
+            "message": message
+        }
+    })
+    .to_string();
+
+    respond(
+        request,
+        status,
+        &body,
+        Some("application/json"),
+        cors_origin,
+        is_preflight,
+    );
+}
+
+#[derive(Debug, Deserialize)]
+struct WyomingHeaderIn {
+    #[serde(rename = "type")]
+    event_type: String,
+    #[serde(default)]
+    data: Value,
+    #[serde(default)]
+    payload_length: Option<usize>,
+}
+
+#[derive(Serialize)]
+struct WyomingHeaderOut {
+    #[serde(rename = "type")]
+    event_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    payload_length: Option<usize>,
+}
+
+fn run_wyoming_server(
+    addr: &str,
+    transcriber: Arc<dyn Transcriber>,
+    config: LocalApiRuntimeConfig,
+    shutdown: Arc<AtomicBool>,
+) {
+    let listener = match TcpListener::bind(addr) {
+        Ok(listener) => {
+            if let Err(err) = listener.set_nonblocking(true) {
+                error!("Failed to set Wyoming listener non-blocking mode: {}", err);
+                return;
+            }
+            info!("Wyoming-compatible ASR server listening on {}", addr);
+            listener
+        }
+        Err(err) => {
+            error!("Failed to bind Wyoming server on {}: {}", addr, err);
+            return;
+        }
+    };
+
+    while !shutdown.load(Ordering::Relaxed) {
+        match listener.accept() {
+            Ok((stream, peer)) => {
+                if let Err(err) = stream.set_nonblocking(false) {
+                    warn!("Failed to set Wyoming stream blocking mode: {}", err);
+                    continue;
+                }
+                let transcriber = transcriber.clone();
+                let required_token = config.token.clone();
+                thread::spawn(move || {
+                    if let Err(err) = handle_wyoming_connection(stream, transcriber, required_token)
+                    {
+                        warn!("Wyoming connection {} ended with error: {}", peer, err);
+                    }
+                });
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(50));
+            }
+            Err(err) => {
+                warn!("Wyoming accept error: {}", err);
+                thread::sleep(Duration::from_millis(100));
+            }
+        }
+    }
+}
+
+fn handle_wyoming_connection(
+    stream: TcpStream,
+    transcriber: Arc<dyn Transcriber>,
+    required_token: Option<String>,
+) -> Result<()> {
+    let reader_stream = stream.try_clone().context("failed to clone TCP stream")?;
+    let mut reader = BufReader::new(reader_stream);
+    let mut writer = BufWriter::new(stream);
+
+    let mut audio_buffer: Vec<u8> = Vec::new();
+    let mut sample_rate: u32 = REQUIRED_SAMPLE_RATE;
+    let mut authenticated = required_token.is_none();
+
+    loop {
+        let event = match read_wyoming_event(&mut reader)? {
+            Some(event) => event,
+            None => break,
+        };
+
+        match event.event_type.as_str() {
+            "describe" => {
+                let info_payload = json!({
+                    "asr": [{
+                        "name": "handy",
+                        "description": "Handy local ASR",
+                        "attribution": { "name": "Handy" }
+                    }],
+                    "auth_required": required_token.is_some()
+                });
+                write_wyoming_event(&mut writer, "info", Some(info_payload), None)?;
+            }
+            "auth" => {
+                let provided = event.data.get("token").and_then(Value::as_str);
+                if provided == required_token.as_deref() {
+                    authenticated = true;
+                    write_wyoming_event(
+                        &mut writer,
+                        "auth-ok",
+                        Some(json!({ "status": "ok" })),
+                        None,
+                    )?;
+                } else {
+                    write_wyoming_event(
+                        &mut writer,
+                        "error",
+                        Some(json!({ "message": "invalid token" })),
+                        None,
+                    )?;
+                    break;
+                }
+            }
+            "audio-start" | "audio-chunk" | "audio-stop" | "transcribe" => {
+                if !authenticated {
+                    write_wyoming_event(
+                        &mut writer,
+                        "error",
+                        Some(json!({ "message": "unauthorized: send auth event first" })),
+                        None,
+                    )?;
+                    break;
+                }
+
+                match event.event_type.as_str() {
+                    "audio-start" => {
+                        audio_buffer.clear();
+                        sample_rate = event
+                            .data
+                            .get("rate")
+                            .and_then(Value::as_u64)
+                            .map(|rate| rate as u32)
+                            .unwrap_or(REQUIRED_SAMPLE_RATE);
+                    }
+                    "audio-chunk" => {
+                        if let Some(payload) =
+                            event_payload_bytes(event.payload_length, &mut reader)?
+                        {
+                            audio_buffer.extend_from_slice(&payload);
+                        }
+                    }
+                    "audio-stop" => {
+                        let samples = decode_pcm_s16le(&audio_buffer, Some(sample_rate))?;
+                        let transcript = transcriber.transcribe(samples)?;
+                        write_wyoming_event(
+                            &mut writer,
+                            "transcript",
+                            Some(json!({ "text": transcript })),
+                            None,
+                        )?;
+                        audio_buffer.clear();
+                    }
+                    _ => {}
+                }
+            }
+            _ => {
+                write_wyoming_event(
+                    &mut writer,
+                    "error",
+                    Some(json!({
+                        "message": format!("unsupported event type '{}'", event.event_type)
+                    })),
+                    None,
+                )?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn read_wyoming_event<R: BufRead>(reader: &mut R) -> Result<Option<WyomingHeaderIn>> {
+    let mut line = String::new();
+    let bytes_read = reader.read_line(&mut line)?;
+    if bytes_read == 0 {
+        return Ok(None);
+    }
+
+    let header: WyomingHeaderIn =
+        serde_json::from_str(line.trim_end()).context("invalid Wyoming JSON header")?;
+    Ok(Some(header))
+}
+
+fn event_payload_bytes<R: Read>(
+    payload_length: Option<usize>,
+    reader: &mut R,
+) -> Result<Option<Vec<u8>>> {
+    let Some(payload_length) = payload_length else {
+        return Ok(None);
+    };
+
+    let mut payload = vec![0_u8; payload_length];
+    reader
+        .read_exact(&mut payload)
+        .context("failed to read Wyoming payload bytes")?;
+    Ok(Some(payload))
+}
+
+fn write_wyoming_event<W: Write>(
+    writer: &mut W,
+    event_type: &str,
+    data: Option<Value>,
+    payload: Option<&[u8]>,
+) -> Result<()> {
+    let header = WyomingHeaderOut {
+        event_type: event_type.to_string(),
+        data,
+        payload_length: payload.map(|bytes| bytes.len()),
+    };
+
+    let mut line = serde_json::to_string(&header)?;
+    line.push('\n');
+    writer.write_all(line.as_bytes())?;
+
+    if let Some(payload) = payload {
+        writer.write_all(payload)?;
+    }
+
+    writer.flush()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::engine::general_purpose::STANDARD;
+    use std::io::Read;
+    use std::net::TcpStream;
+
+    struct MockTranscriber;
+
+    impl Transcriber for MockTranscriber {
+        fn transcribe(&self, _samples: Vec<f32>) -> Result<String> {
+            Ok("mock transcript".to_string())
+        }
+    }
+
+    fn free_port() -> u16 {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        port
+    }
+
+    fn spawn_http_server(
+        config: LocalApiRuntimeConfig,
+    ) -> (String, Arc<AtomicBool>, thread::JoinHandle<()>) {
+        let port = free_port();
+        let addr = format!("127.0.0.1:{}", port);
+        let addr_for_thread = addr.clone();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_clone = shutdown.clone();
+        let transcriber: Arc<dyn Transcriber> = Arc::new(MockTranscriber);
+
+        let handle = thread::spawn(move || {
+            run_http_server(&addr_for_thread, transcriber, config, shutdown_clone);
+        });
+
+        thread::sleep(Duration::from_millis(120));
+        (addr, shutdown, handle)
+    }
+
+    fn spawn_wyoming_server(
+        config: LocalApiRuntimeConfig,
+    ) -> (String, Arc<AtomicBool>, thread::JoinHandle<()>) {
+        let port = free_port();
+        let addr = format!("127.0.0.1:{}", port);
+        let addr_for_thread = addr.clone();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_clone = shutdown.clone();
+        let transcriber: Arc<dyn Transcriber> = Arc::new(MockTranscriber);
+
+        let handle = thread::spawn(move || {
+            run_wyoming_server(&addr_for_thread, transcriber, config, shutdown_clone);
+        });
+
+        thread::sleep(Duration::from_millis(120));
+        (addr, shutdown, handle)
+    }
+
+    fn stop_server(shutdown: Arc<AtomicBool>, handle: thread::JoinHandle<()>) {
+        shutdown.store(true, Ordering::Relaxed);
+        let _ = handle.join();
+    }
+
+    fn send_http(addr: &str, raw_request: &[u8]) -> String {
+        let mut stream = TcpStream::connect(addr).unwrap();
+        stream.write_all(raw_request).unwrap();
+        stream.shutdown(std::net::Shutdown::Write).unwrap();
+
+        let mut response = String::new();
+        stream.read_to_string(&mut response).unwrap();
+        response
+    }
+
+    fn test_wav_bytes() -> Vec<u8> {
+        let mut cursor = std::io::Cursor::new(Vec::<u8>::new());
+        {
+            let spec = hound::WavSpec {
+                channels: 1,
+                sample_rate: REQUIRED_SAMPLE_RATE,
+                bits_per_sample: 16,
+                sample_format: hound::SampleFormat::Int,
+            };
+            let mut writer = hound::WavWriter::new(&mut cursor, spec).unwrap();
+            for _ in 0..320 {
+                writer.write_sample::<i16>(0).unwrap();
+            }
+            writer.finalize().unwrap();
+        }
+        cursor.into_inner()
+    }
+
+    #[test]
+    fn http_json_request_returns_transcript() {
+        let config = LocalApiRuntimeConfig {
+            enabled: true,
+            scope: ApiNetworkScope::Loopback,
+            token: None,
+        };
+        let (addr, shutdown, handle) = spawn_http_server(config);
+
+        let pcm = vec![0_u8; 640];
+        let body = json!({
+            "audio_base64": STANDARD.encode(pcm),
+            "encoding": "pcm_s16le",
+            "sample_rate": 16000
+        })
+        .to_string();
+
+        let request = format!(
+            "POST /v1/audio/transcriptions HTTP/1.1\r\nHost: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            addr,
+            body.len(),
+            body
+        );
+
+        let response = send_http(&addr, request.as_bytes());
+        assert!(response.starts_with("HTTP/1.1 200"));
+        assert!(response.contains("mock transcript"));
+
+        stop_server(shutdown, handle);
+    }
+
+    #[test]
+    fn http_multipart_request_returns_transcript() {
+        let config = LocalApiRuntimeConfig {
+            enabled: true,
+            scope: ApiNetworkScope::Loopback,
+            token: None,
+        };
+        let (addr, shutdown, handle) = spawn_http_server(config);
+
+        let boundary = "----handyBoundary";
+        let wav = test_wav_bytes();
+        let mut body = Vec::new();
+        body.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
+        body.extend_from_slice(
+            b"Content-Disposition: form-data; name=\"file\"; filename=\"sample.wav\"\r\n",
+        );
+        body.extend_from_slice(b"Content-Type: audio/wav\r\n\r\n");
+        body.extend_from_slice(&wav);
+        body.extend_from_slice(b"\r\n");
+        body.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
+        body.extend_from_slice(b"Content-Disposition: form-data; name=\"response_format\"\r\n\r\n");
+        body.extend_from_slice(b"json\r\n");
+        body.extend_from_slice(format!("--{}--\r\n", boundary).as_bytes());
+
+        let request_head = format!(
+            "POST /v1/audio/transcriptions HTTP/1.1\r\nHost: {}\r\nContent-Type: multipart/form-data; boundary={}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            addr,
+            boundary,
+            body.len()
+        );
+
+        let mut raw = request_head.into_bytes();
+        raw.extend_from_slice(&body);
+
+        let response = send_http(&addr, &raw);
+        assert!(response.starts_with("HTTP/1.1 200"));
+        assert!(response.contains("mock transcript"));
+
+        stop_server(shutdown, handle);
+    }
+
+    #[test]
+    fn http_auth_token_is_enforced() {
+        let config = LocalApiRuntimeConfig {
+            enabled: true,
+            scope: ApiNetworkScope::Loopback,
+            token: Some("secret-token".to_string()),
+        };
+        let (addr, shutdown, handle) = spawn_http_server(config);
+
+        let pcm = vec![0_u8; 640];
+        let body = json!({
+            "audio_base64": STANDARD.encode(pcm),
+            "encoding": "pcm_s16le",
+            "sample_rate": 16000
+        })
+        .to_string();
+
+        let unauthorized = format!(
+            "POST /v1/audio/transcriptions HTTP/1.1\r\nHost: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            addr,
+            body.len(),
+            body
+        );
+
+        let unauthorized_response = send_http(&addr, unauthorized.as_bytes());
+        assert!(unauthorized_response.starts_with("HTTP/1.1 401"));
+
+        let authorized = format!(
+            "POST /v1/audio/transcriptions HTTP/1.1\r\nHost: {}\r\nAuthorization: Bearer secret-token\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            addr,
+            body.len(),
+            body
+        );
+
+        let authorized_response = send_http(&addr, authorized.as_bytes());
+        assert!(authorized_response.starts_with("HTTP/1.1 200"));
+
+        stop_server(shutdown, handle);
+    }
+
+    #[test]
+    fn wyoming_transcript_flow_works() {
+        let config = LocalApiRuntimeConfig {
+            enabled: true,
+            scope: ApiNetworkScope::Loopback,
+            token: None,
+        };
+        let (addr, shutdown, handle) = spawn_wyoming_server(config);
+
+        let mut stream = TcpStream::connect(addr).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .unwrap();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+
+        stream.write_all(b"{\"type\":\"describe\"}\n").unwrap();
+
+        let mut line = String::new();
+        reader.read_line(&mut line).unwrap();
+        assert!(line.contains("\"type\":\"info\""));
+
+        stream
+            .write_all(b"{\"type\":\"audio-start\",\"data\":{\"rate\":16000}}\n")
+            .unwrap();
+
+        let payload = vec![0_u8; 640];
+        stream
+            .write_all(
+                format!(
+                    "{{\"type\":\"audio-chunk\",\"payload_length\":{}}}\n",
+                    payload.len()
+                )
+                .as_bytes(),
+            )
+            .unwrap();
+        stream.write_all(&payload).unwrap();
+        stream.write_all(b"{\"type\":\"audio-stop\"}\n").unwrap();
+
+        let mut saw_transcript = false;
+        for _ in 0..3 {
+            line.clear();
+            reader.read_line(&mut line).unwrap();
+            if line.contains("\"type\":\"transcript\"") && line.contains("mock transcript") {
+                saw_transcript = true;
+                break;
+            }
+            if line.is_empty() {
+                break;
+            }
+        }
+        assert!(saw_transcript);
+
+        stop_server(shutdown, handle);
+    }
+}

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -169,6 +169,19 @@ pub enum KeyboardImplementation {
     HandyKeys,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum ApiNetworkScope {
+    Loopback,
+    LocalNetwork,
+}
+
+impl Default for ApiNetworkScope {
+    fn default() -> Self {
+        ApiNetworkScope::Loopback
+    }
+}
+
 impl Default for KeyboardImplementation {
     fn default() -> Self {
         // Default to HandyKeys only on macOS where it's well-tested.
@@ -351,6 +364,12 @@ pub struct AppSettings {
     pub app_language: String,
     #[serde(default)]
     pub experimental_enabled: bool,
+    #[serde(default)]
+    pub local_api_enabled: bool,
+    #[serde(default)]
+    pub local_api_network_scope: ApiNetworkScope,
+    #[serde(default)]
+    pub local_api_token: Option<String>,
     #[serde(default)]
     pub keyboard_implementation: KeyboardImplementation,
     #[serde(default = "default_show_tray_icon")]
@@ -719,6 +738,9 @@ pub fn get_default_settings() -> AppSettings {
         append_trailing_space: false,
         app_language: default_app_language(),
         experimental_enabled: false,
+        local_api_enabled: false,
+        local_api_network_scope: ApiNetworkScope::Loopback,
+        local_api_token: None,
         keyboard_implementation: KeyboardImplementation::default(),
         show_tray_icon: default_show_tray_icon(),
         paste_delay_ms: default_paste_delay_ms(),

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -176,6 +176,30 @@ async changeExperimentalEnabledSetting(enabled: boolean) : Promise<Result<null, 
     else return { status: "error", error: e  as any };
 }
 },
+async changeLocalApiEnabledSetting(enabled: boolean) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("change_local_api_enabled_setting", { enabled }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async changeLocalApiNetworkScopeSetting(scope: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("change_local_api_network_scope_setting", { scope }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async changeLocalApiTokenSetting(token: string | null) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("change_local_api_token_setting", { token }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async changePostProcessBaseUrlSetting(providerId: string, baseUrl: string) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("change_post_process_base_url_setting", { providerId, baseUrl }) };
@@ -738,8 +762,9 @@ async isLaptop() : Promise<Result<boolean, string>> {
 
 /** user-defined types **/
 
-export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk: boolean; audio_feedback: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; selected_model?: string; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: Partial<{ [key in string]: string }>; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; experimental_enabled?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool; external_script_path: string | null }
+export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk: boolean; audio_feedback: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; selected_model?: string; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: Partial<{ [key in string]: string }>; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; experimental_enabled?: boolean; local_api_enabled?: boolean; local_api_network_scope?: ApiNetworkScope; local_api_token?: string | null; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool; external_script_path: string | null }
 export type AudioDevice = { index: string; name: string; is_default: boolean }
+export type ApiNetworkScope = "loopback" | "local_network"
 export type AutoSubmitKey = "enter" | "ctrl_enter" | "cmd_enter"
 export type BindingResponse = { success: boolean; binding: ShortcutBinding | null; error: string | null }
 export type ClipboardHandling = "dont_modify" | "copy_to_clipboard"

--- a/src/components/settings/LocalApiEnabled.tsx
+++ b/src/components/settings/LocalApiEnabled.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { ToggleSwitch } from "../ui/ToggleSwitch";
+import { useSettings } from "../../hooks/useSettings";
+
+interface LocalApiEnabledProps {
+  descriptionMode?: "inline" | "tooltip";
+  grouped?: boolean;
+}
+
+export const LocalApiEnabled: React.FC<LocalApiEnabledProps> = React.memo(
+  ({ descriptionMode = "tooltip", grouped = false }) => {
+    const { t } = useTranslation();
+    const { getSetting, updateSetting, isUpdating } = useSettings();
+
+    const enabled = getSetting("local_api_enabled") ?? false;
+
+    return (
+      <ToggleSwitch
+        checked={enabled}
+        onChange={(value) => updateSetting("local_api_enabled", value)}
+        isUpdating={isUpdating("local_api_enabled")}
+        label={t("settings.advanced.localApiEnabled.label")}
+        description={t("settings.advanced.localApiEnabled.description")}
+        descriptionMode={descriptionMode}
+        grouped={grouped}
+      />
+    );
+  },
+);

--- a/src/components/settings/LocalApiNetworkScope.tsx
+++ b/src/components/settings/LocalApiNetworkScope.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { Dropdown } from "../ui/Dropdown";
+import { SettingContainer } from "../ui/SettingContainer";
+import { useSettings } from "../../hooks/useSettings";
+import type { ApiNetworkScope } from "@/bindings";
+
+interface LocalApiNetworkScopeProps {
+  descriptionMode?: "tooltip" | "inline";
+  grouped?: boolean;
+}
+
+export const LocalApiNetworkScope: React.FC<LocalApiNetworkScopeProps> = ({
+  descriptionMode = "inline",
+  grouped = false,
+}) => {
+  const { t } = useTranslation();
+  const { getSetting, updateSetting, isUpdating } = useSettings();
+
+  const enabled = getSetting("local_api_enabled") ?? false;
+  const value =
+    (getSetting("local_api_network_scope") as ApiNetworkScope | undefined) ??
+    "loopback";
+
+  const options = [
+    {
+      value: "loopback" as ApiNetworkScope,
+      label: t("settings.advanced.localApiNetwork.options.loopback"),
+    },
+    {
+      value: "local_network" as ApiNetworkScope,
+      label: t("settings.advanced.localApiNetwork.options.localNetwork"),
+    },
+  ];
+
+  return (
+    <SettingContainer
+      title={t("settings.advanced.localApiNetwork.title")}
+      description={t("settings.advanced.localApiNetwork.description")}
+      descriptionMode={descriptionMode}
+      grouped={grouped}
+      disabled={!enabled}
+    >
+      <Dropdown
+        options={options}
+        selectedValue={value}
+        onSelect={(nextValue) =>
+          updateSetting("local_api_network_scope", nextValue as ApiNetworkScope)
+        }
+        disabled={!enabled || isUpdating("local_api_network_scope")}
+      />
+    </SettingContainer>
+  );
+};

--- a/src/components/settings/LocalApiToken.tsx
+++ b/src/components/settings/LocalApiToken.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Input } from "../ui/Input";
+import { SettingContainer } from "../ui/SettingContainer";
+import { useSettings } from "../../hooks/useSettings";
+
+interface LocalApiTokenProps {
+  descriptionMode?: "tooltip" | "inline";
+  grouped?: boolean;
+}
+
+export const LocalApiToken: React.FC<LocalApiTokenProps> = ({
+  descriptionMode = "inline",
+  grouped = false,
+}) => {
+  const { t } = useTranslation();
+  const { getSetting, updateSetting, isUpdating } = useSettings();
+
+  const enabled = getSetting("local_api_enabled") ?? false;
+  const storedToken = getSetting("local_api_token") ?? "";
+  const [value, setValue] = useState(storedToken);
+
+  useEffect(() => {
+    setValue(storedToken);
+  }, [storedToken]);
+
+  return (
+    <SettingContainer
+      title={t("settings.advanced.localApiToken.title")}
+      description={t("settings.advanced.localApiToken.description")}
+      descriptionMode={descriptionMode}
+      grouped={grouped}
+      disabled={!enabled}
+    >
+      <Input
+        type="password"
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        onBlur={() => updateSetting("local_api_token", value.trim() || null)}
+        placeholder={t("settings.advanced.localApiToken.placeholder")}
+        variant="compact"
+        disabled={!enabled || isUpdating("local_api_token")}
+        className="flex-1 min-w-[320px]"
+      />
+    </SettingContainer>
+  );
+};

--- a/src/components/settings/advanced/AdvancedSettings.tsx
+++ b/src/components/settings/advanced/AdvancedSettings.tsx
@@ -16,6 +16,9 @@ import { AppendTrailingSpace } from "../AppendTrailingSpace";
 import { HistoryLimit } from "../HistoryLimit";
 import { RecordingRetentionPeriodSelector } from "../RecordingRetentionPeriod";
 import { ExperimentalToggle } from "../ExperimentalToggle";
+import { LocalApiEnabled } from "../LocalApiEnabled";
+import { LocalApiNetworkScope } from "../LocalApiNetworkScope";
+import { LocalApiToken } from "../LocalApiToken";
 import { useSettings } from "../../../hooks/useSettings";
 import { KeyboardImplementationSelector } from "../debug/KeyboardImplementationSelector";
 
@@ -57,6 +60,9 @@ export const AdvancedSettings: React.FC = () => {
 
       {experimentalEnabled && (
         <SettingsGroup title={t("settings.advanced.groups.experimental")}>
+          <LocalApiEnabled descriptionMode="tooltip" grouped={true} />
+          <LocalApiNetworkScope descriptionMode="tooltip" grouped={true} />
+          <LocalApiToken descriptionMode="tooltip" grouped={true} />
           <PostProcessingToggle descriptionMode="tooltip" grouped={true} />
           <KeyboardImplementationSelector
             descriptionMode="tooltip"

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -296,6 +296,23 @@
         "add": "إضافة",
         "remove": "إزالة {{word}}",
         "duplicate": "\"{{word}}\" موجود بالفعل"
+      },
+      "localApiEnabled": {
+        "label": "خدمة واجهة API المحلية",
+        "description": "توفير نقاط نهاية للنسخ لتستخدمها الأدوات المحلية (HTTP بأسلوب OpenAI + Wyoming)."
+      },
+      "localApiNetwork": {
+        "title": "وصول الشبكة لواجهة API",
+        "description": "وضع الاسترجاع المحلي (Loopback) يجعل نقاط النهاية متاحة على هذا الجهاز فقط. الشبكة المحلية تسمح لأجهزة LAN الأخرى بالوصول.",
+        "options": {
+          "loopback": "هذا الجهاز فقط (127.0.0.1)",
+          "localNetwork": "الشبكة المحلية (0.0.0.0)"
+        }
+      },
+      "localApiToken": {
+        "title": "رمز وصول API (اختياري)",
+        "description": "عند تعيينه، يجب على العملاء إرسال Authorization: Bearer <token> عند استدعاء واجهة HTTP API.",
+        "placeholder": "اتركه فارغاً لتعطيل المصادقة"
       }
     },
     "postProcessing": {

--- a/src/i18n/locales/cs/translation.json
+++ b/src/i18n/locales/cs/translation.json
@@ -318,6 +318,23 @@
         "add": "Přidat",
         "remove": "Odebrat {{word}}",
         "duplicate": "\"{{word}}\" již existuje"
+      },
+      "localApiEnabled": {
+        "label": "Lokální API služba",
+        "description": "Zpřístupní přepisovací endpointy pro lokální nástroje (OpenAI-style HTTP + Wyoming)."
+      },
+      "localApiNetwork": {
+        "title": "Síťový přístup API",
+        "description": "Loopback zpřístupní endpointy jen na tomto počítači. Lokální síť je zpřístupní i ostatním zařízením v LAN.",
+        "options": {
+          "loopback": "Pouze tento počítač (127.0.0.1)",
+          "localNetwork": "Místní síť (0.0.0.0)"
+        }
+      },
+      "localApiToken": {
+        "title": "API přístupový token (volitelné)",
+        "description": "Pokud je nastaven, klient musí při volání HTTP API poslat Authorization: Bearer <token>.",
+        "placeholder": "Ponechte prázdné pro vypnutí ověřování"
       }
     },
     "postProcessing": {

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -318,6 +318,23 @@
         "add": "Hinzufügen",
         "remove": "{{word}} entfernen",
         "duplicate": "\"{{word}}\" existiert bereits"
+      },
+      "localApiEnabled": {
+        "label": "Lokaler API-Dienst",
+        "description": "Stellt Transkriptions-Endpunkte für lokale Tools bereit (OpenAI-Style HTTP + Wyoming)."
+      },
+      "localApiNetwork": {
+        "title": "API-Netzwerkzugriff",
+        "description": "Loopback macht die Endpunkte nur auf diesem Computer erreichbar. Lokales Netzwerk erlaubt Zugriff von anderen Geräten im LAN.",
+        "options": {
+          "loopback": "Nur dieser Computer (127.0.0.1)",
+          "localNetwork": "Lokales Netzwerk (0.0.0.0)"
+        }
+      },
+      "localApiToken": {
+        "title": "API-Zugriffstoken (optional)",
+        "description": "Wenn gesetzt, müssen Clients beim HTTP-API-Aufruf Authorization: Bearer <token> senden.",
+        "placeholder": "Leer lassen, um Auth zu deaktivieren"
       }
     },
     "postProcessing": {

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -232,6 +232,23 @@
         "label": "Experimental Features",
         "description": "Enable experimental features that are still in development."
       },
+      "localApiEnabled": {
+        "label": "Local API Service",
+        "description": "Expose transcription endpoints for local tools (OpenAI-style HTTP + Wyoming)."
+      },
+      "localApiNetwork": {
+        "title": "API Network Access",
+        "description": "Loopback keeps endpoints accessible only on this computer. Local Network allows other devices on your LAN to call them.",
+        "options": {
+          "loopback": "This computer only (127.0.0.1)",
+          "localNetwork": "Local network (0.0.0.0)"
+        }
+      },
+      "localApiToken": {
+        "title": "API Access Token (Optional)",
+        "description": "If set, clients must send Authorization: Bearer <token> when calling the HTTP API.",
+        "placeholder": "Leave empty to disable auth"
+      },
       "startHidden": {
         "label": "Start Hidden",
         "description": "Launch to system tray without opening the window."

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -318,6 +318,23 @@
         "add": "Agregar",
         "remove": "Eliminar {{word}}",
         "duplicate": "\"{{word}}\" ya existe"
+      },
+      "localApiEnabled": {
+        "label": "Servicio API local",
+        "description": "Expone endpoints de transcripción para herramientas locales (HTTP estilo OpenAI + Wyoming)."
+      },
+      "localApiNetwork": {
+        "title": "Acceso de red a la API",
+        "description": "Loopback mantiene los endpoints disponibles solo en este equipo. Red local permite acceso desde otros dispositivos de tu LAN.",
+        "options": {
+          "loopback": "Solo este equipo (127.0.0.1)",
+          "localNetwork": "Red local (0.0.0.0)"
+        }
+      },
+      "localApiToken": {
+        "title": "Token de acceso API (opcional)",
+        "description": "Si se configura, los clientes deben enviar Authorization: Bearer <token> al llamar a la API HTTP.",
+        "placeholder": "Déjalo vacío para desactivar la autenticación"
       }
     },
     "postProcessing": {

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -318,6 +318,23 @@
         "add": "Ajouter",
         "remove": "Supprimer {{word}}",
         "duplicate": "\"{{word}}\" existe déjà"
+      },
+      "localApiEnabled": {
+        "label": "Service API local",
+        "description": "Expose des endpoints de transcription pour les outils locaux (HTTP type OpenAI + Wyoming)."
+      },
+      "localApiNetwork": {
+        "title": "Accès réseau API",
+        "description": "Loopback rend les endpoints accessibles uniquement sur cet ordinateur. Réseau local autorise l’accès depuis les autres appareils du LAN.",
+        "options": {
+          "loopback": "Cet ordinateur uniquement (127.0.0.1)",
+          "localNetwork": "Réseau local (0.0.0.0)"
+        }
+      },
+      "localApiToken": {
+        "title": "Jeton d’accès API (optionnel)",
+        "description": "Si défini, les clients doivent envoyer Authorization: Bearer <token> lors des appels HTTP API.",
+        "placeholder": "Laisser vide pour désactiver l’authentification"
       }
     },
     "postProcessing": {

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -318,6 +318,23 @@
         "add": "Aggiungi",
         "remove": "Rimuovi {{word}}",
         "duplicate": "\"{{word}}\" esiste già"
+      },
+      "localApiEnabled": {
+        "label": "Servizio API locale",
+        "description": "Espone endpoint di trascrizione per strumenti locali (HTTP stile OpenAI + Wyoming)."
+      },
+      "localApiNetwork": {
+        "title": "Accesso rete API",
+        "description": "Loopback rende gli endpoint accessibili solo su questo computer. Rete locale consente l’accesso agli altri dispositivi della LAN.",
+        "options": {
+          "loopback": "Solo questo computer (127.0.0.1)",
+          "localNetwork": "Rete locale (0.0.0.0)"
+        }
+      },
+      "localApiToken": {
+        "title": "Token di accesso API (opzionale)",
+        "description": "Se impostato, i client devono inviare Authorization: Bearer <token> quando chiamano l’API HTTP.",
+        "placeholder": "Lascia vuoto per disattivare l’autenticazione"
       }
     },
     "postProcessing": {

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -318,6 +318,23 @@
         "add": "追加",
         "remove": "{{word}}を削除",
         "duplicate": "「{{word}}」は既に存在します"
+      },
+      "localApiEnabled": {
+        "label": "ローカルAPIサービス",
+        "description": "ローカルツール向けに文字起こしエンドポイントを公開します（OpenAI互換HTTP + Wyoming）。"
+      },
+      "localApiNetwork": {
+        "title": "APIネットワークアクセス",
+        "description": "Loopback はこのPCのみで利用可能。ローカルネットワークは LAN 上の他デバイスからのアクセスを許可します。",
+        "options": {
+          "loopback": "このPCのみ (127.0.0.1)",
+          "localNetwork": "ローカルネットワーク (0.0.0.0)"
+        }
+      },
+      "localApiToken": {
+        "title": "APIアクセストークン（任意）",
+        "description": "設定すると、HTTP API 呼び出し時に Authorization: Bearer <token> が必要になります。",
+        "placeholder": "空欄で認証を無効化"
       }
     },
     "postProcessing": {

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -318,6 +318,23 @@
         "add": "추가",
         "remove": "{{word}} 제거",
         "duplicate": "\"{{word}}\"이(가) 이미 존재합니다"
+      },
+      "localApiEnabled": {
+        "label": "로컬 API 서비스",
+        "description": "로컬 도구에서 사용할 수 있도록 전사 엔드포인트를 노출합니다(OpenAI 스타일 HTTP + Wyoming)."
+      },
+      "localApiNetwork": {
+        "title": "API 네트워크 접근",
+        "description": "루프백은 이 컴퓨터에서만 엔드포인트에 접근할 수 있습니다. 로컬 네트워크는 LAN의 다른 기기 접근을 허용합니다.",
+        "options": {
+          "loopback": "이 컴퓨터만 (127.0.0.1)",
+          "localNetwork": "로컬 네트워크 (0.0.0.0)"
+        }
+      },
+      "localApiToken": {
+        "title": "API 접근 토큰(선택)",
+        "description": "설정하면 HTTP API 호출 시 Authorization: Bearer <token> 헤더가 필요합니다.",
+        "placeholder": "인증을 비활성화하려면 비워두세요"
       }
     },
     "postProcessing": {

--- a/src/i18n/locales/pl/translation.json
+++ b/src/i18n/locales/pl/translation.json
@@ -318,6 +318,23 @@
         "add": "Dodaj",
         "remove": "Usuń {{word}}",
         "duplicate": "\"{{word}}\" już istnieje"
+      },
+      "localApiEnabled": {
+        "label": "Lokalna usługa API",
+        "description": "Udostępnia endpointy transkrypcji dla lokalnych narzędzi (HTTP w stylu OpenAI + Wyoming)."
+      },
+      "localApiNetwork": {
+        "title": "Dostęp sieciowy API",
+        "description": "Loopback udostępnia endpointy tylko na tym komputerze. Sieć lokalna pozwala na dostęp z innych urządzeń w LAN.",
+        "options": {
+          "loopback": "Tylko ten komputer (127.0.0.1)",
+          "localNetwork": "Sieć lokalna (0.0.0.0)"
+        }
+      },
+      "localApiToken": {
+        "title": "Token dostępu API (opcjonalnie)",
+        "description": "Jeśli ustawiony, klient musi wysyłać Authorization: Bearer <token> przy wywołaniu HTTP API.",
+        "placeholder": "Pozostaw puste, aby wyłączyć uwierzytelnianie"
       }
     },
     "postProcessing": {

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -318,6 +318,23 @@
         "add": "Adicionar",
         "remove": "Remover {{word}}",
         "duplicate": "\"{{word}}\" já existe"
+      },
+      "localApiEnabled": {
+        "label": "Serviço de API local",
+        "description": "Expõe endpoints de transcrição para ferramentas locais (HTTP estilo OpenAI + Wyoming)."
+      },
+      "localApiNetwork": {
+        "title": "Acesso de rede da API",
+        "description": "Loopback mantém os endpoints acessíveis apenas neste computador. Rede local permite acesso de outros dispositivos na LAN.",
+        "options": {
+          "loopback": "Somente este computador (127.0.0.1)",
+          "localNetwork": "Rede local (0.0.0.0)"
+        }
+      },
+      "localApiToken": {
+        "title": "Token de acesso da API (opcional)",
+        "description": "Se definido, os clientes devem enviar Authorization: Bearer <token> ao chamar a API HTTP.",
+        "placeholder": "Deixe vazio para desativar autenticação"
       }
     },
     "postProcessing": {

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -318,6 +318,23 @@
         "add": "Добавлять",
         "remove": "Удалить {{word}}",
         "duplicate": "\"{{word}}\" уже существует"
+      },
+      "localApiEnabled": {
+        "label": "Локальный API-сервис",
+        "description": "Открывает эндпоинты транскрибации для локальных инструментов (HTTP в стиле OpenAI + Wyoming)."
+      },
+      "localApiNetwork": {
+        "title": "Сетевой доступ к API",
+        "description": "Loopback делает эндпоинты доступными только на этом компьютере. Локальная сеть разрешает доступ с других устройств в LAN.",
+        "options": {
+          "loopback": "Только этот компьютер (127.0.0.1)",
+          "localNetwork": "Локальная сеть (0.0.0.0)"
+        }
+      },
+      "localApiToken": {
+        "title": "Токен доступа API (необязательно)",
+        "description": "Если задан, клиенты должны отправлять Authorization: Bearer <token> при вызове HTTP API.",
+        "placeholder": "Оставьте пустым, чтобы отключить аутентификацию"
       }
     },
     "postProcessing": {

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -318,6 +318,23 @@
         "add": "Ekle",
         "remove": "{{word}} Kaldır",
         "duplicate": "\"{{word}}\" zaten mevcut"
+      },
+      "localApiEnabled": {
+        "label": "Yerel API Hizmeti",
+        "description": "Yerel araçlar için transkripsiyon uç noktalarını açar (OpenAI tarzı HTTP + Wyoming)."
+      },
+      "localApiNetwork": {
+        "title": "API Ağ Erişimi",
+        "description": "Loopback uç noktaları yalnızca bu bilgisayarda erişilebilir yapar. Yerel ağ, LAN içindeki diğer cihazlardan erişime izin verir.",
+        "options": {
+          "loopback": "Yalnızca bu bilgisayar (127.0.0.1)",
+          "localNetwork": "Yerel ağ (0.0.0.0)"
+        }
+      },
+      "localApiToken": {
+        "title": "API Erişim Belirteci (Opsiyonel)",
+        "description": "Ayarlanırsa, istemciler HTTP API çağrısında Authorization: Bearer <token> göndermelidir.",
+        "placeholder": "Kimlik doğrulamayı kapatmak için boş bırakın"
       }
     },
     "postProcessing": {

--- a/src/i18n/locales/uk/translation.json
+++ b/src/i18n/locales/uk/translation.json
@@ -318,6 +318,23 @@
         "add": "Додати",
         "remove": "Видалити {{word}}",
         "duplicate": "\"{{word}}\" вже існує"
+      },
+      "localApiEnabled": {
+        "label": "Локальний API-сервіс",
+        "description": "Відкриває ендпойнти транскрипції для локальних інструментів (HTTP у стилі OpenAI + Wyoming)."
+      },
+      "localApiNetwork": {
+        "title": "Мережевий доступ до API",
+        "description": "Loopback робить ендпойнти доступними лише на цьому комп’ютері. Локальна мережа дозволяє доступ з інших пристроїв у LAN.",
+        "options": {
+          "loopback": "Лише цей комп’ютер (127.0.0.1)",
+          "localNetwork": "Локальна мережа (0.0.0.0)"
+        }
+      },
+      "localApiToken": {
+        "title": "Токен доступу API (необов’язково)",
+        "description": "Якщо встановлено, клієнти мають надсилати Authorization: Bearer <token> під час виклику HTTP API.",
+        "placeholder": "Залиште порожнім, щоб вимкнути автентифікацію"
       }
     },
     "postProcessing": {

--- a/src/i18n/locales/vi/translation.json
+++ b/src/i18n/locales/vi/translation.json
@@ -318,6 +318,23 @@
         "add": "Thêm",
         "remove": "Xóa {{word}}",
         "duplicate": "\"{{word}}\" đã tồn tại"
+      },
+      "localApiEnabled": {
+        "label": "Dịch vụ API cục bộ",
+        "description": "Mở các endpoint phiên âm cho công cụ cục bộ (HTTP kiểu OpenAI + Wyoming)."
+      },
+      "localApiNetwork": {
+        "title": "Truy cập mạng API",
+        "description": "Loopback chỉ cho phép truy cập endpoint trên máy này. Mạng cục bộ cho phép các thiết bị khác trong LAN truy cập.",
+        "options": {
+          "loopback": "Chỉ máy này (127.0.0.1)",
+          "localNetwork": "Mạng cục bộ (0.0.0.0)"
+        }
+      },
+      "localApiToken": {
+        "title": "Mã truy cập API (tùy chọn)",
+        "description": "Nếu đặt, client phải gửi Authorization: Bearer <token> khi gọi HTTP API.",
+        "placeholder": "Để trống để tắt xác thực"
       }
     },
     "postProcessing": {

--- a/src/i18n/locales/zh-TW/translation.json
+++ b/src/i18n/locales/zh-TW/translation.json
@@ -318,6 +318,23 @@
         "add": "新增",
         "remove": "刪除 {{word}}",
         "duplicate": "「{{word}}」已存在"
+      },
+      "localApiEnabled": {
+        "label": "本機 API 服務",
+        "description": "為本機工具提供轉錄端點（OpenAI 風格 HTTP + Wyoming）。"
+      },
+      "localApiNetwork": {
+        "title": "API 網路存取",
+        "description": "迴圈位址模式僅允許本機存取端點。區域網路模式允許 LAN 內其他裝置存取。",
+        "options": {
+          "loopback": "僅此電腦 (127.0.0.1)",
+          "localNetwork": "區域網路 (0.0.0.0)"
+        }
+      },
+      "localApiToken": {
+        "title": "API 存取權杖（選用）",
+        "description": "若已設定，客戶端呼叫 HTTP API 時必須送出 Authorization: Bearer <token>。",
+        "placeholder": "留空以停用驗證"
       }
     },
     "postProcessing": {

--- a/src/i18n/locales/zh/translation.json
+++ b/src/i18n/locales/zh/translation.json
@@ -318,6 +318,23 @@
         "add": "添加",
         "remove": "删除 {{word}}",
         "duplicate": "\"{{word}}\" 已存在"
+      },
+      "localApiEnabled": {
+        "label": "本地 API 服务",
+        "description": "为本地工具暴露转录端点（OpenAI 风格 HTTP + Wyoming）。"
+      },
+      "localApiNetwork": {
+        "title": "API 网络访问",
+        "description": "回环模式仅允许本机访问端点。本地网络模式允许局域网中的其他设备访问。",
+        "options": {
+          "loopback": "仅本机 (127.0.0.1)",
+          "localNetwork": "本地网络 (0.0.0.0)"
+        }
+      },
+      "localApiToken": {
+        "title": "API 访问令牌（可选）",
+        "description": "设置后，客户端调用 HTTP API 时必须发送 Authorization: Bearer <token>。",
+        "placeholder": "留空以禁用认证"
       }
     },
     "postProcessing": {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -133,6 +133,12 @@ const settingUpdaters: {
   app_language: (value) => commands.changeAppLanguageSetting(value as string),
   experimental_enabled: (value) =>
     commands.changeExperimentalEnabledSetting(value as boolean),
+  local_api_enabled: (value) =>
+    commands.changeLocalApiEnabledSetting(value as boolean),
+  local_api_network_scope: (value) =>
+    commands.changeLocalApiNetworkScopeSetting(value as string),
+  local_api_token: (value) =>
+    commands.changeLocalApiTokenSetting((value as string | null) ?? null),
   show_tray_icon: (value) =>
     commands.changeShowTrayIconSetting(value as boolean),
 };


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

I wanted Handy's existing on-device transcription pipeline to be callable by other local tools without adding any remote/cloud provider dependency. This PR adds an experimental local API service with OpenAI-compatible HTTP and Wyoming endpoints so external local workflows can reuse the same model/runtime already running in Handy.

The feature is loopback-first by default and integrated through existing settings/command patterns.

## Related Issues/Discussions

Fixes #
Discussion: https://github.com/cjpais/Handy/discussions/241

Related PRs for context:
- https://github.com/cjpais/Handy/pull/509 (same local-server direction)
- https://github.com/cjpais/Handy/pull/886 (remote/provider-client direction, intentionally not part of this PR)

## Community Feedback

- https://github.com/cjpais/Handy/discussions/241
- https://github.com/cjpais/Handy/pull/509

## Maintainer FAQ (Pre-Answered)

- **Is this remote/provider transcription?** No. This PR does not add remote/cloud transcription provider support.
- **How does this align with local-first?** It exposes Handy's existing local inference pipeline as local endpoints; no outbound STT provider integration is introduced.
- **How is this positioned vs #509?** Same broad local-server direction; this branch includes integrated settings, protocol coverage (OpenAI-style HTTP + Wyoming), and endpoint tests in `src-tauri/src/api_server.rs`.
- **What are the defaults/security posture?** Service is experimental and disabled by default; network scope defaults to `127.0.0.1`; optional bearer token auth is supported.

## What’s Included

- New backend manager and server implementation:
  - OpenAI-style HTTP endpoint on `:5500` (`/v1/audio/transcriptions`)
  - Wyoming TCP endpoint on `:10300`
- Settings plumbing for:
  - enable/disable local API service
  - loopback vs local-network binding
  - optional API token
- Advanced settings UI controls and i18n strings
- README docs for endpoint usage
- Backend tests for HTTP JSON, HTTP multipart, auth enforcement, and Wyoming transcript flow

## Testing

I ran the following locally:

- Build + frontend typecheck:
  - `bun run build`
- Rust tests:
  - `cargo test --manifest-path src-tauri/Cargo.toml`
  - includes passing local API tests in `api_server::tests::*`
- Manual endpoint smoke tests against installed app:
  - HTTP preflight/JSON/multipart/error cases on `127.0.0.1:5500`
  - Wyoming describe + audio-start/chunk/stop flow on `127.0.0.1:10300`
  - Real audio test transcript produced expected text: "Hello, sir. All systems are online."

## Screenshots/Videos (if applicable)

N/A (backend/API + settings additions only)

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenCode / GPT-5.3-codex
- How extensively: AI-assisted implementation support, test execution assistance, and PR drafting; final content reviewed before submission.