### PR TITLE
fix: add configurable clipboard restore delay to fix race condition

### DIFF
--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -19,6 +19,7 @@ fn paste_via_clipboard(
     app_handle: &AppHandle,
     paste_method: &PasteMethod,
     paste_delay_ms: u64,
+    clipboard_restore_delay_ms: u64,
 ) -> Result<(), String> {
     let clipboard = app_handle.clipboard();
     let clipboard_content = clipboard.read_text().unwrap_or_default();
@@ -61,7 +62,7 @@ fn paste_via_clipboard(
         }
     }
 
-    std::thread::sleep(std::time::Duration::from_millis(50));
+    std::thread::sleep(Duration::from_millis(clipboard_restore_delay_ms));
 
     // Restore original clipboard content
     // On Wayland, prefer wl-copy for better compatibility
@@ -592,6 +593,7 @@ pub fn paste(text: String, app_handle: AppHandle) -> Result<(), String> {
     let settings = get_settings(&app_handle);
     let paste_method = settings.paste_method;
     let paste_delay_ms = settings.paste_delay_ms;
+    let clipboard_restore_delay_ms = settings.clipboard_restore_delay_ms;
 
     // Append trailing space if setting is enabled
     let text = if settings.append_trailing_space {
@@ -634,6 +636,7 @@ pub fn paste(text: String, app_handle: AppHandle) -> Result<(), String> {
                 &app_handle,
                 &paste_method,
                 paste_delay_ms,
+                clipboard_restore_delay_ms,
             )?
         }
         PasteMethod::ExternalScript => {

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -355,6 +355,8 @@ pub struct AppSettings {
     pub show_tray_icon: bool,
     #[serde(default = "default_paste_delay_ms")]
     pub paste_delay_ms: u64,
+    #[serde(default = "default_clipboard_restore_delay_ms")]
+    pub clipboard_restore_delay_ms: u64,
     #[serde(default = "default_typing_tool")]
     pub typing_tool: TypingTool,
     pub external_script_path: Option<String>,
@@ -411,6 +413,10 @@ fn default_word_correction_threshold() -> f64 {
 
 fn default_paste_delay_ms() -> u64 {
     60
+}
+
+fn default_clipboard_restore_delay_ms() -> u64 {
+    150
 }
 
 fn default_auto_submit() -> bool {


### PR DESCRIPTION
## Problem

Fixes #502 - Under heavy system load, Handy sometimes pastes the clipboard content instead of the transcribed text.

## Root Cause

In the `paste_via_clipboard` function, there was a hardcoded 50ms delay after sending the paste keystroke before restoring the original clipboard content. On systems under intense processor load, this delay was too short - the target application hadn't yet read from the clipboard before it was restored to its original content.

## Solution

Added a new configurable setting `clipboard_restore_delay_ms` (default: 150ms) that controls the delay between sending the paste keystroke and restoring the clipboard.

### Changes:
- **settings.rs**: Added `clipboard_restore_delay_ms` field with default of 150ms
- **clipboard.rs**: Updated `paste_via_clipboard` to use the configurable delay instead of hardcoded 50ms

## Testing

This fix increases the default delay from 50ms to 150ms, providing more headroom for the paste operation to complete on loaded systems. Users experiencing this issue can further increase the delay via the setting if needed.

## Notes

- The setting is backward compatible (defaults to 150ms if not present in existing configs)
- No changes to the public API or user-facing behavior beyond fixing the race condition