### PR TITLE
fix(ci): simplify Bun setup for Windows ARM64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,17 +77,8 @@ jobs:
             echo "Build profile: release"
           fi
 
-      - name: Setup Bun (standard)
-        if: ${{ !(contains(inputs.platform, 'windows') && contains(inputs.target, 'aarch64')) }}
+      - name: Setup Bun
         uses: oven-sh/setup-bun@v2
-
-      # Bun does not fully support Windows ARM64 yet, so we pin the baseline build.
-      # See https://github.com/oven-sh/bun/issues/9824 for details.
-      - name: Setup Bun (Windows ARM64 baseline)
-        if: ${{ contains(inputs.platform, 'windows') && contains(inputs.target, 'aarch64') }}
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-download-url: "https://github.com/oven-sh/bun/releases/latest/download/bun-windows-x64-baseline.zip"
 
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description
Bun now releases aarch64 native builds for Windows. This removes the previous work-around I implemented when originally creating the aaarch64/arm64 Windows build. We can now have a single, unified bun setup step.

## Related Issues/Discussions

Discussion:
- Original aarch64 implementation: https://github.com/cjpais/Handy/pull/340
- Upstream change to the `setup-bun` action: https://github.com/oven-sh/setup-bun/pull/165 (merged)
- Follow-up report/closure: https://github.com/oven-sh/setup-bun/issues/168 (closed)

## Community Feedback

N/A (CI/workflow cleanup based on upstream action behavior)

## Testing

- Confirmed workflow runs and selects the the aarch64 version on Windows. https://github.com/oddrationale/Handy/actions/runs/22690953409/job/65786029286#step:5:6
- Note: The build fails because I don't have the code signing certificates. But the Setup Bun step selects the correct bun architecture and build correctly.

## Screenshots/Videos (if applicable)

N/A

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex (gpt-5.3-codex) and Claude Code (Opus 4.6)
- How extensively: Perform code review and draft PR.
