### PR TITLE
[macOS] Fix tray icon disabled + start hidden causing app to become permanently invisible 

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -460,8 +460,8 @@ pub fn run(cli_args: CliArgs) {
                 let _res = window.hide();
 
                 let settings = get_settings(&window.app_handle());
-                let tray_visible = settings.show_tray_icon
-                    && !window.app_handle().state::<CliArgs>().no_tray;
+                let tray_visible =
+                    settings.show_tray_icon && !window.app_handle().state::<CliArgs>().no_tray;
 
                 #[cfg(target_os = "macos")]
                 {


### PR DESCRIPTION
When a user disables "Show Tray Icon" in settings and also has "Start Hidden" enabled, the app launches into a completely unreachable state:

  - The window is hidden (start hidden)
  - The tray icon is hidden (show tray icon disabled)
  - On macOS, the dock icon is removed (Accessory activation policy)

  The app is running but there is no way to interact with it. The only recovery is re-launching from Spotlight or Applications, which triggers the
  single-instance plugin to show the window. But on the next launch, the same invisible state occurs again.

  Additionally, macOS had no RunEvent::Reopen handler, so clicking the dock icon (when visible) did nothing to bring the window back.

  Fix

  1. Prevent invisible app state on startup: When the tray icon is not available (either via the show_tray_icon setting or the --no-tray CLI flag), the app
   now forces the main window to be shown regardless of the start_hidden setting. On macOS, the activation policy is also reset from Accessory to Regular
  so the dock icon remains visible.
  2. Add RunEvent::Reopen handler for macOS: Clicking the dock icon now calls show_main_window(), providing a recovery path for users whose app is running
  but has no visible window


**TODO**: Verify all possible code branches and make sure expectations are aligned for each