### PR TITLE
fix(ci): use sign-binaries: true in main-build.yml

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -48,5 +48,5 @@ jobs:
       target: ${{ matrix.target }}
       build-args: ${{ matrix.args }}
       upload-artifacts: true
-      sign-binaries: false
+      sign-binaries: true
     secrets: inherit


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched existing issues and pull requests to ensure this isn't a duplicate
- [x] I have read CONTRIBUTING.md

## Human Written Description

All 7 platform builds in the new main-build.yml were failing. The cause: `sign-binaries: false` passes empty strings for `TAURI_SIGNING_PRIVATE_KEY` and `APPLE_CERTIFICATE` as env vars. Tauri treats a *set-but-empty* env var as a signing attempt and immediately fails trying to decode/import the key. On macOS: `failed to import keychain certificate`. On Linux: `failed to decode secret key: Missing comment in secret key`. Windows ARM64 failed for the same reason on top of a separate missing bundler issue.

This code path was never exercised before — `pr-test-build.yml` always uses `sign-binaries: true`. Fix is to match that behavior. Secrets are already configured in the repo and signed artifacts are actually installable for testing, which is the point.

## Related Issues/Discussions

Follow-up to #1092 (which itself followed #1091)

## Testing

- [ ] push to main triggers Main Branch Build and all platform jobs complete without signing failures

## AI Assistance

- [x] AI was used

- Tools used: Claude Code
- How extensively: diagnosed from CI logs, wrote the one-line fix