### PR TITLE
dropdown type safety

### DIFF
--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -201,22 +201,22 @@ fn try_direct_typing_linux(text: &str, preferred_tool: TypingTool) -> Result<boo
 /// Returns the list of available typing tools on this system.
 /// Always includes "auto" as the first entry.
 #[cfg(target_os = "linux")]
-pub fn get_available_typing_tools() -> Vec<String> {
-    let mut tools = vec!["auto".to_string()];
+pub fn get_available_typing_tools() -> Vec<TypingTool> {
+    let mut tools = vec![TypingTool::Auto];
     if is_wtype_available() {
-        tools.push("wtype".to_string());
+        tools.push(TypingTool::Wtype);
     }
     if is_kwtype_available() {
-        tools.push("kwtype".to_string());
+        tools.push(TypingTool::Kwtype);
     }
     if is_dotool_available() {
-        tools.push("dotool".to_string());
+        tools.push(TypingTool::Dotool);
     }
     if is_ydotool_available() {
-        tools.push("ydotool".to_string());
+        tools.push(TypingTool::Ydotool);
     }
     if is_xdotool_available() {
-        tools.push("xdotool".to_string());
+        tools.push(TypingTool::Xdotool);
     }
     tools
 }

--- a/src-tauri/src/commands/history.rs
+++ b/src-tauri/src/commands/history.rs
@@ -1,7 +1,8 @@
 use crate::actions::process_transcription_output;
 use crate::managers::{
-    history::{HistoryManager, PaginatedHistory},
     transcription::TranscriptionManager,
+    managers::history::{HistoryEntry, HistoryManager, PaginatedHistory},
+    settings::RecordingRetentionPeriod,
 };
 use std::sync::Arc;
 use tauri::{AppHandle, State};
@@ -129,21 +130,10 @@ pub async fn update_history_limit(
 pub async fn update_recording_retention_period(
     app: AppHandle,
     history_manager: State<'_, Arc<HistoryManager>>,
-    period: String,
+    period: RecordingRetentionPeriod,
 ) -> Result<(), String> {
-    use crate::settings::RecordingRetentionPeriod;
-
-    let retention_period = match period.as_str() {
-        "never" => RecordingRetentionPeriod::Never,
-        "preserve_limit" => RecordingRetentionPeriod::PreserveLimit,
-        "days3" => RecordingRetentionPeriod::Days3,
-        "weeks2" => RecordingRetentionPeriod::Weeks2,
-        "months3" => RecordingRetentionPeriod::Months3,
-        _ => return Err(format!("Invalid retention period: {}", period)),
-    };
-
     let mut settings = crate::settings::get_settings(&app);
-    settings.recording_retention_period = retention_period;
+    settings.recording_retention_period = period;
     crate::settings::write_settings(&app, settings);
 
     history_manager

--- a/src-tauri/src/commands/history.rs
+++ b/src-tauri/src/commands/history.rs
@@ -1,7 +1,9 @@
-use crate::actions::process_transcription_output;
-use crate::managers::{
-    transcription::TranscriptionManager,
-    managers::history::{HistoryEntry, HistoryManager, PaginatedHistory},
+use crate::{
+    actions::process_transcription_output,
+    managers::{
+        history::{HistoryManager, PaginatedHistory},
+        transcription::TranscriptionManager,
+    },
     settings::RecordingRetentionPeriod,
 };
 use std::sync::Arc;

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -765,21 +765,29 @@ fn cached_gpu_devices() -> &'static [GpuDeviceOption] {
 
 #[derive(Serialize, Clone, Debug, Type)]
 pub struct AvailableAccelerators {
-    pub whisper: Vec<String>,
-    pub ort: Vec<String>,
+    pub whisper: Vec<WhisperAcceleratorSetting>,
+    pub ort: Vec<OrtAcceleratorSetting>,
     pub gpu_devices: Vec<GpuDeviceOption>,
 }
 
 /// Return which accelerators are compiled into this build.
 pub fn get_available_accelerators() -> AvailableAccelerators {
-    use transcribe_rs::accel::OrtAccelerator;
-
-    let ort_options: Vec<String> = OrtAccelerator::available()
+    let ort_options: Vec<OrtAcceleratorSetting> = transcribe_rs::accel::OrtAccelerator::available()
         .into_iter()
-        .map(|a| a.to_string())
+        .map(|accelerator| match accelerator {
+            transcribe_rs::accel::OrtAccelerator::Auto => OrtAcceleratorSetting::Auto,
+            transcribe_rs::accel::OrtAccelerator::CpuOnly => OrtAcceleratorSetting::Cpu,
+            transcribe_rs::accel::OrtAccelerator::Cuda => OrtAcceleratorSetting::Cuda,
+            transcribe_rs::accel::OrtAccelerator::DirectMl => OrtAcceleratorSetting::DirectMl,
+            transcribe_rs::accel::OrtAccelerator::Rocm => OrtAcceleratorSetting::Rocm,
+        })
         .collect();
 
-    let whisper_options = vec!["auto".to_string(), "cpu".to_string(), "gpu".to_string()];
+    let whisper_options = vec![
+        WhisperAcceleratorSetting::Auto,
+        WhisperAcceleratorSetting::Cpu,
+        WhisperAcceleratorSetting::Gpu,
+    ];
 
     AvailableAccelerators {
         whisper: whisper_options,

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -783,6 +783,9 @@ pub fn get_available_accelerators() -> AvailableAccelerators {
         })
         .collect();
 
+    // Whisper acceleration is currently a policy choice (auto/cpu/gpu), not a backend choice.
+    // If `WhisperAcceleratorSetting` ever grows backend-specific variants (for example CoreMl),
+    // this should be revisited to mirror the capability-driven ORT mapping above.
     let whisper_options = vec![
         WhisperAcceleratorSetting::Auto,
         WhisperAcceleratorSetting::Cpu,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -114,7 +114,7 @@ pub enum OverlayPosition {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Type)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "lowercase")]
 pub enum ModelUnloadTimeout {
     Never,
     Immediately,
@@ -153,9 +153,10 @@ pub enum AutoSubmitKey {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Type)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "lowercase")]
 pub enum RecordingRetentionPeriod {
     Never,
+    #[serde(rename = "preserve_limit")] // kept for backward compatibility
     PreserveLimit,
     Days3,
     Weeks2,

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -1029,15 +1029,21 @@ pub async fn fetch_post_process_models(
 
 #[tauri::command]
 #[specta::specta]
-pub fn set_post_process_selected_prompt(app: AppHandle, id: String) -> Result<(), String> {
+pub fn set_post_process_selected_prompt(app: AppHandle, id: Option<String>) -> Result<(), String> {
     let mut settings = settings::get_settings(&app);
 
     // Verify the prompt exists
-    if !settings.post_process_prompts.iter().any(|p| p.id == id) {
-        return Err(format!("Prompt with id '{}' not found", id));
+    if let Some(ref id_value) = id {
+        if !settings
+            .post_process_prompts
+            .iter()
+            .any(|p| p.id == *id_value)
+        {
+            return Err(format!("Prompt with id '{}' not found", id_value));
+        }
     }
 
-    settings.post_process_selected_prompt_id = Some(id);
+    settings.post_process_selected_prompt_id = id;
     settings::write_settings(&app, settings);
     Ok(())
 }

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -701,14 +701,14 @@ pub fn change_paste_method_setting(app: AppHandle, method: String) -> Result<(),
 
 #[tauri::command]
 #[specta::specta]
-pub fn get_available_typing_tools() -> Vec<String> {
+pub fn get_available_typing_tools() -> Vec<TypingTool> {
     #[cfg(target_os = "linux")]
     {
         crate::clipboard::get_available_typing_tools()
     }
     #[cfg(not(target_os = "linux"))]
     {
-        vec!["auto".to_string()]
+        vec![TypingTool::Auto]
     }
 }
 

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -256,7 +256,7 @@ async deletePostProcessPrompt(id: string) : Promise<Result<null, string>> {
     else return { status: "error", error: e  as any };
 }
 },
-async setPostProcessSelectedPrompt(id: string) : Promise<Result<null, string>> {
+async setPostProcessSelectedPrompt(id: string | null) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("set_post_process_selected_prompt", { id }) };
 } catch (e) {

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -798,7 +798,7 @@ async updateRecordingRetentionPeriod(period: RecordingRetentionPeriod) : Promise
 },
 /**
  * Checks if the Mac is a laptop by detecting battery presence
- *
+ * 
  * This uses pmset to check for battery information.
  * Returns true if a battery is detected (laptop), false otherwise (desktop)
  */
@@ -841,7 +841,7 @@ export type HistoryUpdatePayload = { action: "added"; entry: HistoryEntry } | { 
 /**
  * Result of changing keyboard implementation
  */
-export type ImplementationChangeResult = { success: boolean;
+export type ImplementationChangeResult = { success: boolean; 
 /**
  * List of binding IDs that were reset to defaults due to incompatibility
  */
@@ -851,7 +851,7 @@ export type LLMPrompt = { id: string; name: string; prompt: string }
 export type LogLevel = "trace" | "debug" | "info" | "warn" | "error"
 export type ModelInfo = { id: string; name: string; description: string; filename: string; url: string | null; sha256: string | null; size_mb: number; is_downloaded: boolean; is_downloading: boolean; partial_size: number; is_directory: boolean; engine_type: EngineType; accuracy_score: number; speed_score: number; supports_translation: boolean; is_recommended: boolean; supported_languages: string[]; supports_language_selection: boolean; is_custom: boolean }
 export type ModelLoadStatus = { is_loaded: boolean; current_model: string | null }
-export type ModelUnloadTimeout = "never" | "immediately" | "min2" | "min5" | "min10" | "min15" | "hour1" | "sec5"
+export type ModelUnloadTimeout = "never" | "immediately" | "min2" | "min5" | "min10" | "min15" | "hour1" | "sec15"
 export type OrtAcceleratorSetting = "auto" | "cpu" | "cuda" | "directml" | "rocm"
 export type OverlayPosition = "none" | "top" | "bottom"
 export type PaginatedHistory = { entries: HistoryEntry[]; has_more: boolean }

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -133,7 +133,7 @@ async changePasteMethodSetting(method: string) : Promise<Result<null, string>> {
     else return { status: "error", error: e  as any };
 }
 },
-async getAvailableTypingTools() : Promise<string[]> {
+async getAvailableTypingTools() : Promise<TypingTool[]> {
     return await TAURI_INVOKE("get_available_typing_tools");
 },
 async changeTypingToolSetting(tool: string) : Promise<Result<null, string>> {
@@ -788,7 +788,7 @@ async updateHistoryLimit(limit: number) : Promise<Result<null, string>> {
     else return { status: "error", error: e  as any };
 }
 },
-async updateRecordingRetentionPeriod(period: string) : Promise<Result<null, string>> {
+async updateRecordingRetentionPeriod(period: RecordingRetentionPeriod) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("update_recording_retention_period", { period }) };
 } catch (e) {
@@ -798,7 +798,7 @@ async updateRecordingRetentionPeriod(period: string) : Promise<Result<null, stri
 },
 /**
  * Checks if the Mac is a laptop by detecting battery presence
- * 
+ *
  * This uses pmset to check for battery information.
  * Returns true if a battery is detected (laptop), false otherwise (desktop)
  */
@@ -830,7 +830,7 @@ historyUpdatePayload: "history-update-payload"
 export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk: boolean; audio_feedback: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; selected_model?: string; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: Partial<{ [key in string]: string }>; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; experimental_enabled?: boolean; lazy_stream_close?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool; external_script_path: string | null; custom_filler_words?: string[] | null; whisper_accelerator?: WhisperAcceleratorSetting; ort_accelerator?: OrtAcceleratorSetting; whisper_gpu_device?: number; extra_recording_buffer_ms?: number }
 export type AudioDevice = { index: string; name: string; is_default: boolean }
 export type AutoSubmitKey = "enter" | "ctrl_enter" | "cmd_enter"
-export type AvailableAccelerators = { whisper: string[]; ort: string[]; gpu_devices: GpuDeviceOption[] }
+export type AvailableAccelerators = { whisper: WhisperAcceleratorSetting[]; ort: OrtAcceleratorSetting[]; gpu_devices: GpuDeviceOption[] }
 export type BindingResponse = { success: boolean; binding: ShortcutBinding | null; error: string | null }
 export type ClipboardHandling = "dont_modify" | "copy_to_clipboard"
 export type CustomSounds = { start: boolean; stop: boolean }
@@ -841,7 +841,7 @@ export type HistoryUpdatePayload = { action: "added"; entry: HistoryEntry } | { 
 /**
  * Result of changing keyboard implementation
  */
-export type ImplementationChangeResult = { success: boolean; 
+export type ImplementationChangeResult = { success: boolean;
 /**
  * List of binding IDs that were reset to defaults due to incompatibility
  */
@@ -851,14 +851,14 @@ export type LLMPrompt = { id: string; name: string; prompt: string }
 export type LogLevel = "trace" | "debug" | "info" | "warn" | "error"
 export type ModelInfo = { id: string; name: string; description: string; filename: string; url: string | null; sha256: string | null; size_mb: number; is_downloaded: boolean; is_downloading: boolean; partial_size: number; is_directory: boolean; engine_type: EngineType; accuracy_score: number; speed_score: number; supports_translation: boolean; is_recommended: boolean; supported_languages: string[]; supports_language_selection: boolean; is_custom: boolean }
 export type ModelLoadStatus = { is_loaded: boolean; current_model: string | null }
-export type ModelUnloadTimeout = "never" | "immediately" | "min_2" | "min_5" | "min_10" | "min_15" | "hour_1" | "sec_15"
+export type ModelUnloadTimeout = "never" | "immediately" | "min2" | "min5" | "min10" | "min15" | "hour1" | "sec5"
 export type OrtAcceleratorSetting = "auto" | "cpu" | "cuda" | "directml" | "rocm"
 export type OverlayPosition = "none" | "top" | "bottom"
 export type PaginatedHistory = { entries: HistoryEntry[]; has_more: boolean }
 export type PasteMethod = "ctrl_v" | "direct" | "none" | "shift_insert" | "ctrl_shift_v" | "external_script"
 export type PermissionAccess = "allowed" | "denied" | "unknown"
 export type PostProcessProvider = { id: string; label: string; base_url: string; allow_base_url_edit?: boolean; models_endpoint?: string | null; supports_structured_output?: boolean }
-export type RecordingRetentionPeriod = "never" | "preserve_limit" | "days_3" | "weeks_2" | "months_3"
+export type RecordingRetentionPeriod = "never" | "preserve_limit" | "days3" | "weeks2" | "months3"
 export type ShortcutBinding = { id: string; name: string; description: string; default_binding: string; current_binding: string }
 export type SoundTheme = "marimba" | "pop" | "custom"
 export type TypingTool = "auto" | "wtype" | "kwtype" | "dotool" | "ydotool" | "xdotool"

--- a/src/components/settings/AccelerationSelector.tsx
+++ b/src/components/settings/AccelerationSelector.tsx
@@ -57,13 +57,13 @@ export const AccelerationSelector: FC<AccelerationSelectorProps> = ({
   const { t } = useTranslation();
   const { getSetting, updateSetting, isUpdating } = useSettings();
 
-  const [whisperOptions, setWhisperOptions] = useState<DropdownOption[]>([]);
-  const [ortOptions, setOrtOptions] = useState<DropdownOption[]>([]);
+  const [whisperOptions, setWhisperOptions] = useState<DropdownOption<string>[]>([]);
+  const [ortOptions, setOrtOptions] = useState<DropdownOption<OrtAcceleratorSetting>[]>([]);
 
   useEffect(() => {
     commands.getAvailableAccelerators().then((available) => {
       // Build combined Whisper options: Auto, [GPU devices...], CPU
-      const opts: DropdownOption[] = [
+      const opts: DropdownOption<string>[] = [
         {
           value: "auto",
           label: t("settings.advanced.acceleration.gpuDevice.auto"),
@@ -85,13 +85,14 @@ export const AccelerationSelector: FC<AccelerationSelectorProps> = ({
       setWhisperOptions(opts);
 
       // ORT options (unchanged)
-      const ortVals = available.ort.includes("auto")
+      const ortVals: OrtAcceleratorSetting[] = available.ort.includes("auto")
         ? available.ort
         : ["auto", ...available.ort];
+
       setOrtOptions(
         ortVals.map((v) => ({
           value: v,
-          label: ORT_LABELS[v as OrtAcceleratorSetting] ?? v,
+          label: ORT_LABELS[v] ?? v,
         })),
       );
     });
@@ -141,9 +142,7 @@ export const AccelerationSelector: FC<AccelerationSelectorProps> = ({
           <Dropdown
             options={ortOptions}
             selectedValue={currentOrt}
-            onSelect={(value) =>
-              updateSetting("ort_accelerator", value as OrtAcceleratorSetting)
-            }
+            onSelect={(value) => updateSetting("ort_accelerator", value)}
             disabled={isUpdating("ort_accelerator")}
           />
         </SettingContainer>

--- a/src/components/settings/AppLanguageSelector.tsx
+++ b/src/components/settings/AppLanguageSelector.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { Dropdown } from "../ui/Dropdown";
+import { Dropdown, type DropdownOption } from "../ui/Dropdown";
 import { SettingContainer } from "../ui/SettingContainer";
 import { SUPPORTED_LANGUAGES, type SupportedLanguageCode } from "../../i18n";
 import { useSettings } from "@/hooks/useSettings";
@@ -15,13 +15,13 @@ export const AppLanguageSelector: React.FC<AppLanguageSelectorProps> =
     const { t, i18n } = useTranslation();
     const { settings, updateSetting } = useSettings();
 
-    const currentLanguage = (settings?.app_language ||
-      i18n.language) as SupportedLanguageCode;
+    const currentLanguage = settings?.app_language || i18n.language;
 
-    const languageOptions = SUPPORTED_LANGUAGES.map((lang) => ({
-      value: lang.code,
-      label: `${lang.nativeName} (${lang.name})`,
-    }));
+    const languageOptions: DropdownOption<SupportedLanguageCode>[] =
+      SUPPORTED_LANGUAGES.map((lang) => ({
+        value: lang.code,
+        label: `${lang.nativeName} (${lang.name})`,
+      }));
 
     const handleLanguageChange = (langCode: string) => {
       i18n.changeLanguage(langCode);

--- a/src/components/settings/AutoSubmit.tsx
+++ b/src/components/settings/AutoSubmit.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { Dropdown } from "../ui/Dropdown";
+import { Dropdown, type DropdownOption } from "../ui/Dropdown";
 import { SettingContainer } from "../ui/SettingContainer";
 import { useSettings } from "../../hooks/useSettings";
 import { useOsType } from "../../hooks/useOsType";
@@ -28,7 +28,7 @@ export const AutoSubmit: React.FC<AutoSubmitProps> = React.memo(
         ? t("settings.advanced.autoSubmit.options.cmdEnter")
         : t("settings.advanced.autoSubmit.options.superEnter");
 
-    const autoSubmitOptions = [
+    const autoSubmitOptions: DropdownOption<AutoSubmitOptionValue>[] = [
       {
         value: "off",
         label: t("settings.advanced.autoSubmit.options.off"),
@@ -47,15 +47,13 @@ export const AutoSubmit: React.FC<AutoSubmitProps> = React.memo(
       },
     ];
 
-    const handleAutoSubmitSelect = async (value: string) => {
-      const selected = value as AutoSubmitOptionValue;
-
-      if (selected === "off") {
+    const handleAutoSubmitSelect = async (value: AutoSubmitOptionValue) => {
+      if (value === "off") {
         await updateSetting("auto_submit", false);
         return;
       }
 
-      await updateSetting("auto_submit_key", selected as AutoSubmitKey);
+      await updateSetting("auto_submit_key", value);
       if (!enabled) {
         await updateSetting("auto_submit", true);
       }

--- a/src/components/settings/ClipboardHandling.tsx
+++ b/src/components/settings/ClipboardHandling.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { Dropdown } from "../ui/Dropdown";
+import { Dropdown, type DropdownOption } from "../ui/Dropdown";
 import { SettingContainer } from "../ui/SettingContainer";
 import { useSettings } from "../../hooks/useSettings";
 import type { ClipboardHandling } from "@/bindings";
@@ -15,7 +15,7 @@ export const ClipboardHandlingSetting: React.FC<ClipboardHandlingProps> =
     const { t } = useTranslation();
     const { getSetting, updateSetting, isUpdating } = useSettings();
 
-    const clipboardHandlingOptions = [
+    const clipboardHandlingOptions: DropdownOption<ClipboardHandling>[] = [
       {
         value: "dont_modify",
         label: t("settings.advanced.clipboardHandling.options.dontModify"),
@@ -26,8 +26,7 @@ export const ClipboardHandlingSetting: React.FC<ClipboardHandlingProps> =
       },
     ];
 
-    const selectedHandling = (getSetting("clipboard_handling") ||
-      "dont_modify") as ClipboardHandling;
+    const selectedHandling = getSetting("clipboard_handling") || "dont_modify";
 
     return (
       <SettingContainer
@@ -39,9 +38,7 @@ export const ClipboardHandlingSetting: React.FC<ClipboardHandlingProps> =
         <Dropdown
           options={clipboardHandlingOptions}
           selectedValue={selectedHandling}
-          onSelect={(value) =>
-            updateSetting("clipboard_handling", value as ClipboardHandling)
-          }
+          onSelect={(value) => updateSetting("clipboard_handling", value)}
           disabled={isUpdating("clipboard_handling")}
         />
       </SettingContainer>

--- a/src/components/settings/ModelUnloadTimeout.tsx
+++ b/src/components/settings/ModelUnloadTimeout.tsx
@@ -51,7 +51,7 @@ export const ModelUnloadTimeoutSetting: React.FC<ModelUnloadTimeoutProps> = ({
   const debugTimeoutOptions: DropdownOption<ModelUnloadTimeout>[] = [
     ...timeoutOptions,
     {
-      value: "sec5",
+      value: "sec15",
       label: t("settings.advanced.modelUnload.options.sec5"),
     },
   ];

--- a/src/components/settings/ModelUnloadTimeout.tsx
+++ b/src/components/settings/ModelUnloadTimeout.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useSettings } from "../../hooks/useSettings";
-import { commands, type ModelUnloadTimeout } from "@/bindings";
-import { Dropdown } from "../ui/Dropdown";
+import type { ModelUnloadTimeout } from "@/bindings";
+import { Dropdown, type DropdownOption } from "../ui/Dropdown";
 import { SettingContainer } from "../ui/SettingContainer";
 
 interface ModelUnloadTimeoutProps {
@@ -17,51 +17,48 @@ export const ModelUnloadTimeoutSetting: React.FC<ModelUnloadTimeoutProps> = ({
   const { t } = useTranslation();
   const { settings, getSetting, updateSetting } = useSettings();
 
-  const timeoutOptions = [
+  const timeoutOptions: DropdownOption<ModelUnloadTimeout>[] = [
     {
-      value: "never" as ModelUnloadTimeout,
+      value: "never",
       label: t("settings.advanced.modelUnload.options.never"),
     },
     {
-      value: "immediately" as ModelUnloadTimeout,
+      value: "immediately",
       label: t("settings.advanced.modelUnload.options.immediately"),
     },
     {
-      value: "min2" as ModelUnloadTimeout,
+      value: "min2",
       label: t("settings.advanced.modelUnload.options.min2"),
     },
     {
-      value: "min5" as ModelUnloadTimeout,
+      value: "min5",
       label: t("settings.advanced.modelUnload.options.min5"),
     },
     {
-      value: "min10" as ModelUnloadTimeout,
+      value: "min10",
       label: t("settings.advanced.modelUnload.options.min10"),
     },
     {
-      value: "min15" as ModelUnloadTimeout,
+      value: "min15",
       label: t("settings.advanced.modelUnload.options.min15"),
     },
     {
-      value: "hour1" as ModelUnloadTimeout,
+      value: "hour1",
       label: t("settings.advanced.modelUnload.options.hour1"),
     },
   ];
 
-  const debugTimeoutOptions = [
+  const debugTimeoutOptions: DropdownOption<ModelUnloadTimeout>[] = [
     ...timeoutOptions,
     {
-      value: "sec15" as ModelUnloadTimeout,
-      label: t("settings.advanced.modelUnload.options.sec15"),
+      value: "sec5",
+      label: t("settings.advanced.modelUnload.options.sec5"),
     },
   ];
 
-  const handleChange = async (event: React.ChangeEvent<HTMLSelectElement>) => {
-    const newTimeout = event.target.value as ModelUnloadTimeout;
-
+  const handleChange = async (newTimeout: ModelUnloadTimeout) => {
     try {
-      await commands.setModelUnloadTimeout(newTimeout);
-      updateSetting("model_unload_timeout", newTimeout);
+      await updateSetting("model_unload_timeout", newTimeout);
     } catch (error) {
       console.error("Failed to update model unload timeout:", error);
     }
@@ -83,11 +80,7 @@ export const ModelUnloadTimeoutSetting: React.FC<ModelUnloadTimeoutProps> = ({
       <Dropdown
         options={options}
         selectedValue={currentValue}
-        onSelect={(value) =>
-          handleChange({
-            target: { value },
-          } as React.ChangeEvent<HTMLSelectElement>)
-        }
+        onSelect={handleChange}
         disabled={false}
       />
     </SettingContainer>

--- a/src/components/settings/PasteMethod.tsx
+++ b/src/components/settings/PasteMethod.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { Dropdown } from "../ui/Dropdown";
+import { Dropdown, type DropdownOption } from "../ui/Dropdown";
 import { SettingContainer } from "../ui/SettingContainer";
 import { Input } from "../ui/Input";
 import { useSettings } from "../../hooks/useSettings";
 import { useOsType } from "../../hooks/useOsType";
 import type { PasteMethod } from "@/bindings";
+import { type OSType } from "@/lib/utils/keyboard";
 
 interface PasteMethodProps {
   descriptionMode?: "inline" | "tooltip";
@@ -18,10 +19,12 @@ export const PasteMethodSetting: React.FC<PasteMethodProps> = React.memo(
     const { getSetting, updateSetting, isUpdating } = useSettings();
     const osType = useOsType();
 
-    const getPasteMethodOptions = (osType: string) => {
+    function getPasteMethodOptions(
+      osType: OSType,
+    ): DropdownOption<PasteMethod>[] {
       const mod = osType === "macos" ? "Cmd" : "Ctrl";
 
-      const options = [
+      const options: DropdownOption<PasteMethod>[] = [
         {
           value: "ctrl_v",
           label: t("settings.advanced.pasteMethod.options.clipboard", {
@@ -65,10 +68,9 @@ export const PasteMethodSetting: React.FC<PasteMethodProps> = React.memo(
       }
 
       return options;
-    };
+    }
 
-    const selectedMethod = (getSetting("paste_method") ||
-      "ctrl_v") as PasteMethod;
+    const selectedMethod = getSetting("paste_method") || "ctrl_v";
     const externalScriptPath = getSetting("external_script_path") || "";
 
     const pasteMethodOptions = getPasteMethodOptions(osType);
@@ -85,9 +87,7 @@ export const PasteMethodSetting: React.FC<PasteMethodProps> = React.memo(
           <Dropdown
             options={pasteMethodOptions}
             selectedValue={selectedMethod}
-            onSelect={(value) =>
-              updateSetting("paste_method", value as PasteMethod)
-            }
+            onSelect={(value) => updateSetting("paste_method", value)}
             disabled={isUpdating("paste_method")}
           />
           {selectedMethod === "external_script" && (

--- a/src/components/settings/RecordingRetentionPeriod.tsx
+++ b/src/components/settings/RecordingRetentionPeriod.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { Dropdown } from "../ui/Dropdown";
+import { Dropdown, DropdownOption } from "../ui/Dropdown";
 import { SettingContainer } from "../ui/SettingContainer";
 import { useSettings } from "../../hooks/useSettings";
 import { RecordingRetentionPeriod } from "@/bindings";
@@ -19,14 +19,13 @@ export const RecordingRetentionPeriodSelector: React.FC<RecordingRetentionPeriod
       getSetting("recording_retention_period") || "never";
     const historyLimit = getSetting("history_limit") || 5;
 
-    const handleRetentionPeriodSelect = async (period: string) => {
-      await updateSetting(
-        "recording_retention_period",
-        period as RecordingRetentionPeriod,
-      );
+    const handleRetentionPeriodSelect = async (
+      period: RecordingRetentionPeriod,
+    ) => {
+      await updateSetting("recording_retention_period", period);
     };
 
-    const retentionOptions = [
+    const retentionOptions: DropdownOption<RecordingRetentionPeriod>[] = [
       { value: "never", label: t("settings.debug.recordingRetention.never") },
       {
         value: "preserve_limit",
@@ -34,8 +33,14 @@ export const RecordingRetentionPeriodSelector: React.FC<RecordingRetentionPeriod
           count: Number(historyLimit),
         }),
       },
-      { value: "days3", label: t("settings.debug.recordingRetention.days3") },
-      { value: "weeks2", label: t("settings.debug.recordingRetention.weeks2") },
+      {
+        value: "days3",
+        label: t("settings.debug.recordingRetention.days3"),
+      },
+      {
+        value: "weeks2",
+        label: t("settings.debug.recordingRetention.weeks2"),
+      },
       {
         value: "months3",
         label: t("settings.debug.recordingRetention.months3"),

--- a/src/components/settings/ShowOverlay.tsx
+++ b/src/components/settings/ShowOverlay.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { Dropdown } from "../ui/Dropdown";
+import { Dropdown, type DropdownOption } from "../ui/Dropdown";
 import { SettingContainer } from "../ui/SettingContainer";
 import { useSettings } from "../../hooks/useSettings";
 import type { OverlayPosition } from "@/bindings";
@@ -15,14 +15,13 @@ export const ShowOverlay: React.FC<ShowOverlayProps> = React.memo(
     const { t } = useTranslation();
     const { getSetting, updateSetting, isUpdating } = useSettings();
 
-    const overlayOptions = [
+    const overlayOptions: DropdownOption<OverlayPosition>[] = [
       { value: "none", label: t("settings.advanced.overlay.options.none") },
       { value: "bottom", label: t("settings.advanced.overlay.options.bottom") },
       { value: "top", label: t("settings.advanced.overlay.options.top") },
     ];
 
-    const selectedPosition = (getSetting("overlay_position") ||
-      "bottom") as OverlayPosition;
+    const selectedPosition = getSetting("overlay_position") || "bottom";
 
     return (
       <SettingContainer
@@ -34,9 +33,7 @@ export const ShowOverlay: React.FC<ShowOverlayProps> = React.memo(
         <Dropdown
           options={overlayOptions}
           selectedValue={selectedPosition}
-          onSelect={(value) =>
-            updateSetting("overlay_position", value as OverlayPosition)
-          }
+          onSelect={(value) => updateSetting("overlay_position", value)}
           disabled={isUpdating("overlay_position")}
         />
       </SettingContainer>

--- a/src/components/settings/SoundPicker.tsx
+++ b/src/components/settings/SoundPicker.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { Button } from "../ui/Button";
-import { Dropdown, DropdownOption } from "../ui/Dropdown";
+import { Dropdown, type DropdownOption } from "../ui/Dropdown";
 import { PlayIcon } from "lucide-react";
 import { SettingContainer } from "../ui/SettingContainer";
 import { useSettingsStore } from "../../stores/settingsStore";
 import { useSettings } from "../../hooks/useSettings";
+import { type SoundTheme } from "@/bindings";
 
 interface SoundPickerProps {
   label: string;
@@ -21,7 +22,7 @@ export const SoundPicker: React.FC<SoundPickerProps> = ({
 
   const selectedTheme = getSetting("sound_theme") ?? "marimba";
 
-  const options: DropdownOption[] = [
+  const options: DropdownOption<SoundTheme>[] = [
     { value: "marimba", label: "Marimba" },
     { value: "pop", label: "Pop" },
   ];
@@ -46,9 +47,7 @@ export const SoundPicker: React.FC<SoundPickerProps> = ({
       <div className="flex items-center gap-2">
         <Dropdown
           selectedValue={selectedTheme}
-          onSelect={(value) =>
-            updateSetting("sound_theme", value as "marimba" | "pop" | "custom")
-          }
+          onSelect={(value) => updateSetting("sound_theme", value)}
           options={options}
         />
         <Button

--- a/src/components/settings/TypingTool.tsx
+++ b/src/components/settings/TypingTool.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Dropdown } from "../ui/Dropdown";
+import { Dropdown, DropdownOption } from "../ui/Dropdown";
 import { SettingContainer } from "../ui/SettingContainer";
 import { useSettings } from "../../hooks/useSettings";
 import { useOsType } from "../../hooks/useOsType";
@@ -25,7 +25,7 @@ export const TypingToolSetting: React.FC<TypingToolProps> = React.memo(
     const { t } = useTranslation();
     const { getSetting, updateSetting, isUpdating } = useSettings();
     const osType = useOsType();
-    const [availableTools, setAvailableTools] = useState<string[] | null>(null);
+    const [availableTools, setAvailableTools] = useState<TypingTool[]>([]);
 
     useEffect(() => {
       if (osType !== "linux") return;
@@ -49,7 +49,7 @@ export const TypingToolSetting: React.FC<TypingToolProps> = React.memo(
     }
 
     const tools = availableTools ?? ["auto"];
-    const typingToolOptions = tools.map((tool) =>
+    const typingToolOptions: DropdownOption<TypingTool>[] = tools.map((tool) =>
       tool === "auto"
         ? {
             value: "auto",
@@ -58,7 +58,7 @@ export const TypingToolSetting: React.FC<TypingToolProps> = React.memo(
         : { value: tool, label: allToolLabels[tool] ?? tool },
     );
 
-    const selectedTool = (getSetting("typing_tool") || "auto") as TypingTool;
+    const selectedTool = getSetting("typing_tool") || "auto";
 
     return (
       <SettingContainer
@@ -71,9 +71,7 @@ export const TypingToolSetting: React.FC<TypingToolProps> = React.memo(
         <Dropdown
           options={typingToolOptions}
           selectedValue={selectedTool}
-          onSelect={(value) =>
-            updateSetting("typing_tool", value as TypingTool)
-          }
+          onSelect={(value) => updateSetting("typing_tool", value)}
           disabled={isUpdating("typing_tool")}
         />
       </SettingContainer>

--- a/src/components/settings/debug/KeyboardImplementationSelector.tsx
+++ b/src/components/settings/debug/KeyboardImplementationSelector.tsx
@@ -3,13 +3,14 @@ import { useTranslation } from "react-i18next";
 import { SettingContainer } from "../../ui/SettingContainer";
 import { Dropdown, type DropdownOption } from "../../ui/Dropdown";
 import { useSettings } from "../../../hooks/useSettings";
-import { commands } from "@/bindings";
+import { commands, type KeyboardImplementation } from "@/bindings";
 import { toast } from "sonner";
 
-const KEYBOARD_IMPLEMENTATION_OPTIONS: DropdownOption[] = [
-  { value: "tauri", label: "Tauri Global Shortcut" },
-  { value: "handy_keys", label: "Handy Keys" },
-];
+const KEYBOARD_IMPLEMENTATION_OPTIONS: DropdownOption<KeyboardImplementation>[] =
+  [
+    { value: "tauri", label: "Tauri Global Shortcut" },
+    { value: "handy_keys", label: "Handy Keys" },
+  ];
 
 interface KeyboardImplementationSelectorProps {
   descriptionMode?: "tooltip" | "inline";

--- a/src/components/settings/debug/LogLevelSelector.tsx
+++ b/src/components/settings/debug/LogLevelSelector.tsx
@@ -5,7 +5,7 @@ import { Dropdown, type DropdownOption } from "../../ui/Dropdown";
 import { useSettings } from "../../../hooks/useSettings";
 import type { LogLevel } from "../../../bindings";
 
-const LOG_LEVEL_OPTIONS: DropdownOption[] = [
+const LOG_LEVEL_OPTIONS: DropdownOption<LogLevel>[] = [
   { value: "error", label: "Error" },
   { value: "warn", label: "Warn" },
   { value: "info", label: "Info" },
@@ -26,11 +26,11 @@ export const LogLevelSelector: React.FC<LogLevelSelectorProps> = ({
   const { settings, updateSetting, isUpdating } = useSettings();
   const currentLevel = settings?.log_level ?? "debug";
 
-  const handleSelect = async (value: string) => {
+  const handleSelect = async (value: LogLevel) => {
     if (value === currentLevel) return;
 
     try {
-      await updateSetting("log_level", value as LogLevel);
+      await updateSetting("log_level", value);
     } catch (error) {
       console.error("Failed to update log level:", error);
     }

--- a/src/components/ui/Dropdown.tsx
+++ b/src/components/ui/Dropdown.tsx
@@ -1,23 +1,23 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-export interface DropdownOption {
-  value: string;
+export interface DropdownOption<T extends string = string> {
+  value: T;
   label: string;
   disabled?: boolean;
 }
 
-interface DropdownProps {
-  options: DropdownOption[];
+interface DropdownProps<T extends string = string> {
+  options: DropdownOption<T>[];
   className?: string;
-  selectedValue: string | null;
-  onSelect: (value: string) => void;
+  selectedValue: T | null;
+  onSelect: (value: T) => void;
   placeholder?: string;
   disabled?: boolean;
   onRefresh?: () => void;
 }
 
-export const Dropdown: React.FC<DropdownProps> = ({
+export function Dropdown<T extends string = string>({
   options,
   selectedValue,
   onSelect,
@@ -25,7 +25,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
   placeholder = "Select an option...",
   disabled = false,
   onRefresh,
-}) => {
+}: DropdownProps<T>) {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -47,7 +47,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
     (option) => option.value === selectedValue,
   );
 
-  const handleSelect = (value: string) => {
+  const handleSelect = (value: T) => {
     onSelect(value);
     setIsOpen(false);
   };
@@ -112,4 +112,4 @@ export const Dropdown: React.FC<DropdownProps> = ({
       )}
     </div>
   );
-};
+}

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -15,7 +15,7 @@ interface UseSettingsReturn {
   // Actions
   updateSetting: <K extends keyof Settings>(
     key: K,
-    value: Settings[K],
+    value: Exclude<Settings[K], undefined>,
   ) => Promise<void>;
   resetSetting: (key: keyof Settings) => Promise<void>;
   refreshSettings: () => Promise<void>;

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -4,8 +4,6 @@ import { listen } from "@tauri-apps/api/event";
 import type {
   AppSettings as Settings,
   AudioDevice,
-  WhisperAcceleratorSetting,
-  OrtAcceleratorSetting,
   ModelUnloadTimeout,
 } from "@/bindings";
 import { commands } from "@/bindings";
@@ -25,7 +23,7 @@ interface SettingsStore {
   loadDefaultSettings: () => Promise<void>;
   updateSetting: <K extends keyof Settings>(
     key: K,
-    value: Settings[K],
+    value: Exclude<Settings[K], undefined>,
   ) => Promise<void>;
   resetSetting: (key: keyof Settings) => Promise<void>;
   refreshSettings: () => Promise<void>;
@@ -75,89 +73,77 @@ const DEFAULT_AUDIO_DEVICE: AudioDevice = {
 };
 
 const settingUpdaters: {
-  [K in keyof Settings]?: (value: Settings[K]) => Promise<unknown>;
+  [K in keyof Settings]?: (
+    value: Exclude<Settings[K], undefined>,
+  ) => Promise<unknown>;
 } = {
-  always_on_microphone: (value) =>
-    commands.updateMicrophoneMode(value as boolean),
-  audio_feedback: (value) =>
-    commands.changeAudioFeedbackSetting(value as boolean),
+  always_on_microphone: (value) => commands.updateMicrophoneMode(value),
+  audio_feedback: (value) => commands.changeAudioFeedbackSetting(value),
   audio_feedback_volume: (value) =>
-    commands.changeAudioFeedbackVolumeSetting(value as number),
-  sound_theme: (value) => commands.changeSoundThemeSetting(value as string),
-  start_hidden: (value) => commands.changeStartHiddenSetting(value as boolean),
-  autostart_enabled: (value) =>
-    commands.changeAutostartSetting(value as boolean),
-  update_checks_enabled: (value) =>
-    commands.changeUpdateChecksSetting(value as boolean),
-  push_to_talk: (value) => commands.changePttSetting(value as boolean),
+    commands.changeAudioFeedbackVolumeSetting(value),
+  sound_theme: (value) => commands.changeSoundThemeSetting(value),
+  start_hidden: (value) => commands.changeStartHiddenSetting(value),
+  autostart_enabled: (value) => commands.changeAutostartSetting(value),
+  update_checks_enabled: (value) => commands.changeUpdateChecksSetting(value),
+  push_to_talk: (value) => commands.changePttSetting(value),
   selected_microphone: (value) =>
     commands.setSelectedMicrophone(
-      (value as string) === "Default" || value === null
-        ? "default"
-        : (value as string),
+      value === "Default" || value === null ? "default" : value,
     ),
   clamshell_microphone: (value) =>
     commands.setClamshellMicrophone(
-      (value as string) === "Default" ? "default" : (value as string),
+      value === "Default" || value == null ? "default" : value,
     ),
   selected_output_device: (value) =>
     commands.setSelectedOutputDevice(
-      (value as string) === "Default" || value === null
-        ? "default"
-        : (value as string),
+      value === "Default" || value === null ? "default" : value,
     ),
   recording_retention_period: (value) =>
-    commands.updateRecordingRetentionPeriod(value ?? "never"),
-  model_unload_timeout: (value) =>
-    commands.setModelUnloadTimeout(value ?? "min5"),
+    commands.updateRecordingRetentionPeriod(value),
+  model_unload_timeout: (value: ModelUnloadTimeout) =>
+    commands.setModelUnloadTimeout(value),
   translate_to_english: (value) =>
-    commands.changeTranslateToEnglishSetting(value as boolean),
-  selected_language: (value) =>
-    commands.changeSelectedLanguageSetting(value as string),
-  overlay_position: (value) =>
-    commands.changeOverlayPositionSetting(value as string),
-  debug_mode: (value) => commands.changeDebugModeSetting(value as boolean),
-  custom_words: (value) => commands.updateCustomWords(value as string[]),
+    commands.changeTranslateToEnglishSetting(value),
+  selected_language: (value) => commands.changeSelectedLanguageSetting(value),
+  overlay_position: (value) => commands.changeOverlayPositionSetting(value),
+  debug_mode: (value) => commands.changeDebugModeSetting(value),
+  custom_words: (value) => commands.updateCustomWords(value),
   word_correction_threshold: (value) =>
-    commands.changeWordCorrectionThresholdSetting(value as number),
+    commands.changeWordCorrectionThresholdSetting(value),
   paste_delay_ms: (value) =>
-    commands.changePasteDelayMsSetting(value as number),
-  paste_method: (value) => commands.changePasteMethodSetting(value as string),
-  typing_tool: (value) => commands.changeTypingToolSetting(value as string),
+    commands.changePasteDelayMsSetting(value),
+  paste_method: (value) => commands.changePasteMethodSetting(value),
+  typing_tool: (value) => commands.changeTypingToolSetting(value),
   external_script_path: (value) =>
-    commands.changeExternalScriptPathSetting(value as string | null),
-  clipboard_handling: (value) =>
-    commands.changeClipboardHandlingSetting(value as string),
-  auto_submit: (value) => commands.changeAutoSubmitSetting(value as boolean),
-  auto_submit_key: (value) =>
-    commands.changeAutoSubmitKeySetting(value as string),
-  history_limit: (value) => commands.updateHistoryLimit(value as number),
+    commands.changeExternalScriptPathSetting(value),
+  clipboard_handling: (value) => commands.changeClipboardHandlingSetting(value),
+  auto_submit: (value) => commands.changeAutoSubmitSetting(value),
+  auto_submit_key: (value) => commands.changeAutoSubmitKeySetting(value),
+  history_limit: (value) => commands.updateHistoryLimit(value),
   post_process_enabled: (value) =>
-    commands.changePostProcessEnabledSetting(value as boolean),
+    commands.changePostProcessEnabledSetting(value),
   post_process_selected_prompt_id: (value) =>
-    commands.setPostProcessSelectedPrompt(value as string),
+    commands.setPostProcessSelectedPrompt(value),
   mute_while_recording: (value) =>
-    commands.changeMuteWhileRecordingSetting(value as boolean),
+    commands.changeMuteWhileRecordingSetting(value),
   append_trailing_space: (value) =>
-    commands.changeAppendTrailingSpaceSetting(value as boolean),
-  log_level: (value) => commands.setLogLevel(value as any),
-  app_language: (value) => commands.changeAppLanguageSetting(value as string),
+    commands.changeAppendTrailingSpaceSetting(value),
+  log_level: (value) => commands.setLogLevel(value),
+  app_language: (value) => commands.changeAppLanguageSetting(value),
   experimental_enabled: (value) =>
-    commands.changeExperimentalEnabledSetting(value as boolean),
-  lazy_stream_close: (value) =>
-    commands.changeLazyStreamCloseSetting(value as boolean),
-  show_tray_icon: (value) =>
-    commands.changeShowTrayIconSetting(value as boolean),
+    commands.changeExperimentalEnabledSetting(value),
+  lazy_stream_close: (value) => commands.changeLazyStreamCloseSetting(value),
+  show_tray_icon: (value) => commands.changeShowTrayIconSetting(value),
   whisper_accelerator: (value) =>
     commands.changeWhisperAcceleratorSetting(
-      value as WhisperAcceleratorSetting,
+      value,
     ),
   ort_accelerator: (value) =>
-    commands.changeOrtAcceleratorSetting(value as OrtAcceleratorSetting),
+    commands.changeOrtAcceleratorSetting(value),
   whisper_gpu_device: (value) =>
-    commands.changeWhisperGpuDevice(value as number),
+    commands.changeWhisperGpuDevice(value),
   extra_recording_buffer_ms: (value) =>
-    commands.changeExtraRecordingBufferSetting(value as number),
+    commands.changeExtraRecordingBufferSetting(value),
 };
 
 export const useSettingsStore = create<SettingsStore>()(
@@ -275,7 +261,7 @@ export const useSettingsStore = create<SettingsStore>()(
     // Update a specific setting
     updateSetting: async <K extends keyof Settings>(
       key: K,
-      value: Settings[K],
+      value: Exclude<Settings[K], undefined>,
     ) => {
       const { settings, setUpdating } = get();
       const updateKey = String(key);

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -6,6 +6,7 @@ import type {
   AudioDevice,
   WhisperAcceleratorSetting,
   OrtAcceleratorSetting,
+  ModelUnloadTimeout,
 } from "@/bindings";
 import { commands } from "@/bindings";
 
@@ -106,7 +107,9 @@ const settingUpdaters: {
         : (value as string),
     ),
   recording_retention_period: (value) =>
-    commands.updateRecordingRetentionPeriod(value as string),
+    commands.updateRecordingRetentionPeriod(value ?? "never"),
+  model_unload_timeout: (value) =>
+    commands.setModelUnloadTimeout(value ?? "min5"),
   translate_to_english: (value) =>
     commands.changeTranslateToEnglishSetting(value as boolean),
   selected_language: (value) =>


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Human Written Description

Improving type safety of dropdowns with a generic on `DropdownOption`, allowing option to be typed instead of plain `string`s.

## Related Issues/Discussions

https://github.com/cjpais/Handy/pull/1071#issuecomment-4074374308

## Testing

Tested all dropdowns for interactivity. Tested some of simple options like overlay position -- works correctly. Biggest risks are the Whisper acceleration option (wasn't able to find it in the settings) and the clipboard options since I had to change rust code for those.

## AI Assistance

- [x] AI was used (please describe below)

Used codex 5.4 for `get_available_accelerators()` rust function and to add the generic parameter `T` to `DropdownOption` in typescript.
