### PR TITLE
feat(history): add search functionality to history tab

### DIFF
--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { AudioPlayer } from "../../ui/AudioPlayer";
 import { Button } from "../../ui/Button";
-import { Copy, Star, Check, Trash2, FolderOpen } from "lucide-react";
+import { Copy, Star, Check, Trash2, FolderOpen, Search } from "lucide-react";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { readFile } from "@tauri-apps/plugin-fs";
@@ -36,6 +36,7 @@ export const HistorySettings: React.FC = () => {
   const osType = useOsType();
   const [historyEntries, setHistoryEntries] = useState<HistoryEntry[]>([]);
   const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState("");
 
   const loadHistoryEntries = useCallback(async () => {
     try {
@@ -182,6 +183,17 @@ export const HistorySettings: React.FC = () => {
     );
   }
 
+  const filteredEntries = searchQuery
+    ? historyEntries.filter((entry) => {
+        const query = searchQuery.toLowerCase();
+        return (
+          entry.transcription_text.toLowerCase().includes(query) ||
+          (entry.post_processed_text &&
+            entry.post_processed_text.toLowerCase().includes(query))
+        );
+      })
+    : historyEntries;
+
   return (
     <div className="max-w-3xl w-full mx-auto space-y-6">
       <div className="space-y-2">
@@ -196,19 +208,35 @@ export const HistorySettings: React.FC = () => {
             label={t("settings.history.openFolder")}
           />
         </div>
+        <div className="px-4 relative">
+          <Search className="absolute left-7 top-1/2 -translate-y-1/2 w-4 h-4 text-text/40" />
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder={t("settings.history.search")}
+            className="w-full pl-9 pr-3 py-2 text-sm bg-mid-gray/10 border border-mid-gray/80 rounded-md text-start transition-all duration-150 hover:bg-logo-primary/10 hover:border-logo-primary focus:outline-none focus:bg-logo-primary/20 focus:border-logo-primary"
+          />
+        </div>
         <div className="bg-background border border-mid-gray/20 rounded-lg overflow-visible">
-          <div className="divide-y divide-mid-gray/20">
-            {historyEntries.map((entry) => (
-              <HistoryEntryComponent
-                key={entry.id}
-                entry={entry}
-                onToggleSaved={() => toggleSaved(entry.id)}
-                onCopyText={() => copyToClipboard(entry.transcription_text)}
-                getAudioUrl={getAudioUrl}
-                deleteAudio={deleteAudioEntry}
-              />
-            ))}
-          </div>
+          {filteredEntries.length === 0 ? (
+            <div className="px-4 py-3 text-center text-text/60">
+              {t("settings.history.noResults")}
+            </div>
+          ) : (
+            <div className="divide-y divide-mid-gray/20">
+              {filteredEntries.map((entry) => (
+                <HistoryEntryComponent
+                  key={entry.id}
+                  entry={entry}
+                  onToggleSaved={() => toggleSaved(entry.id)}
+                  onCopyText={() => copyToClipboard(entry.transcription_text)}
+                  getAudioUrl={getAudioUrl}
+                  deleteAudio={deleteAudioEntry}
+                />
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -393,7 +393,9 @@
       "save": "Save transcription",
       "unsave": "Remove from saved",
       "delete": "Delete entry",
-      "deleteError": "Failed to delete entry. Please try again."
+      "deleteError": "Failed to delete entry. Please try again.",
+      "search": "Search transcriptions...",
+      "noResults": "No matching transcriptions found"
     },
     "debug": {
       "title": "Debug",


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [x] I have explained in the description below why this should be reconsidered
- [x] I have gathered community feedback (link to discussion below)

## Human Written Description

I found myself scrolling through my entire transcription history trying to find a specific past recording. With auto-delete disabled, the list grows quickly and there's no way to locate anything without reading through every entry. A simple search bar at the top of the History tab would make this much more usable.

A previous attempt at this (#590) was self-closed because it broke audio playback. My implementation takes a simpler approach — it only filters the already-loaded list client-side without touching audio loading, so that issue doesn't apply here.

## Related Issues/Discussions

- Previous attempt: #590 (self-closed by author due to audio playback bug)
- Discussion: #974

## Community Feedback

Discussion opened at https://github.com/cjpais/Handy/discussions/974

The author of the previous PR #590 noted: *"search option would be really useful if implemented well"*. This implementation avoids the audio playback issue that caused #590 to be closed.

## Testing

- Verified search filters entries by transcription text (case-insensitive)
- Verified search also matches against post-processed text
- Confirmed "No matching transcriptions found" message appears when search has no matches
- Confirmed audio playback still works correctly on filtered entries
- Confirmed clearing the search input restores the full list
- Verified ESLint passes cleanly

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: AI helped with implementation; human provided direction, testing, and review

## Implementation Notes

**Why client-side filtering:** The default history limit is 5 entries. Even users who increase this or disable auto-delete are unlikely to have thousands of entries. Filtering the already-loaded array is instant and avoids unnecessary backend complexity (no new Tauri commands or database query changes needed).

**Changes:**
- `src/components/settings/history/HistorySettings.tsx` — Added search input with icon, search state, and filtering logic
- `src/i18n/locales/en/translation.json` — Added `search` and `noResults` translation keys
