### PR TITLE
fix(ci): enable binary signing in main-build.yml

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -48,5 +48,5 @@ jobs:
       target: ${{ matrix.target }}
       build-args: ${{ matrix.args }}
       upload-artifacts: true
-      sign-binaries: false
+      sign-binaries: true
     secrets: inherit


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched existing issues and pull requests to ensure this isn't a duplicate
- [x] I have read CONTRIBUTING.md

## Human Written Description

`sign-binaries` was set to `false` in the main build workflow, so releases were shipping unsigned binaries. This flips it to `true` so builds are properly signed.

## Related Issues/Discussions

N/A

## Testing

- [ ] CI passes with signed binaries on next build

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: one-line fix