### PR TITLE
feat(cli): add --auto-submit flag to force Enter/Ctrl+Enter/Cmd+Enter…

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -5,7 +5,9 @@ use crate::audio_toolkit::is_microphone_access_denied;
 use crate::managers::audio::AudioRecordingManager;
 use crate::managers::history::HistoryManager;
 use crate::managers::transcription::TranscriptionManager;
-use crate::settings::{get_settings, AppSettings, APPLE_INTELLIGENCE_PROVIDER_ID};
+use crate::settings::{
+    get_settings, AppSettings, TranscriptionContext, APPLE_INTELLIGENCE_PROVIDER_ID,
+};
 use crate::shortcut;
 use crate::tray::{change_tray_icon, TrayIconState};
 use crate::utils::{
@@ -41,7 +43,13 @@ impl Drop for FinishGuard {
 // Shortcut Action Trait
 pub trait ShortcutAction: Send + Sync {
     fn start(&self, app: &AppHandle, binding_id: &str, shortcut_str: &str);
-    fn stop(&self, app: &AppHandle, binding_id: &str, shortcut_str: &str);
+    fn stop(
+        &self,
+        app: &AppHandle,
+        binding_id: &str,
+        shortcut_str: &str,
+        context: TranscriptionContext,
+    );
 }
 
 // Transcribe Action
@@ -409,7 +417,13 @@ impl ShortcutAction for TranscribeAction {
         );
     }
 
-    fn stop(&self, app: &AppHandle, binding_id: &str, _shortcut_str: &str) {
+    fn stop(
+        &self,
+        app: &AppHandle,
+        binding_id: &str,
+        _shortcut_str: &str,
+        context: TranscriptionContext,
+    ) {
         // Unregister the cancel shortcut when transcription stops
         shortcut::unregister_cancel_shortcut(app);
 
@@ -521,7 +535,7 @@ impl ShortcutAction for TranscribeAction {
                             let ah_clone = ah.clone();
                             let paste_time = Instant::now();
                             ah.run_on_main_thread(move || {
-                                match utils::paste(final_text, ah_clone.clone()) {
+                                match utils::paste(final_text, ah_clone.clone(), context) {
                                     Ok(()) => debug!(
                                         "Text pasted successfully in {:?}",
                                         paste_time.elapsed()
@@ -570,7 +584,13 @@ impl ShortcutAction for CancelAction {
         utils::cancel_current_operation(app);
     }
 
-    fn stop(&self, _app: &AppHandle, _binding_id: &str, _shortcut_str: &str) {
+    fn stop(
+        &self,
+        _app: &AppHandle,
+        _binding_id: &str,
+        _shortcut_str: &str,
+        _context: TranscriptionContext,
+    ) {
         // Nothing to do on stop for cancel
     }
 }
@@ -588,7 +608,13 @@ impl ShortcutAction for TestAction {
         );
     }
 
-    fn stop(&self, app: &AppHandle, binding_id: &str, shortcut_str: &str) {
+    fn stop(
+        &self,
+        app: &AppHandle,
+        binding_id: &str,
+        shortcut_str: &str,
+        _context: TranscriptionContext,
+    ) {
         log::info!(
             "Shortcut ID '{}': Stopped - {} (App: {})", // Changed "Released" to "Stopped" for consistency
             binding_id,

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -23,6 +23,10 @@ pub struct CliArgs {
     #[arg(long)]
     pub cancel: bool,
 
+    /// Force auto-submit after transcription (sent to running instance)
+    #[arg(long, value_parser = ["enter", "ctrl+enter", "cmd+enter"], default_missing_value = "enter", num_args = 0..=1)]
+    pub auto_submit: Option<String>,
+
     /// Enable debug mode with verbose logging
     #[arg(long)]
     pub debug: bool,

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -1,7 +1,9 @@
 use crate::input::{self, EnigoState};
 #[cfg(target_os = "linux")]
 use crate::settings::TypingTool;
-use crate::settings::{get_settings, AutoSubmitKey, ClipboardHandling, PasteMethod};
+use crate::settings::{
+    get_settings, AutoSubmitKey, ClipboardHandling, PasteMethod, TranscriptionContext,
+};
 use enigo::{Direction, Enigo, Key, Keyboard};
 use log::info;
 use std::process::Command;
@@ -588,7 +590,11 @@ fn should_send_auto_submit(auto_submit: bool, paste_method: PasteMethod) -> bool
     auto_submit && paste_method != PasteMethod::None
 }
 
-pub fn paste(text: String, app_handle: AppHandle) -> Result<(), String> {
+pub fn paste(
+    text: String,
+    app_handle: AppHandle,
+    context: TranscriptionContext,
+) -> Result<(), String> {
     let settings = get_settings(&app_handle);
     let paste_method = settings.paste_method;
     let paste_delay_ms = settings.paste_delay_ms;
@@ -646,9 +652,14 @@ pub fn paste(text: String, app_handle: AppHandle) -> Result<(), String> {
         }
     }
 
-    if should_send_auto_submit(settings.auto_submit, paste_method) {
+    let (auto_submit, auto_submit_key) = match context.auto_submit_override {
+        Some(key) => (true, key),
+        None => (settings.auto_submit, settings.auto_submit_key),
+    };
+
+    if should_send_auto_submit(auto_submit, paste_method) {
         std::thread::sleep(Duration::from_millis(50));
-        send_return_key(&mut enigo, settings.auto_submit_key)?;
+        send_return_key(&mut enigo, auto_submit_key)?;
     }
 
     // After pasting, optionally copy to clipboard based on settings

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -472,10 +472,32 @@ pub fn run(cli_args: CliArgs) {
 
     builder
         .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
+            let context = {
+                let mut ctx = settings::TranscriptionContext::default();
+                if let Some(pos) = args.iter().position(|a| a == "--auto-submit") {
+                    let key = args
+                        .get(pos + 1)
+                        .filter(|s| !s.starts_with("--"))
+                        .map(|s| s.as_str())
+                        .unwrap_or("enter");
+                    ctx.auto_submit_override = Some(match key {
+                        "ctrl+enter" => settings::AutoSubmitKey::CtrlEnter,
+                        "cmd+enter" => settings::AutoSubmitKey::CmdEnter,
+                        _ => settings::AutoSubmitKey::Enter,
+                    });
+                }
+                ctx
+            };
+
             if args.iter().any(|a| a == "--toggle-transcription") {
-                signal_handle::send_transcription_input(app, "transcribe", "CLI");
+                signal_handle::send_transcription_input(app, "transcribe", "CLI", context);
             } else if args.iter().any(|a| a == "--toggle-post-process") {
-                signal_handle::send_transcription_input(app, "transcribe_with_post_process", "CLI");
+                signal_handle::send_transcription_input(
+                    app,
+                    "transcribe_with_post_process",
+                    "CLI",
+                    context,
+                );
             } else if args.iter().any(|a| a == "--cancel") {
                 crate::utils::cancel_current_operation(app);
             } else {

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -206,6 +206,16 @@ impl Default for AutoSubmitKey {
     }
 }
 
+/// Per-invocation overrides for transcription behavior.
+/// Passed through the pipeline from CLI/signal triggers to the paste step.
+/// Fields are `Option` — `None` means "use the persistent setting".
+#[derive(Debug, Clone, Default)]
+pub struct TranscriptionContext {
+    /// `None` = use persistent `auto_submit` + `auto_submit_key` settings.
+    /// `Some(key)` = force auto-submit with the given key.
+    pub auto_submit_override: Option<AutoSubmitKey>,
+}
+
 impl ModelUnloadTimeout {
     pub fn to_minutes(self) -> Option<u64> {
         match self {

--- a/src-tauri/src/shortcut/handler.rs
+++ b/src-tauri/src/shortcut/handler.rs
@@ -9,7 +9,7 @@ use tauri::{AppHandle, Manager};
 
 use crate::actions::ACTION_MAP;
 use crate::managers::audio::AudioRecordingManager;
-use crate::settings::get_settings;
+use crate::settings::{get_settings, TranscriptionContext};
 use crate::transcription_coordinator::is_transcribe_binding;
 use crate::TranscriptionCoordinator;
 
@@ -37,7 +37,13 @@ pub fn handle_shortcut_event(
     // Transcribe bindings are handled by the coordinator.
     if is_transcribe_binding(binding_id) {
         if let Some(coordinator) = app.try_state::<TranscriptionCoordinator>() {
-            coordinator.send_input(binding_id, hotkey_string, is_pressed, settings.push_to_talk);
+            coordinator.send_input(
+                binding_id,
+                hotkey_string,
+                is_pressed,
+                settings.push_to_talk,
+                TranscriptionContext::default(),
+            );
         } else {
             warn!("TranscriptionCoordinator is not initialized");
         }
@@ -65,6 +71,11 @@ pub fn handle_shortcut_event(
     if is_pressed {
         action.start(app, binding_id, hotkey_string);
     } else {
-        action.stop(app, binding_id, hotkey_string);
+        action.stop(
+            app,
+            binding_id,
+            hotkey_string,
+            TranscriptionContext::default(),
+        );
     }
 }

--- a/src-tauri/src/signal_handle.rs
+++ b/src-tauri/src/signal_handle.rs
@@ -1,3 +1,4 @@
+use crate::settings::TranscriptionContext;
 use crate::TranscriptionCoordinator;
 #[cfg(unix)]
 use log::debug;
@@ -13,9 +14,14 @@ use std::thread;
 
 /// Send a transcription input to the coordinator.
 /// Used by signal handlers, CLI flags, and any other external trigger.
-pub fn send_transcription_input(app: &AppHandle, binding_id: &str, source: &str) {
+pub fn send_transcription_input(
+    app: &AppHandle,
+    binding_id: &str,
+    source: &str,
+    context: TranscriptionContext,
+) {
     if let Some(c) = app.try_state::<TranscriptionCoordinator>() {
-        c.send_input(binding_id, source, true, false);
+        c.send_input(binding_id, source, true, false, context);
     } else {
         warn!("TranscriptionCoordinator not initialized");
     }
@@ -32,7 +38,12 @@ pub fn setup_signal_handler(app_handle: AppHandle, mut signals: Signals) {
                 _ => continue,
             };
             debug!("Received {signal_name}");
-            send_transcription_input(&app_handle, binding_id, signal_name);
+            send_transcription_input(
+                &app_handle,
+                binding_id,
+                signal_name,
+                TranscriptionContext::default(),
+            );
         }
     });
 }

--- a/src-tauri/src/transcription_coordinator.rs
+++ b/src-tauri/src/transcription_coordinator.rs
@@ -1,5 +1,6 @@
 use crate::actions::ACTION_MAP;
 use crate::managers::audio::AudioRecordingManager;
+use crate::settings::TranscriptionContext;
 use log::{debug, error, warn};
 use std::sync::mpsc::{self, Sender};
 use std::sync::Arc;
@@ -16,6 +17,7 @@ enum Command {
         hotkey_string: String,
         is_pressed: bool,
         push_to_talk: bool,
+        context: TranscriptionContext,
     },
     Cancel {
         recording_was_active: bool,
@@ -26,7 +28,7 @@ enum Command {
 /// Pipeline lifecycle, owned exclusively by the coordinator thread.
 enum Stage {
     Idle,
-    Recording(String), // binding_id
+    Recording(String, TranscriptionContext),
     Processing,
 }
 
@@ -57,6 +59,7 @@ impl TranscriptionCoordinator {
                             hotkey_string,
                             is_pressed,
                             push_to_talk,
+                            context,
                         } => {
                             // Debounce rapid-fire press events (key repeat / double-tap).
                             // Releases always pass through for push-to-talk.
@@ -71,19 +74,27 @@ impl TranscriptionCoordinator {
 
                             if push_to_talk {
                                 if is_pressed && matches!(stage, Stage::Idle) {
-                                    start(&app, &mut stage, &binding_id, &hotkey_string);
+                                    start(&app, &mut stage, &binding_id, &hotkey_string, context);
                                 } else if !is_pressed
-                                    && matches!(&stage, Stage::Recording(id) if id == &binding_id)
+                                    && matches!(&stage, Stage::Recording(ref id, _) if id == &binding_id)
                                 {
-                                    stop(&app, &mut stage, &binding_id, &hotkey_string);
+                                    let ctx = take_recording_context(&mut stage);
+                                    stop(&app, &mut stage, &binding_id, &hotkey_string, ctx);
                                 }
                             } else if is_pressed {
                                 match &stage {
                                     Stage::Idle => {
-                                        start(&app, &mut stage, &binding_id, &hotkey_string);
+                                        start(
+                                            &app,
+                                            &mut stage,
+                                            &binding_id,
+                                            &hotkey_string,
+                                            context,
+                                        );
                                     }
-                                    Stage::Recording(id) if id == &binding_id => {
-                                        stop(&app, &mut stage, &binding_id, &hotkey_string);
+                                    Stage::Recording(id, _) if id == &binding_id => {
+                                        let ctx = take_recording_context(&mut stage);
+                                        stop(&app, &mut stage, &binding_id, &hotkey_string, ctx);
                                     }
                                     _ => {
                                         debug!("Ignoring press for '{binding_id}': pipeline busy")
@@ -96,7 +107,7 @@ impl TranscriptionCoordinator {
                         } => {
                             // Don't reset during processing — wait for the pipeline to finish.
                             if !matches!(stage, Stage::Processing)
-                                && (recording_was_active || matches!(stage, Stage::Recording(_)))
+                                && (recording_was_active || matches!(stage, Stage::Recording(_, _)))
                             {
                                 stage = Stage::Idle;
                             }
@@ -124,6 +135,7 @@ impl TranscriptionCoordinator {
         hotkey_string: &str,
         is_pressed: bool,
         push_to_talk: bool,
+        context: TranscriptionContext,
     ) {
         if self
             .tx
@@ -132,6 +144,7 @@ impl TranscriptionCoordinator {
                 hotkey_string: hotkey_string.to_string(),
                 is_pressed,
                 push_to_talk,
+                context,
             })
             .is_err()
         {
@@ -158,7 +171,23 @@ impl TranscriptionCoordinator {
     }
 }
 
-fn start(app: &AppHandle, stage: &mut Stage, binding_id: &str, hotkey_string: &str) {
+fn take_recording_context(stage: &mut Stage) -> TranscriptionContext {
+    match std::mem::replace(stage, Stage::Processing) {
+        Stage::Recording(_, ctx) => ctx,
+        other => {
+            *stage = other;
+            TranscriptionContext::default()
+        }
+    }
+}
+
+fn start(
+    app: &AppHandle,
+    stage: &mut Stage,
+    binding_id: &str,
+    hotkey_string: &str,
+    context: TranscriptionContext,
+) {
     let Some(action) = ACTION_MAP.get(binding_id) else {
         warn!("No action in ACTION_MAP for '{binding_id}'");
         return;
@@ -168,17 +197,23 @@ fn start(app: &AppHandle, stage: &mut Stage, binding_id: &str, hotkey_string: &s
         .try_state::<Arc<AudioRecordingManager>>()
         .map_or(false, |a| a.is_recording())
     {
-        *stage = Stage::Recording(binding_id.to_string());
+        *stage = Stage::Recording(binding_id.to_string(), context);
     } else {
         debug!("Start for '{binding_id}' did not begin recording; staying idle");
     }
 }
 
-fn stop(app: &AppHandle, stage: &mut Stage, binding_id: &str, hotkey_string: &str) {
+fn stop(
+    app: &AppHandle,
+    stage: &mut Stage,
+    binding_id: &str,
+    hotkey_string: &str,
+    context: TranscriptionContext,
+) {
     let Some(action) = ACTION_MAP.get(binding_id) else {
         warn!("No action in ACTION_MAP for '{binding_id}'");
         return;
     };
-    action.stop(app, binding_id, hotkey_string);
+    action.stop(app, binding_id, hotkey_string, context);
     *stage = Stage::Processing;
 }


### PR DESCRIPTION
**Please confirm you have done the following:**

- [X] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [X] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Human Written Description

<!-- Describe your changes clearly and concisely

Please write 2-3 sentences in your own words explaining:
- What problem you noticed or idea you had
- Why you think this change matters

This section should be YOUR thinking, not AI-generated text. Even if AI helped write the code, we want to hear from you directly. Your perspective as a human is what makes contributions meaningful. Your PR may be rejected if you do not
include a human-written description.
-->
I keep auto-submit disabled in settings by default, but for certain my automation I need to selectively trigger an Enter keypress after transcription via CLI. 
Also I prepared new struct - for future extend settings.


## Related Issues/Discussions

<!-- Link to related issues, discussions, or previous PRs -->
<!-- If reopening something previously closed, explain why this should be reconsidered -->

Extends #147 

## Testing

I used this new CLI in my linux setup

## AI Assistance

<!-- AI-assisted PRs are welcome! Just let us know so we can review appropriately. -->

- [ ] No AI was used in this PR
- [X] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Assist to implement my idea
