### PR TITLE
fix(ci): grant contents: write in main-build.yml

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   build:
     permissions:
-      contents: read
+      contents: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched existing issues and pull requests to ensure this isn't a duplicate
- [x] I have read CONTRIBUTING.md

## Human Written Description

The main-build.yml I added in #1091 has a startup_failure on first run. GitHub enforces that when a calling workflow job specifies permissions, those permissions must be >= what the called reusable workflow declares — build.yml declares contents: write, so the caller must also grant contents: write or GitHub won't start the jobs at all. Missed this during local testing since actionlint doesn't catch it.

## Related Issues/Discussions

Fixes startup_failure introduced by #1091

## Testing

- [x] push to main triggers Main Branch Build without startup_failure
- [x] all 7 platform matrix jobs queue and run

## AI Assistance

- [x] AI was used

- Tools used: Claude Code
- How extensively: identified and fixed the permissions mismatch