### PR TITLE
docs: add Raycast extension to Integrations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,9 @@ For detailed build instructions including platform-specific requirements, see [B
 
 ## Integrations
 
-### ![Raycast](https://img.shields.io/badge/Raycast-FF6363?style=for-the-badge&logo=raycast&logoColor=white)
+<a href="https://www.raycast.com/mattiacolombomc/handy" title="Install Handy Raycast Extension"><img src="https://www.raycast.com/mattiacolombomc/handy/install_button@2x.png?v=1.1" height="64" style="height: 64px;" alt="Install handy Raycast Extension" /></a>
 
 Control Handy from [Raycast](https://www.raycast.com) — start/stop recording, browse transcript history, manage dictionary, switch models.
-
-<a href="https://www.raycast.com/mattiacolombomc/handy" title="Install handy Raycast Extension"><img src="https://www.raycast.com/mattiacolombomc/handy/install_button@2x.png?v=1.1" height="64" style="height: 64px;" alt="Install handy Raycast Extension" /></a>
 
 [Source](https://github.com/mattiacolombomc/raycast-handy) · by [@mattiacolombomc](https://github.com/mattiacolombomc)
 


### PR DESCRIPTION
## What

Adds a new **Integrations** section to the README mentioning the Raycast extension for Handy.

## Context

Following up on Discussion #1061, where you said:

> sure, submit a pr and it'll be added to the readme!

The extension is currently pending review on the Raycast Store. I'm opening this as a draft so it's ready to merge once the PR on `raycast/extensions` is approved — at which point I'll update the link to point to the official Store page instead of the GitHub repo.

## Extension

Source: https://github.com/mattiacolombomc/raycast-handy

Commands: start/stop recording, copy last transcript, search transcript history, add dictionary word, manage dictionary, select model, open recordings folder.