### PR TITLE
Update Italian translation

### DIFF
--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -3,7 +3,7 @@
     "settings": "Impostazioni...",
     "checkUpdates": "Verifica aggiornamenti...",
     "copyLastTranscript": "Copia l'ultima trascrizione",
-    "unloadModel": "Scarica modello",
+    "unloadModel": "Rilascia modello",
     "model": "Modello",
     "quit": "Esci",
     "cancel": "Annulla"


### PR DESCRIPTION
Rename 'unload' to 'release' to avoid confusion in Italian, as 'download' and 'unload' share the same translation.