### PR TITLE
Add secondary transcription shortcut and language

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -5,7 +5,11 @@ use crate::audio_toolkit::is_microphone_access_denied;
 use crate::managers::audio::AudioRecordingManager;
 use crate::managers::history::HistoryManager;
 use crate::managers::transcription::TranscriptionManager;
-use crate::settings::{get_settings, AppSettings, APPLE_INTELLIGENCE_PROVIDER_ID};
+use crate::settings::{
+    get_settings, selected_language_for_binding, AppSettings, APPLE_INTELLIGENCE_PROVIDER_ID,
+    TRANSCRIBE_BINDING_ID, TRANSCRIBE_SECONDARY_BINDING_ID,
+    TRANSCRIBE_WITH_POST_PROCESS_BINDING_ID,
+};
 use crate::shortcut;
 use crate::tray::{change_tray_icon, TrayIconState};
 use crate::utils::{
@@ -271,22 +275,19 @@ async fn post_process_transcription(settings: &AppSettings, transcription: &str)
     }
 }
 
-async fn maybe_convert_chinese_variant(
-    settings: &AppSettings,
-    transcription: &str,
-) -> Option<String> {
+async fn maybe_convert_chinese_variant(language: &str, transcription: &str) -> Option<String> {
     // Check if language is set to Simplified or Traditional Chinese
-    let is_simplified = settings.selected_language == "zh-Hans";
-    let is_traditional = settings.selected_language == "zh-Hant";
+    let is_simplified = language == "zh-Hans";
+    let is_traditional = language == "zh-Hant";
 
     if !is_simplified && !is_traditional {
-        debug!("selected_language is not Simplified or Traditional Chinese; skipping translation");
+        debug!("Language is not Simplified or Traditional Chinese; skipping translation");
         return None;
     }
 
     debug!(
         "Starting Chinese translation using OpenCC for language: {}",
-        settings.selected_language
+        language
     );
 
     // Use OpenCC to convert based on selected language
@@ -451,7 +452,11 @@ impl ShortcutAction for TranscribeAction {
 
                 let transcription_time = Instant::now();
                 let samples_clone = samples.clone(); // Clone for history saving
-                match tm.transcribe(samples) {
+                let settings = get_settings(&ah);
+                let selected_language =
+                    selected_language_for_binding(&settings, &binding_id).to_string();
+
+                match tm.transcribe(samples, &selected_language) {
                     Ok(transcription) => {
                         debug!(
                             "Transcription completed in {:?}: '{}'",
@@ -459,14 +464,14 @@ impl ShortcutAction for TranscribeAction {
                             transcription
                         );
                         if !transcription.is_empty() {
-                            let settings = get_settings(&ah);
                             let mut final_text = transcription.clone();
                             let mut post_processed_text: Option<String> = None;
                             let mut post_process_prompt: Option<String> = None;
 
                             // First, check if Chinese variant conversion is needed
                             if let Some(converted_text) =
-                                maybe_convert_chinese_variant(&settings, &transcription).await
+                                maybe_convert_chinese_variant(&selected_language, &transcription)
+                                    .await
                             {
                                 final_text = converted_text;
                             }
@@ -602,14 +607,20 @@ impl ShortcutAction for TestAction {
 pub static ACTION_MAP: Lazy<HashMap<String, Arc<dyn ShortcutAction>>> = Lazy::new(|| {
     let mut map = HashMap::new();
     map.insert(
-        "transcribe".to_string(),
+        TRANSCRIBE_BINDING_ID.to_string(),
         Arc::new(TranscribeAction {
             post_process: false,
         }) as Arc<dyn ShortcutAction>,
     );
     map.insert(
-        "transcribe_with_post_process".to_string(),
+        TRANSCRIBE_WITH_POST_PROCESS_BINDING_ID.to_string(),
         Arc::new(TranscribeAction { post_process: true }) as Arc<dyn ShortcutAction>,
+    );
+    map.insert(
+        TRANSCRIBE_SECONDARY_BINDING_ID.to_string(),
+        Arc::new(TranscribeAction {
+            post_process: false,
+        }) as Arc<dyn ShortcutAction>,
     );
     map.insert(
         "cancel".to_string(),

--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -1,8 +1,79 @@
 use crate::managers::model::{ModelInfo, ModelManager};
 use crate::managers::transcription::{ModelStateEvent, TranscriptionManager};
-use crate::settings::{get_settings, write_settings, ModelUnloadTimeout};
+use crate::settings::{get_settings, write_settings, AppSettings, ModelUnloadTimeout};
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter, Manager, State};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ModelSelectionSnapshot {
+    selected_model: String,
+    selected_language: String,
+    secondary_selected_language: String,
+}
+
+fn sanitize_language_for_model(language: &str, model_info: &ModelInfo) -> Option<String> {
+    if language == "auto"
+        || model_info.supported_languages.is_empty()
+        || model_info
+            .supported_languages
+            .iter()
+            .any(|supported| supported == language)
+    {
+        return None;
+    }
+
+    Some("auto".to_string())
+}
+
+fn sanitize_transcription_languages(
+    settings: &mut AppSettings,
+    model_id: &str,
+    model_info: &ModelInfo,
+) {
+    sanitize_setting_language(
+        &mut settings.selected_language,
+        "language",
+        model_id,
+        model_info,
+    );
+    sanitize_setting_language(
+        &mut settings.secondary_selected_language,
+        "secondary language",
+        model_id,
+        model_info,
+    );
+}
+
+fn sanitize_setting_language(
+    language: &mut String,
+    label: &str,
+    model_id: &str,
+    model_info: &ModelInfo,
+) {
+    if let Some(sanitized_language) = sanitize_language_for_model(language, model_info) {
+        log::info!(
+            "Resetting {} from '{}' to 'auto' (not supported by {})",
+            label,
+            language,
+            model_id
+        );
+        *language = sanitized_language;
+    }
+}
+
+fn snapshot_model_selection(settings: &AppSettings) -> ModelSelectionSnapshot {
+    ModelSelectionSnapshot {
+        selected_model: settings.selected_model.clone(),
+        selected_language: settings.selected_language.clone(),
+        secondary_selected_language: settings.secondary_selected_language.clone(),
+    }
+}
+
+fn restore_model_selection(settings: &mut AppSettings, snapshot: &ModelSelectionSnapshot) {
+    settings.selected_model = snapshot.selected_model.clone();
+    settings.selected_language = snapshot.selected_language.clone();
+    settings.secondary_selected_language = snapshot.secondary_selected_language.clone();
+}
 
 #[tauri::command]
 #[specta::specta]
@@ -86,29 +157,16 @@ pub fn switch_active_model(app: &AppHandle, model_id: &str) -> Result<(), String
 
     let settings = get_settings(app);
     let unload_timeout = settings.model_unload_timeout;
-    let old_model = settings.selected_model.clone();
+    let previous_selection = snapshot_model_selection(&settings);
 
     // Persist the new selection early so the frontend sees the correct model
     // when it reacts to events emitted by load_model.
     let mut settings = settings;
     settings.selected_model = model_id.to_string();
 
-    // Reset language to auto if the new model doesn't support the currently selected language.
-    // This prevents stale language settings from causing errors (e.g. Canary receiving zh-Hans)
-    // and stops downstream processing (e.g. OpenCC) from running on an irrelevant language.
-    if settings.selected_language != "auto"
-        && !model_info.supported_languages.is_empty()
-        && !model_info
-            .supported_languages
-            .contains(&settings.selected_language)
-    {
-        log::info!(
-            "Resetting language from '{}' to 'auto' (not supported by {})",
-            settings.selected_language,
-            model_id
-        );
-        settings.selected_language = "auto".to_string();
-    }
+    // Reset languages to auto if the new model doesn't support them.
+    // This prevents stale language settings from causing downstream errors.
+    sanitize_transcription_languages(&mut settings, model_id, &model_info);
 
     write_settings(app, settings);
 
@@ -136,7 +194,7 @@ pub fn switch_active_model(app: &AppHandle, model_id: &str) -> Result<(), String
     // Load the model. On failure, revert the persisted selection.
     if let Err(e) = transcription_manager.load_model(model_id) {
         let mut settings = get_settings(app);
-        settings.selected_model = old_model;
+        restore_model_selection(&mut settings, &previous_selection);
         write_settings(app, settings);
         return Err(e.to_string());
     }
@@ -153,6 +211,100 @@ pub async fn set_active_model(
     model_id: String,
 ) -> Result<(), String> {
     switch_active_model(&app_handle, &model_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::managers::model::EngineType;
+    use crate::settings::get_default_settings;
+
+    fn test_model_info(supported_languages: &[&str]) -> ModelInfo {
+        ModelInfo {
+            id: "test".to_string(),
+            name: "Test Model".to_string(),
+            description: String::new(),
+            filename: String::new(),
+            url: None,
+            size_mb: 0,
+            is_downloaded: true,
+            is_downloading: false,
+            partial_size: 0,
+            is_directory: false,
+            engine_type: EngineType::Whisper,
+            accuracy_score: 0.0,
+            speed_score: 0.0,
+            supports_translation: true,
+            is_recommended: false,
+            supported_languages: supported_languages.iter().map(|s| s.to_string()).collect(),
+            supports_language_selection: true,
+            is_custom: false,
+        }
+    }
+
+    #[test]
+    fn sanitize_language_keeps_supported_values() {
+        let model_info = test_model_info(&["en", "uk"]);
+
+        assert_eq!(sanitize_language_for_model("en", &model_info), None);
+        assert_eq!(sanitize_language_for_model("auto", &model_info), None);
+    }
+
+    #[test]
+    fn sanitize_language_resets_unsupported_values_to_auto() {
+        let model_info = test_model_info(&["en"]);
+
+        assert_eq!(
+            sanitize_language_for_model("uk", &model_info),
+            Some("auto".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_transcription_languages_updates_primary_and_secondary() {
+        let model_info = test_model_info(&["en"]);
+        let mut settings = get_default_settings();
+        settings.selected_language = "uk".to_string();
+        settings.secondary_selected_language = "fr".to_string();
+
+        sanitize_transcription_languages(&mut settings, "test", &model_info);
+
+        assert_eq!(settings.selected_language, "auto");
+        assert_eq!(settings.secondary_selected_language, "auto");
+    }
+
+    #[test]
+    fn sanitize_transcription_languages_keeps_supported_secondary_language() {
+        let model_info = test_model_info(&["en", "uk"]);
+        let mut settings = get_default_settings();
+        settings.selected_language = "en".to_string();
+        settings.secondary_selected_language = "uk".to_string();
+
+        sanitize_transcription_languages(&mut settings, "test", &model_info);
+
+        assert_eq!(settings.selected_language, "en");
+        assert_eq!(settings.secondary_selected_language, "uk");
+    }
+
+    #[test]
+    fn restore_model_selection_restores_model_and_languages() {
+        let mut settings = get_default_settings();
+        settings.selected_model = "new-model".to_string();
+        settings.selected_language = "auto".to_string();
+        settings.secondary_selected_language = "auto".to_string();
+
+        let snapshot = ModelSelectionSnapshot {
+            selected_model: "old-model".to_string(),
+            selected_language: "en".to_string(),
+            secondary_selected_language: "uk".to_string(),
+        };
+
+        restore_model_selection(&mut settings, &snapshot);
+
+        assert_eq!(settings.selected_model, "old-model");
+        assert_eq!(settings.selected_language, "en");
+        assert_eq!(settings.secondary_selected_language, "uk");
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -332,6 +332,7 @@ pub fn run(cli_args: CliArgs) {
         shortcut::change_autostart_setting,
         shortcut::change_translate_to_english_setting,
         shortcut::change_selected_language_setting,
+        shortcut::change_secondary_selected_language_setting,
         shortcut::change_overlay_position_setting,
         shortcut::change_debug_mode_setting,
         shortcut::change_word_correction_threshold_setting,

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -427,7 +427,7 @@ impl TranscriptionManager {
         current_model.clone()
     }
 
-    pub fn transcribe(&self, audio: Vec<f32>) -> Result<String> {
+    pub fn transcribe(&self, audio: Vec<f32>, selected_language: &str) -> Result<String> {
         // Update last activity timestamp
         self.touch_activity();
 
@@ -460,7 +460,7 @@ impl TranscriptionManager {
 
         // Validate selected language against the model's supported languages.
         // If the language isn't supported, fall back to "auto" to prevent errors.
-        let validated_language = if settings.selected_language == "auto" {
+        let validated_language = if selected_language == "auto" {
             "auto".to_string()
         } else {
             let is_supported = self
@@ -470,16 +470,16 @@ impl TranscriptionManager {
                     info.supported_languages.is_empty()
                         || info
                             .supported_languages
-                            .contains(&settings.selected_language)
+                            .contains(&selected_language.to_string())
                 })
                 .unwrap_or(true);
 
             if is_supported {
-                settings.selected_language.clone()
+                selected_language.to_string()
             } else {
                 warn!(
                     "Language '{}' not supported by current model, falling back to auto-detect",
-                    settings.selected_language
+                    selected_language
                 );
                 "auto".to_string()
             }

--- a/src-tauri/src/managers/transcription_mock.rs
+++ b/src-tauri/src/managers/transcription_mock.rs
@@ -57,7 +57,7 @@ impl TranscriptionManager {
         None
     }
 
-    pub fn transcribe(&self, _audio: Vec<f32>) -> Result<String> {
+    pub fn transcribe(&self, _audio: Vec<f32>, _selected_language: &str) -> Result<String> {
         Ok(String::new())
     }
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -8,6 +8,9 @@ use tauri_plugin_store::StoreExt;
 
 pub const APPLE_INTELLIGENCE_PROVIDER_ID: &str = "apple_intelligence";
 pub const APPLE_INTELLIGENCE_DEFAULT_MODEL_ID: &str = "Apple Intelligence";
+pub const TRANSCRIBE_BINDING_ID: &str = "transcribe";
+pub const TRANSCRIBE_SECONDARY_BINDING_ID: &str = "transcribe_secondary";
+pub const TRANSCRIBE_WITH_POST_PROCESS_BINDING_ID: &str = "transcribe_with_post_process";
 
 #[derive(Serialize, Debug, Clone, Copy, PartialEq, Eq, Type)]
 #[serde(rename_all = "lowercase")]
@@ -334,6 +337,8 @@ pub struct AppSettings {
     pub translate_to_english: bool,
     #[serde(default = "default_selected_language")]
     pub selected_language: String,
+    #[serde(default = "default_secondary_selected_language")]
+    pub secondary_selected_language: String,
     #[serde(default = "default_overlay_position")]
     pub overlay_position: OverlayPosition,
     #[serde(default = "default_debug_mode")]
@@ -401,6 +406,26 @@ pub struct AppSettings {
     pub extra_recording_buffer_ms: u64,
 }
 
+pub fn binding_has_value(binding: &str) -> bool {
+    !binding.trim().is_empty()
+}
+
+pub fn is_transcribe_binding_id(id: &str) -> bool {
+    matches!(
+        id,
+        TRANSCRIBE_BINDING_ID
+            | TRANSCRIBE_SECONDARY_BINDING_ID
+            | TRANSCRIBE_WITH_POST_PROCESS_BINDING_ID
+    )
+}
+
+pub fn selected_language_for_binding<'a>(settings: &'a AppSettings, binding_id: &str) -> &'a str {
+    match binding_id {
+        TRANSCRIBE_SECONDARY_BINDING_ID => &settings.secondary_selected_language,
+        _ => &settings.selected_language,
+    }
+}
+
 fn default_model() -> String {
     "".to_string()
 }
@@ -426,6 +451,10 @@ fn default_update_checks_enabled() -> bool {
 }
 
 fn default_selected_language() -> String {
+    "auto".to_string()
+}
+
+fn default_secondary_selected_language() -> String {
     "auto".to_string()
 }
 
@@ -679,9 +708,9 @@ pub fn get_default_settings() -> AppSettings {
 
     let mut bindings = HashMap::new();
     bindings.insert(
-        "transcribe".to_string(),
+        TRANSCRIBE_BINDING_ID.to_string(),
         ShortcutBinding {
-            id: "transcribe".to_string(),
+            id: TRANSCRIBE_BINDING_ID.to_string(),
             name: "Transcribe".to_string(),
             description: "Converts your speech into text.".to_string(),
             default_binding: default_shortcut.to_string(),
@@ -698,14 +727,24 @@ pub fn get_default_settings() -> AppSettings {
     let default_post_process_shortcut = "alt+shift+space";
 
     bindings.insert(
-        "transcribe_with_post_process".to_string(),
+        TRANSCRIBE_WITH_POST_PROCESS_BINDING_ID.to_string(),
         ShortcutBinding {
-            id: "transcribe_with_post_process".to_string(),
+            id: TRANSCRIBE_WITH_POST_PROCESS_BINDING_ID.to_string(),
             name: "Transcribe with Post-Processing".to_string(),
             description: "Converts your speech into text and applies AI post-processing."
                 .to_string(),
             default_binding: default_post_process_shortcut.to_string(),
             current_binding: default_post_process_shortcut.to_string(),
+        },
+    );
+    bindings.insert(
+        TRANSCRIBE_SECONDARY_BINDING_ID.to_string(),
+        ShortcutBinding {
+            id: TRANSCRIBE_SECONDARY_BINDING_ID.to_string(),
+            name: "Transcribe Secondary Language".to_string(),
+            description: "Converts your speech into text using the secondary language.".to_string(),
+            default_binding: String::new(),
+            current_binding: String::new(),
         },
     );
     bindings.insert(
@@ -735,6 +774,7 @@ pub fn get_default_settings() -> AppSettings {
         selected_output_device: None,
         translate_to_english: false,
         selected_language: "auto".to_string(),
+        secondary_selected_language: "auto".to_string(),
         overlay_position: default_overlay_position(),
         debug_mode: false,
         log_level: default_log_level(),
@@ -883,14 +923,6 @@ pub fn get_bindings(app: &AppHandle) -> HashMap<String, ShortcutBinding> {
     settings.bindings
 }
 
-pub fn get_stored_binding(app: &AppHandle, id: &str) -> ShortcutBinding {
-    let bindings = get_bindings(app);
-
-    let binding = bindings.get(id).unwrap().clone();
-
-    binding
-}
-
 pub fn get_history_limit(app: &AppHandle) -> usize {
     let settings = get_settings(app);
     settings.history_limit
@@ -910,5 +942,38 @@ mod tests {
         let settings = get_default_settings();
         assert!(!settings.auto_submit);
         assert_eq!(settings.auto_submit_key, AutoSubmitKey::Enter);
+    }
+
+    #[test]
+    fn secondary_shortcut_is_unbound_by_default() {
+        let settings = get_default_settings();
+        let binding = settings
+            .bindings
+            .get(TRANSCRIBE_SECONDARY_BINDING_ID)
+            .expect("secondary binding should exist");
+
+        assert!(binding.default_binding.is_empty());
+        assert!(binding.current_binding.is_empty());
+        assert_eq!(settings.secondary_selected_language, "auto");
+    }
+
+    #[test]
+    fn selected_language_depends_on_binding_id() {
+        let mut settings = get_default_settings();
+        settings.selected_language = "en".to_string();
+        settings.secondary_selected_language = "uk".to_string();
+
+        assert_eq!(
+            selected_language_for_binding(&settings, TRANSCRIBE_BINDING_ID),
+            "en"
+        );
+        assert_eq!(
+            selected_language_for_binding(&settings, TRANSCRIBE_SECONDARY_BINDING_ID),
+            "uk"
+        );
+        assert_eq!(
+            selected_language_for_binding(&settings, TRANSCRIBE_WITH_POST_PROCESS_BINDING_ID),
+            "en"
+        );
     }
 }

--- a/src-tauri/src/shortcut/handy_keys.rs
+++ b/src-tauri/src/shortcut/handy_keys.rs
@@ -38,9 +38,11 @@ use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use tauri::{AppHandle, Emitter, Manager};
 
-use crate::settings::{self, get_settings, ShortcutBinding};
+use crate::settings::{
+    self, get_settings, ShortcutBinding, TRANSCRIBE_WITH_POST_PROCESS_BINDING_ID,
+};
 
-use super::handler::handle_shortcut_event;
+use super::{handler::handle_shortcut_event, should_register_binding};
 
 /// Commands that can be sent to the hotkey manager thread
 enum ManagerCommand {
@@ -228,6 +230,10 @@ impl HandyKeysState {
 
     /// Register a shortcut binding
     pub fn register(&self, binding: &ShortcutBinding) -> Result<(), String> {
+        if !should_register_binding(binding) {
+            return Ok(());
+        }
+
         let (tx, rx) = mpsc::channel();
         self.command_sender
             .lock()
@@ -434,7 +440,7 @@ pub fn init_shortcuts(app: &AppHandle) -> Result<(), String> {
             continue;
         }
         // Skip post-processing shortcut when the feature is disabled
-        if id == "transcribe_with_post_process" && !user_settings.post_process_enabled {
+        if id == TRANSCRIBE_WITH_POST_PROCESS_BINDING_ID && !user_settings.post_process_enabled {
             continue;
         }
 
@@ -504,6 +510,10 @@ pub fn unregister_cancel_shortcut(app: &AppHandle) {
 
 /// Register a shortcut
 pub fn register_shortcut(app: &AppHandle, binding: ShortcutBinding) -> Result<(), String> {
+    if !should_register_binding(&binding) {
+        return Ok(());
+    }
+
     let state = app
         .try_state::<HandyKeysState>()
         .ok_or("HandyKeysState not initialized")?;
@@ -512,6 +522,10 @@ pub fn register_shortcut(app: &AppHandle, binding: ShortcutBinding) -> Result<()
 
 /// Unregister a shortcut
 pub fn unregister_shortcut(app: &AppHandle, binding: ShortcutBinding) -> Result<(), String> {
+    if !should_register_binding(&binding) {
+        return Ok(());
+    }
+
     let state = app
         .try_state::<HandyKeysState>()
         .ok_or("HandyKeysState not initialized")?;

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -24,7 +24,7 @@ use crate::settings::APPLE_INTELLIGENCE_DEFAULT_MODEL_ID;
 use crate::settings::{
     self, get_settings, AutoSubmitKey, ClipboardHandling, KeyboardImplementation, LLMPrompt,
     OverlayPosition, PasteMethod, ShortcutBinding, SoundTheme, TypingTool,
-    APPLE_INTELLIGENCE_PROVIDER_ID,
+    APPLE_INTELLIGENCE_PROVIDER_ID, TRANSCRIBE_WITH_POST_PROCESS_BINDING_ID,
 };
 use crate::tray;
 
@@ -92,6 +92,10 @@ pub fn unregister_shortcut(app: &AppHandle, binding: ShortcutBinding) -> Result<
     }
 }
 
+pub(crate) fn should_register_binding(binding: &ShortcutBinding) -> bool {
+    settings::binding_has_value(&binding.current_binding)
+}
+
 // ============================================================================
 // Binding Management Commands
 // ============================================================================
@@ -110,11 +114,6 @@ pub fn change_binding(
     id: String,
     binding: String,
 ) -> Result<BindingResponse, String> {
-    // Reject empty bindings — every shortcut should have a value
-    if binding.trim().is_empty() {
-        return Err("Binding cannot be empty".to_string());
-    }
-
     let mut settings = settings::get_settings(&app);
 
     // Get the binding to modify, or create it from defaults if it doesn't exist
@@ -166,10 +165,13 @@ pub fn change_binding(
     }
 
     // Validate the new shortcut for the current keyboard implementation
-    if let Err(e) = validate_shortcut_for_implementation(&binding, settings.keyboard_implementation)
-    {
-        warn!("change_binding validation error: {}", e);
-        return Err(e);
+    if settings::binding_has_value(&binding) {
+        if let Err(e) =
+            validate_shortcut_for_implementation(&binding, settings.keyboard_implementation)
+        {
+            warn!("change_binding validation error: {}", e);
+            return Err(e);
+        }
     }
 
     // Create an updated binding
@@ -177,14 +179,16 @@ pub fn change_binding(
     updated_binding.current_binding = binding;
 
     // Register the new binding
-    if let Err(e) = register_shortcut(&app, updated_binding.clone()) {
-        let error_msg = format!("Failed to register shortcut: {}", e);
-        error!("change_binding error: {}", error_msg);
-        return Ok(BindingResponse {
-            success: false,
-            binding: None,
-            error: Some(error_msg),
-        });
+    if should_register_binding(&updated_binding) {
+        if let Err(e) = register_shortcut(&app, updated_binding.clone()) {
+            let error_msg = format!("Failed to register shortcut: {}", e);
+            error!("change_binding error: {}", error_msg);
+            return Ok(BindingResponse {
+                success: false,
+                binding: None,
+                error: Some(error_msg),
+            });
+        }
     }
 
     // Update the binding in the settings
@@ -204,8 +208,13 @@ pub fn change_binding(
 #[tauri::command]
 #[specta::specta]
 pub fn reset_binding(app: AppHandle, id: String) -> Result<BindingResponse, String> {
-    let binding = settings::get_stored_binding(&app, &id);
-    change_binding(app, id, binding.default_binding)
+    let default_binding = settings::get_default_settings()
+        .bindings
+        .get(&id)
+        .map(|binding| binding.default_binding.clone())
+        .ok_or_else(|| format!("Binding with id '{}' not found in defaults", id))?;
+
+    change_binding(app, id, default_binding)
 }
 
 /// Temporarily unregister a binding while the user is editing it in the UI.
@@ -233,6 +242,37 @@ pub fn resume_binding(app: AppHandle, id: String) -> Result<(), String> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_binding_is_treated_as_unbound() {
+        let binding = ShortcutBinding {
+            id: crate::settings::TRANSCRIBE_SECONDARY_BINDING_ID.to_string(),
+            name: "Secondary".to_string(),
+            description: "Secondary shortcut".to_string(),
+            default_binding: String::new(),
+            current_binding: String::new(),
+        };
+
+        assert!(!should_register_binding(&binding));
+    }
+
+    #[test]
+    fn non_empty_binding_is_registered() {
+        let binding = ShortcutBinding {
+            id: crate::settings::TRANSCRIBE_BINDING_ID.to_string(),
+            name: "Primary".to_string(),
+            description: "Primary shortcut".to_string(),
+            default_binding: "ctrl+space".to_string(),
+            current_binding: "ctrl+space".to_string(),
+        };
+
+        assert!(should_register_binding(&binding));
+    }
 }
 
 // ============================================================================
@@ -395,7 +435,7 @@ fn register_all_shortcuts_for_implementation(
         }
 
         // Skip post-processing shortcut when the feature is disabled
-        if id == "transcribe_with_post_process" && !current_settings.post_process_enabled {
+        if id == TRANSCRIBE_WITH_POST_PROCESS_BINDING_ID && !current_settings.post_process_enabled {
             continue;
         }
 
@@ -406,20 +446,22 @@ fn register_all_shortcuts_for_implementation(
             .unwrap_or_else(|| default_binding.clone());
 
         // Validate the shortcut for the target implementation
-        if let Err(e) =
-            validate_shortcut_for_implementation(&binding.current_binding, implementation)
-        {
-            info!(
-                "Shortcut '{}' ({}) is invalid for {:?}: {}. Resetting to default.",
-                id, binding.current_binding, implementation, e
-            );
+        if should_register_binding(&binding) {
+            if let Err(e) =
+                validate_shortcut_for_implementation(&binding.current_binding, implementation)
+            {
+                info!(
+                    "Shortcut '{}' ({}) is invalid for {:?}: {}. Resetting to default.",
+                    id, binding.current_binding, implementation, e
+                );
 
-            // Reset to default
-            binding.current_binding = default_binding.current_binding.clone();
-            current_settings
-                .bindings
-                .insert(id.clone(), binding.clone());
-            reset_bindings.push(id.clone());
+                // Reset to default
+                binding.current_binding = default_binding.current_binding.clone();
+                current_settings
+                    .bindings
+                    .insert(id.clone(), binding.clone());
+                reset_bindings.push(id.clone());
+            }
         }
 
         // Register with the appropriate implementation
@@ -530,6 +572,18 @@ pub fn change_translate_to_english_setting(app: AppHandle, enabled: bool) -> Res
 pub fn change_selected_language_setting(app: AppHandle, language: String) -> Result<(), String> {
     let mut settings = settings::get_settings(&app);
     settings.selected_language = language;
+    settings::write_settings(&app, settings);
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn change_secondary_selected_language_setting(
+    app: AppHandle,
+    language: String,
+) -> Result<(), String> {
+    let mut settings = settings::get_settings(&app);
+    settings.secondary_selected_language = language;
     settings::write_settings(&app, settings);
     Ok(())
 }
@@ -793,7 +847,7 @@ pub fn change_post_process_enabled_setting(app: AppHandle, enabled: bool) -> Res
     // Register or unregister the post-processing shortcut
     if let Some(binding) = settings
         .bindings
-        .get("transcribe_with_post_process")
+        .get(TRANSCRIBE_WITH_POST_PROCESS_BINDING_ID)
         .cloned()
     {
         if enabled {

--- a/src-tauri/src/shortcut/tauri_impl.rs
+++ b/src-tauri/src/shortcut/tauri_impl.rs
@@ -9,9 +9,9 @@ use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutState};
 
 #[cfg(not(target_os = "linux"))]
 use crate::settings::get_settings;
-use crate::settings::{self, ShortcutBinding};
+use crate::settings::{self, ShortcutBinding, TRANSCRIBE_WITH_POST_PROCESS_BINDING_ID};
 
-use super::handler::handle_shortcut_event;
+use super::{handler::handle_shortcut_event, should_register_binding};
 
 /// Initialize shortcuts using Tauri's global-shortcut plugin
 pub fn init_shortcuts(app: &AppHandle) {
@@ -24,7 +24,7 @@ pub fn init_shortcuts(app: &AppHandle) {
             continue; // Skip cancel shortcut, it will be registered dynamically
         }
         // Skip post-processing shortcut when the feature is disabled
-        if id == "transcribe_with_post_process" && !user_settings.post_process_enabled {
+        if id == TRANSCRIBE_WITH_POST_PROCESS_BINDING_ID && !user_settings.post_process_enabled {
             continue;
         }
         let binding = user_settings
@@ -71,6 +71,10 @@ pub fn validate_shortcut(raw: &str) -> Result<(), String> {
 
 /// Register a shortcut using Tauri's global-shortcut plugin
 pub fn register_shortcut(app: &AppHandle, binding: ShortcutBinding) -> Result<(), String> {
+    if !should_register_binding(&binding) {
+        return Ok(());
+    }
+
     // Validate for Tauri requirements
     if let Err(e) = validate_shortcut(&binding.current_binding) {
         warn!(
@@ -130,6 +134,10 @@ pub fn register_shortcut(app: &AppHandle, binding: ShortcutBinding) -> Result<()
 
 /// Unregister a shortcut from Tauri's global-shortcut plugin
 pub fn unregister_shortcut(app: &AppHandle, binding: ShortcutBinding) -> Result<(), String> {
+    if !should_register_binding(&binding) {
+        return Ok(());
+    }
+
     let shortcut = match binding.current_binding.parse::<Shortcut>() {
         Ok(s) => s,
         Err(e) => {

--- a/src-tauri/src/transcription_coordinator.rs
+++ b/src-tauri/src/transcription_coordinator.rs
@@ -1,5 +1,6 @@
 use crate::actions::ACTION_MAP;
 use crate::managers::audio::AudioRecordingManager;
+use crate::settings::is_transcribe_binding_id;
 use log::{debug, error, warn};
 use std::sync::mpsc::{self, Sender};
 use std::sync::Arc;
@@ -38,7 +39,7 @@ pub struct TranscriptionCoordinator {
 }
 
 pub fn is_transcribe_binding(id: &str) -> bool {
-    id == "transcribe" || id == "transcribe_with_post_process"
+    is_transcribe_binding_id(id)
 }
 
 impl TranscriptionCoordinator {

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -85,6 +85,14 @@ async changeSelectedLanguageSetting(language: string) : Promise<Result<null, str
     else return { status: "error", error: e  as any };
 }
 },
+async changeSecondarySelectedLanguageSetting(language: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("change_secondary_selected_language_setting", { language }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async changeOverlayPositionSetting(position: string) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("change_overlay_position_setting", { position }) };
@@ -795,7 +803,7 @@ async isLaptop() : Promise<Result<boolean, string>> {
 
 /** user-defined types **/
 
-export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk: boolean; audio_feedback: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; selected_model?: string; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: Partial<{ [key in string]: string }>; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; experimental_enabled?: boolean; lazy_stream_close?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool; external_script_path: string | null; custom_filler_words?: string[] | null; whisper_accelerator?: WhisperAcceleratorSetting; ort_accelerator?: OrtAcceleratorSetting; extra_recording_buffer_ms?: number }
+export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk: boolean; audio_feedback: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; selected_model?: string; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; secondary_selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: Partial<{ [key in string]: string }>; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; experimental_enabled?: boolean; lazy_stream_close?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool; external_script_path: string | null; custom_filler_words?: string[] | null; whisper_accelerator?: WhisperAcceleratorSetting; ort_accelerator?: OrtAcceleratorSetting; extra_recording_buffer_ms?: number }
 export type AudioDevice = { index: string; name: string; is_default: boolean }
 export type AutoSubmitKey = "enter" | "ctrl_enter" | "cmd_enter"
 export type AvailableAccelerators = { whisper: string[]; ort: string[] }

--- a/src/components/model-selector/ModelSelector.tsx
+++ b/src/components/model-selector/ModelSelector.tsx
@@ -28,6 +28,7 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ onError }) => {
   const {
     models,
     currentModel,
+    switchingModelId,
     downloadProgress,
     downloadStats,
     extractingModels,
@@ -37,12 +38,10 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ onError }) => {
   const [modelStatus, setModelStatus] = useState<ModelStatus>("unloaded");
   const [modelError, setModelError] = useState<string | null>(null);
   const [showModelDropdown, setShowModelDropdown] = useState(false);
-  // Track pending model switch for optimistic display
-  const [pendingModelId, setPendingModelId] = useState<string | null>(null);
 
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  const displayModelId = pendingModelId || currentModel;
+  const displayModelId = switchingModelId || currentModel;
 
   // Check model status when currentModel changes
   useEffect(() => {
@@ -80,15 +79,17 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ onError }) => {
           case "loading_completed":
             setModelStatus("ready");
             setModelError(null);
-            setPendingModelId(null);
             break;
           case "loading_failed":
             setModelStatus("error");
             setModelError(error || "Failed to load model");
-            setPendingModelId(null);
             break;
           case "unloaded":
             setModelStatus("unloaded");
+            setModelError(null);
+            break;
+          case "selection_changed":
+            setModelStatus("ready");
             setModelError(null);
             break;
         }
@@ -104,13 +105,9 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ onError }) => {
           try {
             const isRecording = await commands.isRecording();
             if (!isRecording) {
-              setPendingModelId(modelId);
               setModelError(null);
               setShowModelDropdown(false);
-              const success = await selectModel(modelId);
-              if (!success) {
-                setPendingModelId(null);
-              }
+              await selectModel(modelId);
             }
           } catch {
             // Ignore errors in auto-select
@@ -139,12 +136,10 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ onError }) => {
   }, [selectModel]);
 
   const handleModelSelect = async (modelId: string) => {
-    setPendingModelId(modelId);
     setModelError(null);
     setShowModelDropdown(false);
     const success = await selectModel(modelId);
     if (!success) {
-      setPendingModelId(null);
       setModelStatus("error");
       setModelError("Failed to switch model");
       onError?.("Failed to switch model");

--- a/src/components/settings/GlobalShortcutInput.tsx
+++ b/src/components/settings/GlobalShortcutInput.tsx
@@ -51,15 +51,13 @@ export const GlobalShortcutInput: React.FC<GlobalShortcutInputProps> = ({
       if (e.repeat) return; // ignore auto-repeat
       if (e.key === "Escape") {
         // Cancel recording and restore original binding
-        if (editingShortcutId && originalBinding) {
+        if (editingShortcutId) {
           try {
             await updateBinding(editingShortcutId, originalBinding);
           } catch (error) {
             console.error("Failed to restore original binding:", error);
             toast.error(t("settings.general.shortcut.errors.restore"));
           }
-        } else if (editingShortcutId) {
-          await commands.resumeBinding(editingShortcutId).catch(console.error);
         }
         setEditingShortcutId(null);
         setKeyPressed([]);
@@ -132,13 +130,11 @@ export const GlobalShortcutInput: React.FC<GlobalShortcutInputProps> = ({
             );
 
             // Reset to original binding on error
-            if (originalBinding) {
-              try {
-                await updateBinding(editingShortcutId, originalBinding);
-              } catch (resetError) {
-                console.error("Failed to reset binding:", resetError);
-                toast.error(t("settings.general.shortcut.errors.reset"));
-              }
+            try {
+              await updateBinding(editingShortcutId, originalBinding);
+            } catch (resetError) {
+              console.error("Failed to reset binding:", resetError);
+              toast.error(t("settings.general.shortcut.errors.reset"));
             }
           }
 
@@ -157,15 +153,13 @@ export const GlobalShortcutInput: React.FC<GlobalShortcutInputProps> = ({
       const activeElement = shortcutRefs.current.get(editingShortcutId);
       if (activeElement && !activeElement.contains(e.target as Node)) {
         // Cancel shortcut recording and restore original binding
-        if (editingShortcutId && originalBinding) {
+        if (editingShortcutId) {
           try {
             await updateBinding(editingShortcutId, originalBinding);
           } catch (error) {
             console.error("Failed to restore original binding:", error);
             toast.error(t("settings.general.shortcut.errors.restore"));
           }
-        } else if (editingShortcutId) {
-          commands.resumeBinding(editingShortcutId).catch(console.error);
         }
         setEditingShortcutId(null);
         setKeyPressed([]);
@@ -270,6 +264,11 @@ export const GlobalShortcutInput: React.FC<GlobalShortcutInputProps> = ({
     );
   }
 
+  const displayBinding =
+    binding.current_binding.trim() === ""
+      ? t("settings.general.shortcut.unassigned")
+      : formatKeyCombination(binding.current_binding, osType);
+
   // Get translated name and description for the binding
   const translatedName = t(
     `settings.general.shortcut.bindings.${shortcutId}.name`,
@@ -302,7 +301,7 @@ export const GlobalShortcutInput: React.FC<GlobalShortcutInputProps> = ({
             className="px-2 py-1 text-sm font-semibold bg-mid-gray/10 border border-mid-gray/80 hover:bg-logo-primary/10 rounded-md cursor-pointer hover:border-logo-primary"
             onClick={() => startRecording(shortcutId)}
           >
-            {formatKeyCombination(binding.current_binding, osType)}
+            {displayBinding}
           </div>
         )}
         <ResetButton

--- a/src/components/settings/HandyKeysShortcutInput.tsx
+++ b/src/components/settings/HandyKeysShortcutInput.tsx
@@ -57,13 +57,11 @@ export const HandyKeysShortcutInput: React.FC<HandyKeysShortcutInputProps> = ({
     await commands.stopHandyKeysRecording().catch(console.error);
 
     // Restore original binding
-    if (originalBinding) {
-      try {
-        await updateBinding(shortcutId, originalBinding);
-      } catch (error) {
-        console.error("Failed to restore original binding:", error);
-        toast.error(t("settings.general.shortcut.errors.restore"));
-      }
+    try {
+      await updateBinding(shortcutId, originalBinding);
+    } catch (error) {
+      console.error("Failed to restore original binding:", error);
+      toast.error(t("settings.general.shortcut.errors.restore"));
     }
 
     setIsRecording(false);
@@ -105,13 +103,11 @@ export const HandyKeysShortcutInput: React.FC<HandyKeysShortcutInputProps> = ({
               );
 
               // Reset to original binding on error
-              if (originalBinding) {
-                try {
-                  await updateBinding(shortcutId, originalBinding);
-                } catch (resetError) {
-                  console.error("Failed to reset binding:", resetError);
-                  toast.error(t("settings.general.shortcut.errors.reset"));
-                }
+              try {
+                await updateBinding(shortcutId, originalBinding);
+              } catch (resetError) {
+                console.error("Failed to reset binding:", resetError);
+                toast.error(t("settings.general.shortcut.errors.reset"));
               }
             }
 
@@ -255,6 +251,11 @@ export const HandyKeysShortcutInput: React.FC<HandyKeysShortcutInputProps> = ({
     );
   }
 
+  const displayBinding =
+    binding.current_binding.trim() === ""
+      ? t("settings.general.shortcut.unassigned")
+      : formatKeyCombination(binding.current_binding, osType);
+
   // Get translated name and description for the binding
   const translatedName = t(
     `settings.general.shortcut.bindings.${shortcutId}.name`,
@@ -287,7 +288,7 @@ export const HandyKeysShortcutInput: React.FC<HandyKeysShortcutInputProps> = ({
             className="px-2 py-1 text-sm font-semibold bg-mid-gray/10 border border-mid-gray/80 hover:bg-logo-primary/10 rounded-md cursor-pointer hover:border-logo-primary"
             onClick={startRecording}
           >
-            {formatKeyCombination(binding.current_binding, osType)}
+            {displayBinding}
           </div>
         )}
         <ResetButton

--- a/src/components/settings/LanguageSelector.tsx
+++ b/src/components/settings/LanguageSelector.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import type { AppSettings as Settings } from "@/bindings";
 import { SettingContainer } from "../ui/SettingContainer";
 import { ResetButton } from "../ui/ResetButton";
 import { useSettings } from "../../hooks/useSettings";
@@ -9,12 +10,20 @@ interface LanguageSelectorProps {
   descriptionMode?: "inline" | "tooltip";
   grouped?: boolean;
   supportedLanguages?: string[];
+  settingKey?: "selected_language" | "secondary_selected_language";
+  titleKey?: string;
+  descriptionKey?: string;
+  disabled?: boolean;
 }
 
 export const LanguageSelector: React.FC<LanguageSelectorProps> = ({
   descriptionMode = "tooltip",
   grouped = false,
   supportedLanguages,
+  settingKey = "selected_language",
+  titleKey = "settings.general.language.title",
+  descriptionKey = "settings.general.language.description",
+  disabled = false,
 }) => {
   const { t } = useTranslation();
   const { getSetting, updateSetting, resetSetting, isUpdating } = useSettings();
@@ -23,7 +32,7 @@ export const LanguageSelector: React.FC<LanguageSelectorProps> = ({
   const dropdownRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
-  const selectedLanguage = getSetting("selected_language") || "auto";
+  const selectedLanguage = getSetting(settingKey) || "auto";
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -70,17 +79,28 @@ export const LanguageSelector: React.FC<LanguageSelectorProps> = ({
     t("settings.general.language.auto");
 
   const handleLanguageSelect = async (languageCode: string) => {
-    await updateSetting("selected_language", languageCode);
+    if (settingKey === "secondary_selected_language") {
+      await updateSetting(
+        "secondary_selected_language",
+        languageCode as Settings["secondary_selected_language"],
+      );
+    } else {
+      await updateSetting(
+        "selected_language",
+        languageCode as Settings["selected_language"],
+      );
+    }
     setIsOpen(false);
     setSearchQuery("");
   };
 
   const handleReset = async () => {
-    await resetSetting("selected_language");
+    if (disabled) return;
+    await resetSetting(settingKey);
   };
 
   const handleToggle = () => {
-    if (isUpdating("selected_language")) return;
+    if (disabled || isUpdating(settingKey)) return;
     setIsOpen(!isOpen);
   };
 
@@ -100,22 +120,23 @@ export const LanguageSelector: React.FC<LanguageSelectorProps> = ({
 
   return (
     <SettingContainer
-      title={t("settings.general.language.title")}
-      description={t("settings.general.language.description")}
+      title={t(titleKey)}
+      description={t(descriptionKey)}
       descriptionMode={descriptionMode}
       grouped={grouped}
+      disabled={disabled}
     >
       <div className="flex items-center space-x-1">
         <div className="relative" ref={dropdownRef}>
           <button
             type="button"
             className={`px-2 py-1 text-sm font-semibold bg-mid-gray/10 border border-mid-gray/80 rounded min-w-[200px] text-start flex items-center justify-between transition-all duration-150 ${
-              isUpdating("selected_language")
+              disabled || isUpdating(settingKey)
                 ? "opacity-50 cursor-not-allowed"
                 : "hover:bg-logo-primary/10 cursor-pointer hover:border-logo-primary"
             }`}
             onClick={handleToggle}
-            disabled={isUpdating("selected_language")}
+            disabled={disabled || isUpdating(settingKey)}
           >
             <span className="truncate">{selectedLanguageName}</span>
             <svg
@@ -135,7 +156,7 @@ export const LanguageSelector: React.FC<LanguageSelectorProps> = ({
             </svg>
           </button>
 
-          {isOpen && !isUpdating("selected_language") && (
+          {isOpen && !disabled && !isUpdating(settingKey) && (
             <div className="absolute top-full left-0 right-0 mt-1 bg-background border border-mid-gray/80 rounded shadow-lg z-50 max-h-60 overflow-hidden">
               {/* Search input */}
               <div className="p-2 border-b border-mid-gray/80">
@@ -179,10 +200,10 @@ export const LanguageSelector: React.FC<LanguageSelectorProps> = ({
         </div>
         <ResetButton
           onClick={handleReset}
-          disabled={isUpdating("selected_language")}
+          disabled={disabled || isUpdating(settingKey)}
         />
       </div>
-      {isUpdating("selected_language") && (
+      {isUpdating(settingKey) && (
         <div className="absolute inset-0 bg-mid-gray/10 rounded flex items-center justify-center">
           <div className="w-4 h-4 border-2 border-logo-primary border-t-transparent rounded-full animate-spin"></div>
         </div>

--- a/src/components/settings/TranslateToEnglish.tsx
+++ b/src/components/settings/TranslateToEnglish.tsx
@@ -6,10 +6,11 @@ import { useSettings } from "../../hooks/useSettings";
 interface TranslateToEnglishProps {
   descriptionMode?: "inline" | "tooltip";
   grouped?: boolean;
+  disabled?: boolean;
 }
 
 export const TranslateToEnglish: React.FC<TranslateToEnglishProps> = React.memo(
-  ({ descriptionMode = "tooltip", grouped = false }) => {
+  ({ descriptionMode = "tooltip", grouped = false, disabled = false }) => {
     const { t } = useTranslation();
     const { getSetting, updateSetting, isUpdating } = useSettings();
 
@@ -19,6 +20,7 @@ export const TranslateToEnglish: React.FC<TranslateToEnglishProps> = React.memo(
       <ToggleSwitch
         checked={translateToEnglish}
         onChange={(enabled) => updateSetting("translate_to_english", enabled)}
+        disabled={disabled}
         isUpdating={isUpdating("translate_to_english")}
         label={t("settings.advanced.translateToEnglish.label")}
         description={t("settings.advanced.translateToEnglish.description")}

--- a/src/components/settings/general/GeneralSettings.tsx
+++ b/src/components/settings/general/GeneralSettings.tsx
@@ -18,6 +18,7 @@ export const GeneralSettings: React.FC = () => {
     <div className="max-w-3xl w-full mx-auto space-y-6">
       <SettingsGroup title={t("settings.general.title")}>
         <ShortcutInput shortcutId="transcribe" grouped={true} />
+        <ShortcutInput shortcutId="transcribe_secondary" grouped={true} />
         <PushToTalk descriptionMode="tooltip" grouped={true} />
       </SettingsGroup>
       <ModelSettingsCard />

--- a/src/components/settings/general/ModelSettingsCard.tsx
+++ b/src/components/settings/general/ModelSettingsCard.tsx
@@ -8,7 +8,8 @@ import type { ModelInfo } from "@/bindings";
 
 export const ModelSettingsCard: React.FC = () => {
   const { t } = useTranslation();
-  const { currentModel, models } = useModelStore();
+  const { currentModel, models, switchingModelId } = useModelStore();
+  const modelSwitchInProgress = switchingModelId !== null;
 
   const currentModelInfo = models.find((m: ModelInfo) => m.id === currentModel);
 
@@ -29,14 +30,30 @@ export const ModelSettingsCard: React.FC = () => {
       })}
     >
       {supportsLanguageSelection && (
-        <LanguageSelector
-          descriptionMode="tooltip"
-          grouped={true}
-          supportedLanguages={currentModelInfo.supported_languages}
-        />
+        <>
+          <LanguageSelector
+            descriptionMode="tooltip"
+            grouped={true}
+            supportedLanguages={currentModelInfo.supported_languages}
+            disabled={modelSwitchInProgress}
+          />
+          <LanguageSelector
+            descriptionMode="tooltip"
+            grouped={true}
+            settingKey="secondary_selected_language"
+            titleKey="settings.general.secondaryLanguage.title"
+            descriptionKey="settings.general.secondaryLanguage.description"
+            supportedLanguages={currentModelInfo.supported_languages}
+            disabled={modelSwitchInProgress}
+          />
+        </>
       )}
       {supportsTranslation && (
-        <TranslateToEnglish descriptionMode="tooltip" grouped={true} />
+        <TranslateToEnglish
+          descriptionMode="tooltip"
+          grouped={true}
+          disabled={modelSwitchInProgress}
+        />
       )}
     </SettingsGroup>
   );

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -154,6 +154,7 @@
         "none": "لا توجد اختصارات مجهزة",
         "notFound": "الاختصار غير موجود",
         "pressKeys": "...اضغط على المفاتيح",
+        "unassigned": "Unassigned",
         "bindings": {
           "transcribe": {
             "name": "اختصار التفريغ الصوتي",
@@ -166,6 +167,10 @@
           "transcribe_with_post_process": {
             "name": "مفتاح المعالجة اللاحقة",
             "description": "اختياري: مفتاح اختصار مخصص يطبق دائماً المعالجة اللاحقة بالذكاء الاصطناعي على التفريغ الصوتي."
+          },
+          "transcribe_secondary": {
+            "name": "Secondary Language Shortcut",
+            "description": "The keyboard shortcut to record and transcribe your voice using the secondary language setting."
           }
         },
         "errors": {
@@ -181,6 +186,10 @@
         "searchPlaceholder": "البحث عن اللغات...",
         "noResults": "لم يتم العثور على لغات",
         "auto": "تلقائي"
+      },
+      "secondaryLanguage": {
+        "title": "Secondary Language",
+        "description": "Select the language used when the secondary shortcut triggers transcription. Auto will automatically determine the language."
       },
       "pushToTalk": {
         "label": "اضغط للتحدث",

--- a/src/i18n/locales/cs/translation.json
+++ b/src/i18n/locales/cs/translation.json
@@ -176,6 +176,7 @@
         "none": "Žádné zkratky nejsou nastavené",
         "notFound": "Zkratka nenalezena",
         "pressKeys": "Stiskněte klávesy...",
+        "unassigned": "Unassigned",
         "bindings": {
           "transcribe": {
             "name": "Zkratka přepisu",
@@ -188,6 +189,10 @@
           "transcribe_with_post_process": {
             "name": "Klávesa pro následné zpracování",
             "description": "Volitelné: Vyhrazená klávesová zkratka, která vždy použije AI následné zpracování na váš přepis."
+          },
+          "transcribe_secondary": {
+            "name": "Secondary Language Shortcut",
+            "description": "The keyboard shortcut to record and transcribe your voice using the secondary language setting."
           }
         },
         "errors": {
@@ -203,6 +208,10 @@
         "searchPlaceholder": "Hledat jazyky...",
         "noResults": "Žádné jazyky nenalezeny",
         "auto": "Auto"
+      },
+      "secondaryLanguage": {
+        "title": "Secondary Language",
+        "description": "Select the language used when the secondary shortcut triggers transcription. Auto will automatically determine the language."
       },
       "pushToTalk": {
         "label": "Stisk a mluv",

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -176,6 +176,7 @@
         "none": "Keine Tastenkürzel konfiguriert",
         "notFound": "Tastenkürzel nicht gefunden",
         "pressKeys": "Tasten drücken...",
+        "unassigned": "Unassigned",
         "bindings": {
           "transcribe": {
             "name": "Transkriptions-Tastenkürzel",
@@ -188,6 +189,10 @@
           "transcribe_with_post_process": {
             "name": "Nachbearbeitungs-Tastenkürzel",
             "description": "Optional: Ein dediziertes Tastenkürzel, das immer die KI-Nachbearbeitung auf Ihre Transkription anwendet."
+          },
+          "transcribe_secondary": {
+            "name": "Secondary Language Shortcut",
+            "description": "The keyboard shortcut to record and transcribe your voice using the secondary language setting."
           }
         },
         "errors": {
@@ -203,6 +208,10 @@
         "searchPlaceholder": "Sprachen suchen...",
         "noResults": "Keine Sprachen gefunden",
         "auto": "Auto"
+      },
+      "secondaryLanguage": {
+        "title": "Secondary Language",
+        "description": "Select the language used when the secondary shortcut triggers transcription. Auto will automatically determine the language."
       },
       "pushToTalk": {
         "label": "Push-to-Talk",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -158,6 +158,7 @@
         "none": "No shortcuts configured",
         "notFound": "Shortcut not found",
         "pressKeys": "Press keys...",
+        "unassigned": "Unassigned",
         "bindings": {
           "transcribe": {
             "name": "Transcribe Shortcut",
@@ -170,6 +171,10 @@
           "transcribe_with_post_process": {
             "name": "Post-Processing Hotkey",
             "description": "Optional: A dedicated hotkey that always applies AI post-processing to your transcription."
+          },
+          "transcribe_secondary": {
+            "name": "Secondary Language Shortcut",
+            "description": "The keyboard shortcut to record and transcribe your voice using the secondary language setting."
           }
         },
         "errors": {
@@ -185,6 +190,10 @@
         "searchPlaceholder": "Search languages...",
         "noResults": "No languages found",
         "auto": "Auto"
+      },
+      "secondaryLanguage": {
+        "title": "Secondary Language",
+        "description": "Select the language used when the secondary shortcut triggers transcription. Auto will automatically determine the language."
       },
       "pushToTalk": {
         "label": "Push To Talk",

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -176,6 +176,7 @@
         "none": "No hay atajos configurados",
         "notFound": "Atajo no encontrado",
         "pressKeys": "Presiona teclas...",
+        "unassigned": "Unassigned",
         "bindings": {
           "transcribe": {
             "name": "Atajo de Transcripción",
@@ -188,6 +189,10 @@
           "transcribe_with_post_process": {
             "name": "Tecla de Post Procesamiento",
             "description": "Opcional: Una tecla de acceso rápido dedicada que siempre aplica post procesamiento con IA a tu transcripción."
+          },
+          "transcribe_secondary": {
+            "name": "Secondary Language Shortcut",
+            "description": "The keyboard shortcut to record and transcribe your voice using the secondary language setting."
           }
         },
         "errors": {
@@ -203,6 +208,10 @@
         "searchPlaceholder": "Buscar idiomas...",
         "noResults": "No se encontraron idiomas",
         "auto": "Auto"
+      },
+      "secondaryLanguage": {
+        "title": "Secondary Language",
+        "description": "Select the language used when the secondary shortcut triggers transcription. Auto will automatically determine the language."
       },
       "pushToTalk": {
         "label": "Presionar para Hablar",

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -176,6 +176,7 @@
         "none": "Aucun raccourci configuré",
         "notFound": "Raccourci non trouvé",
         "pressKeys": "Appuyez sur les touches...",
+        "unassigned": "Unassigned",
         "bindings": {
           "transcribe": {
             "name": "Raccourci de Transcription",
@@ -188,6 +189,10 @@
           "transcribe_with_post_process": {
             "name": "Raccourci de post-traitement",
             "description": "Facultatif : Un raccourci dédié qui applique toujours le post-traitement IA à votre transcription."
+          },
+          "transcribe_secondary": {
+            "name": "Secondary Language Shortcut",
+            "description": "The keyboard shortcut to record and transcribe your voice using the secondary language setting."
           }
         },
         "errors": {
@@ -203,6 +208,10 @@
         "searchPlaceholder": "Rechercher des langues...",
         "noResults": "Aucune langue trouvée",
         "auto": "Auto"
+      },
+      "secondaryLanguage": {
+        "title": "Secondary Language",
+        "description": "Select the language used when the secondary shortcut triggers transcription. Auto will automatically determine the language."
       },
       "pushToTalk": {
         "label": "Appuyer pour parler",

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -176,6 +176,7 @@
         "none": "Nessuna scorciatoia configurata",
         "notFound": "Scorciatoia non trovata",
         "pressKeys": "Premi i tasti...",
+        "unassigned": "Unassigned",
         "bindings": {
           "transcribe": {
             "name": "Scorciatoia Trascrizione",
@@ -188,6 +189,10 @@
           "transcribe_with_post_process": {
             "name": "Tasto di post-elaborazione",
             "description": "Facoltativo: Un tasto di scelta rapida dedicato che applica sempre la post-elaborazione IA alla trascrizione."
+          },
+          "transcribe_secondary": {
+            "name": "Secondary Language Shortcut",
+            "description": "The keyboard shortcut to record and transcribe your voice using the secondary language setting."
           }
         },
         "errors": {
@@ -203,6 +208,10 @@
         "searchPlaceholder": "Cerca lingue...",
         "noResults": "Nessuna lingua trovata",
         "auto": "Auto"
+      },
+      "secondaryLanguage": {
+        "title": "Secondary Language",
+        "description": "Select the language used when the secondary shortcut triggers transcription. Auto will automatically determine the language."
       },
       "pushToTalk": {
         "label": "Premi per Parlare",

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -176,6 +176,7 @@
         "none": "ショートカットが設定されていません",
         "notFound": "ショートカットが見つかりません",
         "pressKeys": "キーを押してください...",
+        "unassigned": "Unassigned",
         "bindings": {
           "transcribe": {
             "name": "文字起こしショートカット",
@@ -188,6 +189,10 @@
           "transcribe_with_post_process": {
             "name": "後処理ホットキー",
             "description": "オプション：文字起こしに常にAI後処理を適用する専用ホットキー。"
+          },
+          "transcribe_secondary": {
+            "name": "Secondary Language Shortcut",
+            "description": "The keyboard shortcut to record and transcribe your voice using the secondary language setting."
           }
         },
         "errors": {
@@ -203,6 +208,10 @@
         "searchPlaceholder": "言語を検索...",
         "noResults": "言語が見つかりません",
         "auto": "自動"
+      },
+      "secondaryLanguage": {
+        "title": "Secondary Language",
+        "description": "Select the language used when the secondary shortcut triggers transcription. Auto will automatically determine the language."
       },
       "pushToTalk": {
         "label": "プッシュトゥトーク",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -158,6 +158,7 @@
         "none": "설정된 단축키 없음",
         "notFound": "단축키를 찾을 수 없음",
         "pressKeys": "키를 눌러주세요...",
+        "unassigned": "Unassigned",
         "bindings": {
           "transcribe": {
             "name": "음성 텍스트 변환 단축키",
@@ -170,6 +171,10 @@
           "transcribe_with_post_process": {
             "name": "후처리 단축키",
             "description": "선택 사항: 항상 AI 후처리를 적용하는 전용 단축키입니다."
+          },
+          "transcribe_secondary": {
+            "name": "Secondary Language Shortcut",
+            "description": "The keyboard shortcut to record and transcribe your voice using the secondary language setting."
           }
         },
         "errors": {
@@ -185,6 +190,10 @@
         "searchPlaceholder": "언어 검색...",
         "noResults": "언어를 찾을 수 없습니다",
         "auto": "자동"
+      },
+      "secondaryLanguage": {
+        "title": "Secondary Language",
+        "description": "Select the language used when the secondary shortcut triggers transcription. Auto will automatically determine the language."
       },
       "pushToTalk": {
         "label": "녹음 중 단축키 홀딩",

--- a/src/i18n/locales/pl/translation.json
+++ b/src/i18n/locales/pl/translation.json
@@ -176,6 +176,7 @@
         "none": "Brak skonfigurowanych skrótów",
         "notFound": "Nie znaleziono skrótu",
         "pressKeys": "Naciśnij klawisze...",
+        "unassigned": "Unassigned",
         "bindings": {
           "transcribe": {
             "name": "Skrót transkrypcji",
@@ -188,6 +189,10 @@
           "transcribe_with_post_process": {
             "name": "Skrót postprocessingu",
             "description": "Opcjonalnie: Dedykowany skrót klawiszowy, który zawsze stosuje postprocessing AI do transkrypcji."
+          },
+          "transcribe_secondary": {
+            "name": "Secondary Language Shortcut",
+            "description": "The keyboard shortcut to record and transcribe your voice using the secondary language setting."
           }
         },
         "errors": {
@@ -203,6 +208,10 @@
         "searchPlaceholder": "Szukaj języka...",
         "noResults": "Nie znaleziono języków",
         "auto": "Auto"
+      },
+      "secondaryLanguage": {
+        "title": "Secondary Language",
+        "description": "Select the language used when the secondary shortcut triggers transcription. Auto will automatically determine the language."
       },
       "pushToTalk": {
         "label": "Push To Talk",

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -158,6 +158,7 @@
         "none": "Nenhum atalho configurado",
         "notFound": "Atalho não encontrado",
         "pressKeys": "Pressione as teclas...",
+        "unassigned": "Unassigned",
         "bindings": {
           "transcribe": {
             "name": "Atalho de Transcrição",
@@ -170,6 +171,10 @@
           "transcribe_with_post_process": {
             "name": "Tecla de Pós-Processamento",
             "description": "Opcional: Uma tecla de atalho dedicada que sempre aplica pós-processamento com IA à sua transcrição."
+          },
+          "transcribe_secondary": {
+            "name": "Secondary Language Shortcut",
+            "description": "The keyboard shortcut to record and transcribe your voice using the secondary language setting."
           }
         },
         "errors": {
@@ -185,6 +190,10 @@
         "searchPlaceholder": "Buscar idiomas...",
         "noResults": "Nenhum idioma encontrado",
         "auto": "Auto"
+      },
+      "secondaryLanguage": {
+        "title": "Secondary Language",
+        "description": "Select the language used when the secondary shortcut triggers transcription. Auto will automatically determine the language."
       },
       "pushToTalk": {
         "label": "Pressionar para Falar",

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -176,6 +176,7 @@
         "none": "Ярлыки не настроены",
         "notFound": "Ярлык не найден",
         "pressKeys": "Нажимайте клавиши...",
+        "unassigned": "Unassigned",
         "bindings": {
           "transcribe": {
             "name": "Горячая клавиша транскрипции",
@@ -188,6 +189,10 @@
           "transcribe_with_post_process": {
             "name": "Горячая клавиша постобработки",
             "description": "Специальное сочетание клавиш для ИИ-постобработки вашей транскрипции."
+          },
+          "transcribe_secondary": {
+            "name": "Secondary Language Shortcut",
+            "description": "The keyboard shortcut to record and transcribe your voice using the secondary language setting."
           }
         },
         "errors": {
@@ -203,6 +208,10 @@
         "searchPlaceholder": "Поиск языков...",
         "noResults": "Языки не найдены",
         "auto": "Авто"
+      },
+      "secondaryLanguage": {
+        "title": "Secondary Language",
+        "description": "Select the language used when the secondary shortcut triggers transcription. Auto will automatically determine the language."
       },
       "pushToTalk": {
         "label": "Нажми и говори",

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -176,6 +176,7 @@
         "none": "Kısayol yapılandırılmadı",
         "notFound": "Kısayol bulunamadı",
         "pressKeys": "Tuşlara basın...",
+        "unassigned": "Unassigned",
         "bindings": {
           "transcribe": {
             "name": "Transkripsiyon Kısayolu",
@@ -188,6 +189,10 @@
           "transcribe_with_post_process": {
             "name": "Son İşlem Kısayolu",
             "description": "İsteğe bağlı: Transkripsiyonunuza her zaman AI son işleme uygulayan özel bir kısayol tuşu."
+          },
+          "transcribe_secondary": {
+            "name": "Secondary Language Shortcut",
+            "description": "The keyboard shortcut to record and transcribe your voice using the secondary language setting."
           }
         },
         "errors": {
@@ -203,6 +208,10 @@
         "searchPlaceholder": "Dil ara...",
         "noResults": "Dil bulunamadı",
         "auto": "Otomatik"
+      },
+      "secondaryLanguage": {
+        "title": "Secondary Language",
+        "description": "Select the language used when the secondary shortcut triggers transcription. Auto will automatically determine the language."
       },
       "pushToTalk": {
         "label": "Bas Konuş",

--- a/src/i18n/locales/uk/translation.json
+++ b/src/i18n/locales/uk/translation.json
@@ -158,6 +158,7 @@
         "none": "Скорочення не налаштовані",
         "notFound": "Скорочення не знайдено",
         "pressKeys": "Натисніть клавіші...",
+        "unassigned": "Unassigned",
         "bindings": {
           "transcribe": {
             "name": "Гаряча клавіша транскрипції",
@@ -170,6 +171,10 @@
           "transcribe_with_post_process": {
             "name": "Гаряча клавіша постобробки",
             "description": "Необов'язково: Спеціальна гаряча клавіша, яка завжди застосовує AI-постобробку до вашої транскрипції."
+          },
+          "transcribe_secondary": {
+            "name": "Secondary Language Shortcut",
+            "description": "The keyboard shortcut to record and transcribe your voice using the secondary language setting."
           }
         },
         "errors": {
@@ -185,6 +190,10 @@
         "searchPlaceholder": "Пошук мов...",
         "noResults": "Мов не знайдено",
         "auto": "Авто"
+      },
+      "secondaryLanguage": {
+        "title": "Secondary Language",
+        "description": "Select the language used when the secondary shortcut triggers transcription. Auto will automatically determine the language."
       },
       "pushToTalk": {
         "label": "Утримувати для запису (Push To Talk)",

--- a/src/i18n/locales/vi/translation.json
+++ b/src/i18n/locales/vi/translation.json
@@ -176,6 +176,7 @@
         "none": "Chưa cấu hình phím tắt",
         "notFound": "Không tìm thấy phím tắt",
         "pressKeys": "Nhấn phím...",
+        "unassigned": "Unassigned",
         "bindings": {
           "transcribe": {
             "name": "Phím tắt chuyển đổi",
@@ -188,6 +189,10 @@
           "transcribe_with_post_process": {
             "name": "Phím tắt xử lý sau",
             "description": "Tùy chọn: Phím tắt chuyên dụng luôn áp dụng xử lý sau bằng AI cho bản chuyển đổi của bạn."
+          },
+          "transcribe_secondary": {
+            "name": "Secondary Language Shortcut",
+            "description": "The keyboard shortcut to record and transcribe your voice using the secondary language setting."
           }
         },
         "errors": {
@@ -203,6 +208,10 @@
         "searchPlaceholder": "Tìm kiếm ngôn ngữ...",
         "noResults": "Không tìm thấy ngôn ngữ",
         "auto": "Tự động"
+      },
+      "secondaryLanguage": {
+        "title": "Secondary Language",
+        "description": "Select the language used when the secondary shortcut triggers transcription. Auto will automatically determine the language."
       },
       "pushToTalk": {
         "label": "Nhấn để nói",

--- a/src/i18n/locales/zh-TW/translation.json
+++ b/src/i18n/locales/zh-TW/translation.json
@@ -158,6 +158,7 @@
         "none": "未設定快捷鍵",
         "notFound": "未找到快捷鍵",
         "pressKeys": "請按鍵...",
+        "unassigned": "Unassigned",
         "bindings": {
           "transcribe": {
             "name": "轉錄快捷鍵",
@@ -170,6 +171,10 @@
           "transcribe_with_post_process": {
             "name": "後處理快捷鍵",
             "description": "可選：專用快捷鍵，使用時一律對轉錄結果套用 AI 後處理"
+          },
+          "transcribe_secondary": {
+            "name": "Secondary Language Shortcut",
+            "description": "The keyboard shortcut to record and transcribe your voice using the secondary language setting."
           }
         },
         "errors": {
@@ -185,6 +190,10 @@
         "searchPlaceholder": "搜尋語言...",
         "noResults": "未找到語言",
         "auto": "自動"
+      },
+      "secondaryLanguage": {
+        "title": "Secondary Language",
+        "description": "Select the language used when the secondary shortcut triggers transcription. Auto will automatically determine the language."
       },
       "pushToTalk": {
         "label": "按住說話",

--- a/src/i18n/locales/zh/translation.json
+++ b/src/i18n/locales/zh/translation.json
@@ -176,6 +176,7 @@
         "none": "未配置快捷键",
         "notFound": "未找到快捷键",
         "pressKeys": "请按键...",
+        "unassigned": "Unassigned",
         "bindings": {
           "transcribe": {
             "name": "转录快捷键",
@@ -188,6 +189,10 @@
           "transcribe_with_post_process": {
             "name": "后处理快捷键",
             "description": "可选：一个专用快捷键，始终对您的转录应用 AI 后处理。"
+          },
+          "transcribe_secondary": {
+            "name": "Secondary Language Shortcut",
+            "description": "The keyboard shortcut to record and transcribe your voice using the secondary language setting."
           }
         },
         "errors": {
@@ -203,6 +208,10 @@
         "searchPlaceholder": "搜索语言...",
         "noResults": "未找到语言",
         "auto": "自动"
+      },
+      "secondaryLanguage": {
+        "title": "Secondary Language",
+        "description": "Select the language used when the secondary shortcut triggers transcription. Auto will automatically determine the language."
       },
       "pushToTalk": {
         "label": "按住说话",

--- a/src/stores/modelStore.ts
+++ b/src/stores/modelStore.ts
@@ -3,6 +3,7 @@ import { subscribeWithSelector } from "zustand/middleware";
 import { produce } from "immer";
 import { listen } from "@tauri-apps/api/event";
 import { commands, type ModelInfo } from "@/bindings";
+import { ModelStateEvent } from "@/lib/types/events";
 
 interface DownloadProgress {
   model_id: string;
@@ -22,6 +23,7 @@ interface DownloadStats {
 interface ModelsStore {
   models: ModelInfo[];
   currentModel: string;
+  switchingModelId: string | null;
   downloadingModels: Record<string, true>;
   extractingModels: Record<string, true>;
   downloadProgress: Record<string, DownloadProgress>;
@@ -57,6 +59,7 @@ export const useModelStore = create<ModelsStore>()(
   subscribeWithSelector((set, get) => ({
     models: [],
     currentModel: "",
+    switchingModelId: null,
     downloadingModels: {},
     extractingModels: {},
     downloadProgress: {},
@@ -142,20 +145,30 @@ export const useModelStore = create<ModelsStore>()(
     selectModel: async (modelId: string) => {
       try {
         set({ error: null });
+        set({
+          switchingModelId: modelId,
+        });
         const result = await commands.setActiveModel(modelId);
         if (result.status === "ok") {
           set({
             currentModel: modelId,
+            switchingModelId: null,
             isFirstRun: false,
             hasAnyModels: true,
           });
           return true;
         } else {
-          set({ error: `Failed to switch to model: ${result.error}` });
+          set({
+            error: `Failed to switch to model: ${result.error}`,
+            switchingModelId: null,
+          });
           return false;
         }
       } catch (err) {
-        set({ error: `Failed to switch to model: ${err}` });
+        set({
+          error: `Failed to switch to model: ${err}`,
+          switchingModelId: null,
+        });
         return false;
       }
     },
@@ -371,7 +384,26 @@ export const useModelStore = create<ModelsStore>()(
         get().loadCurrentModel();
       });
 
-      listen("model-state-changed", () => {
+      listen<ModelStateEvent>("model-state-changed", (event) => {
+        const { event_type, model_id } = event.payload;
+
+        switch (event_type) {
+          case "loading_started":
+            set({
+              switchingModelId: model_id ?? get().switchingModelId,
+            });
+            break;
+          case "loading_completed":
+          case "loading_failed":
+          case "selection_changed":
+            set({
+              switchingModelId: null,
+            });
+            break;
+          default:
+            break;
+        }
+
         get().loadModels();
         get().loadCurrentModel();
       });

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -111,6 +111,8 @@ const settingUpdaters: {
     commands.changeTranslateToEnglishSetting(value as boolean),
   selected_language: (value) =>
     commands.changeSelectedLanguageSetting(value as string),
+  secondary_selected_language: (value) =>
+    commands.changeSecondarySelectedLanguageSetting(value as string),
   overlay_position: (value) =>
     commands.changeOverlayPositionSetting(value as string),
   debug_mode: (value) => commands.changeDebugModeSetting(value as boolean),
@@ -348,7 +350,7 @@ export const useSettingsStore = create<SettingsStore>()(
         console.error(`Failed to update binding ${id}:`, error);
 
         // Rollback on error
-        if (originalBinding && get().settings) {
+        if (originalBinding !== undefined && get().settings) {
           set((state) => ({
             settings: state.settings
               ? {


### PR DESCRIPTION
## Add secondary transcription shortcut and language 

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

I wanted Handy to support two different transcription languages depending on which shortcut is pressed. The current behavior only allows one shortcut and one language, which makes switching between languages unnecessarily slow for multilingual use. This change adds a second shortcut and a second language setting, while keeping the existing primary flow intact and making the shortcut/model behavior more consistent.

## Related Issues/Discussions

Fixes #

Discussion:

## Community Feedback

I have not linked a discussion yet.

## Testing

- Ran `cargo test --manifest-path src-tauri/Cargo.toml`
- Ran `bun run build`
- Ran `bun run check:translations`
- Verified that the secondary shortcut can use a separate language
- Verified that the secondary shortcut is unbound by default
- Verified that resetting the secondary shortcut clears it back to no shortcut
- Verified that model-dependent language settings are disabled while a model switch is in progress

## Screenshots/Videos (if applicable)

Not included.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: codex-cli / GPT-5.4 xhigh
- How extensively: AI was used to help analyze the codebase, implement the changes, run checks, and refine the final code and PR text. I reviewed the changes locally and fixed issues before opening this PR.