### PR TITLE
fix(nix): fix build with ort-sys 2.0.0-rc.12

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,42 @@
         let
           pkgs = import nixpkgs {
             inherit system;
-            overlays = [ bun2nix.overlays.default ];
+            overlays = [
+              bun2nix.overlays.default
+              # TODO: Remove this overlay once nixpkgs ships onnxruntime ≥ 1.24.
+              # Tracking PR: https://github.com/NixOS/nixpkgs/pull/499389
+              # ort-sys 2.0.0-rc.12 requires ONNX Runtime 1.24 (API v24);
+              # nixpkgs only ships 1.23.2, so use MS prebuilt binaries.
+              (final: prev: {
+                onnxruntime = let
+                  version = "1.24.2";
+                  platform = {
+                    x86_64-linux = { name = "linux-x64"; hash = "sha256-Q3JUdLpWY2QuF2hHF5Rmk4UOIAXvvXJKxy2ieP6tJeY="; };
+                    aarch64-linux = { name = "linux-aarch64"; hash = "sha256-spla8PQ3xOAi/YAcV/tcJf0f5mDNM9JutHGUSQpbRsQ="; };
+                  }.${system};
+                in prev.stdenv.mkDerivation {
+                  pname = "onnxruntime";
+                  inherit version;
+                  src = prev.fetchurl {
+                    url = "https://github.com/microsoft/onnxruntime/releases/download/v${version}/onnxruntime-${platform.name}-${version}.tgz";
+                    hash = platform.hash;
+                  };
+                  sourceRoot = "onnxruntime-${platform.name}-${version}";
+                  nativeBuildInputs = [ prev.autoPatchelfHook ];
+                  buildInputs = [ prev.stdenv.cc.cc.lib ];
+                  installPhase = ''
+                    runHook preInstall
+                    mkdir -p $out/lib $out/include
+                    cp -r lib/* $out/lib/
+                    cp -r include/* $out/include/
+                    runHook postInstall
+                  '';
+                  meta = prev.onnxruntime.meta // {
+                    description = "ONNX Runtime ${version} (prebuilt by Microsoft)";
+                  };
+                };
+              })
+            ];
           };
           lib = pkgs.lib;
         in


### PR DESCRIPTION
## Summary

Fixes the Nix build broken by the migration to `ort-sys 2.0.0-rc.12` (commit b85cc03).

Two issues:

1. **Linking failure** — `ort-sys` rc.12 removed `pkg-config` support, so with `ORT_LIB_LOCATION` set it defaults to static linking. nixpkgs only provides shared `.so` libraries → build fails. Fixed by setting `ORT_PREFER_DYNAMIC_LINK=1` (same as already done in `build.yml` for macOS).

2. **Runtime crash** — `ort` rc.12 enables API v24 by default, but nixpkgs ships onnxruntime 1.23.2 (API v23). The binary builds but panics at runtime: `The requested API version [24] is not available`. Fixed by overriding onnxruntime with Microsoft's prebuilt 1.24.2 binaries via a Nix overlay + `autoPatchelfHook`.

The overlay is temporary — once [NixOS/nixpkgs#499389](https://github.com/NixOS/nixpkgs/pull/499389) (onnxruntime 1.23.2 → 1.24.3) is merged, it can be removed.

## Test plan

- [x] `nix build .#handy` completes successfully
- [x] Parakeet model loads and transcribes without API version errors
- [x] Whisper turbo model loads and transcribes via Vulkan