### PR TITLE
feat(nix): NixOS integration — ALSA_PLUGIN_DIR + nixosModule

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -174,6 +174,7 @@
             preFixup = ''
               gappsWrapperArgs+=(
                 --set WEBKIT_DISABLE_DMABUF_RENDERER 1
+                --set ALSA_PLUGIN_DIR "${pkgs.pipewire}/lib/alsa-lib:${pkgs.alsa-plugins}/lib/alsa-lib"
                 --prefix LD_LIBRARY_PATH : "${
                   lib.makeLibraryPath [
                     pkgs.vulkan-loader
@@ -195,6 +196,22 @@
           default = self.packages.${system}.handy;
         }
       );
+
+      # NixOS module for system-level integration (udev, input group)
+      nixosModules.default =
+        { lib, pkgs, ... }:
+        {
+          imports = [ ./nix/module.nix ];
+          programs.handy.package = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.handy;
+        };
+
+      # Home-manager module for per-user service
+      homeManagerModules.default =
+        { lib, pkgs, ... }:
+        {
+          imports = [ ./nix/hm-module.nix ];
+          services.handy.package = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.handy;
+        };
 
       # Development shell for building from source
       devShells = forAllSystems (

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,0 +1,41 @@
+# Home-manager module for Handy speech-to-text
+#
+# Provides a systemd user service for autostart.
+# Usage: imports = [ handy.homeManagerModules.default ];
+#        services.handy.enable = true;
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.handy;
+in
+{
+  options.services.handy = {
+    enable = lib.mkEnableOption "Handy speech-to-text user service";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      defaultText = lib.literalExpression "handy.packages.\${system}.handy";
+      description = "The Handy package to use.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.user.services.handy = {
+      Unit = {
+        Description = "Handy speech-to-text";
+        After = [ "graphical-session.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+      Service = {
+        ExecStart = "${cfg.package}/bin/handy";
+        Restart = "on-failure";
+        RestartSec = 5;
+      };
+      Install.WantedBy = [ "graphical-session.target" ];
+    };
+  };
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,47 @@
+# NixOS module for Handy speech-to-text
+#
+# Handles system-level configuration that the package wrapper cannot:
+#   - udev rule for /dev/uinput (rdev grab() needs it for virtual input)
+#
+# Note: users must add themselves to the "input" group for evdev hotkey access.
+#
+# Usage in your flake:
+#
+#   inputs.handy.url = "github:cjpais/Handy";
+#
+#   nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+#     modules = [
+#       handy.nixosModules.default
+#       { programs.handy.enable = true; }
+#     ];
+#   };
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.handy;
+in
+{
+  options.programs.handy = {
+    enable = lib.mkEnableOption "Handy offline speech-to-text";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      defaultText = lib.literalExpression "handy.packages.\${system}.handy";
+      description = "The Handy package to use.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    # rdev grab() creates virtual input devices via /dev/uinput.
+    # Default permissions are crw------- root root — open it to the input group.
+    services.udev.extraRules = ''
+      KERNEL=="uinput", GROUP="input", MODE="0660"
+    '';
+  };
+}


### PR DESCRIPTION
## Summary

Two changes to make Handy work out-of-the-box on NixOS:

**1. ALSA_PLUGIN_DIR in package wrapper** (`flake.nix`, +1 line)

On NixOS with PipeWire, CPAL opens the ALSA "default" device but gets 0 audio samples because PipeWire's ALSA plugin isn't on the default search path. Setting `ALSA_PLUGIN_DIR` in the gapps wrapper fixes this.

**2. nixosModule for system-level config** (`nix/module.nix`, new file)

Adds a `nixosModules.default` output so NixOS users can enable Handy with:

```nix
inputs.handy.url = "github:cjpais/Handy";

# In your NixOS config:
{ programs.handy.enable = true; }
```

The module handles system config that the package wrapper cannot:
- udev rule for `/dev/uinput` (rdev `grab()` needs it for virtual input devices)
- Adds the Handy package to `systemPackages`

Users still need to add themselves to the `input` group for evdev hotkey access.

## Test plan

- [x] `nix flake check --no-build` passes
- [x] Build and run on NixOS with PipeWire — verify audio capture works
- [x] Verify `programs.handy.enable = true` sets up udev rule correctly