### PR TITLE
Using the whisper `initial_prompt` field for custom words

### DIFF
--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -501,6 +501,11 @@ impl TranscriptionManager {
                             let params = WhisperInferenceParams {
                                 language: whisper_language,
                                 translate: settings.translate_to_english,
+                                initial_prompt: if settings.custom_words.is_empty() {
+                                    None
+                                } else {
+                                    Some(settings.custom_words.join(", "))
+                                },
                                 ..Default::default()
                             };
 
@@ -602,8 +607,15 @@ impl TranscriptionManager {
             }
         };
 
-        // Apply word correction if custom words are configured
-        let corrected_result = if !settings.custom_words.is_empty() {
+        // Apply word correction if custom words are configured.
+        // Skip for Whisper models since custom words are already passed as initial_prompt.
+        let is_whisper = self
+            .model_manager
+            .get_model_info(&settings.selected_model)
+            .map(|info| matches!(info.engine_type, EngineType::Whisper))
+            .unwrap_or(false);
+
+        let corrected_result = if !settings.custom_words.is_empty() && !is_whisper {
             apply_custom_words(
                 &result.text,
                 &settings.custom_words,


### PR DESCRIPTION
Whisper supports an `initial_prompt` parameter that biases the model's vocabulary during transcription. For Whisper models, we now join the user's custom words list into a comma-separated string and pass it as the initial_prompt. This guides the model to prefer those spellings during decoding rather than relying solely on fuzzy post-correction.

For non-Whisper engines (Parakeet, Moonshine, SenseVoice, GigaAM), the existing apply_custom_words post-correction continues to apply since those engines don't support prompt-based vocabulary biasing.

## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

From the discussion:

I've encountered an issue with custom vocabulary/custom words in Handy. The current bigram replacement mechanism can be overly aggressive - it sometimes replaces words that shouldn't be replaced. However, removing those entries from the custom words list means the desired words never appear at all.

I know that Whisper supports an "initial prompt" concept, which biases the model toward producing specific words without forcefully replacing output. While looking through the codebase, I noticed there appears to be a way to use custom words to generate an initial prompt, and I wanted to ask whether a pull request for this would be welcome.


## Related Issues/Discussions

<!-- Link to related issues, discussions, or previous PRs -->
<!-- If reopening something previously closed, explain why this should be reconsidered -->

Fixes #
Discussion: https://github.com/cjpais/Handy/discussions/1009

## Community Feedback

<!--
PRs with community support are much more likely to be merged.

For features: Link to a discussion where community members have expressed interest.
For bug fixes: Link to the issue where others have confirmed the bug.

If you haven't gathered feedback yet, consider starting a discussion first:
https://github.com/cjpais/Handy/discussions

It is not explicitly required to gather feedback, but it certainly helps your PR get merged.
-->

## Testing

<!-- Describe how you tested your changes and if you need help getting additional testing -->

No unit tests for this. I built and used this on my machine. The use case I was working on was "CLI" and "call" - that was fun to see in transcripts once I noticed it :)

## Screenshots/Videos (if applicable)

<!-- Add screenshots or videos demonstrating the change -->

## AI Assistance

<!-- AI-assisted PRs are welcome! Just let us know so we can review appropriately. -->

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: claude-code opus 4.6
- How extensively: I knew of the capability from prior research and came up with the idea of using the existing vocabulary as the prompt instead of replacement. I then used claude-code to see if the fix was small and implement it. I then reviewed it, but I admit I have not written rust before, so my human review may be insufficient.
