### PR TITLE
feat(audio): use device default sample rate and always downsample

### DIFF
--- a/src-tauri/src/audio_toolkit/audio/recorder.rs
+++ b/src-tauri/src/audio_toolkit/audio/recorder.rs
@@ -290,7 +290,13 @@ impl AudioRecorder {
         let target_rate = default_config.sample_rate();
 
         // Try to find the best sample format at the device's default rate
-        let supported_configs = device.supported_input_configs()?;
+        let supported_configs = match device.supported_input_configs() {
+            Ok(configs) => configs,
+            Err(e) => {
+                log::warn!("Could not enumerate input configs ({e}), using device default");
+                return Ok(default_config);
+            }
+        };
         let mut best_config: Option<cpal::SupportedStreamConfigRange> = None;
 
         for config_range in supported_configs {
@@ -320,7 +326,11 @@ impl AudioRecorder {
             return Ok(config.with_sample_rate(target_rate));
         }
 
-        // Fall back to device default if no config matched (shouldn't happen)
+        // Fall back to device default if no config matched (exotic/virtual devices)
+        log::warn!(
+            "No supported config matched device default rate {:?}, using default config",
+            target_rate
+        );
         Ok(default_config)
     }
 }


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Human Written Description

currently we force the mic to open at 16kHz whenever the hardware advertises support for it. this can produce suboptimal audio on devices where 16kHz is technically in the supported range but isn't the native rate, ie bluetooth codecs, certain ALSA drivers on linux, some USB mics. cj suggested using the device's default sample rate and always downsampling instead, since the resampling pipeline already exists and handles it well.

this PR changes `get_preferred_config()` to query the device's default rate and pick the best sample format at that rate, letting the existing `FrameResampler` (rubato FFT) downsample to 16kHz. devices that already default to 16kHz are unaffected (resampler short-circuits).

## Related Issues/Discussions

per cj's suggestion in https://github.com/cjpais/Handy/pull/747#issuecomment-4065206815

## Testing

- [x] built-in mic (typically 48kHz native): transcription works correctly
- [x] bluetooth headset: transcription works, audio quality not degraded
- [x] back-to-back recordings: no latency regression
- [x] device that defaults to 16kHz: no regression (resampler short-circuits)

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: claude code
- How extensively: researched the audio pipeline to understand sample rate flow, wrote the implementation