### PR TITLE
fix(macos): allow function keys (F1-F20) as shortcuts regardless of keyboard mode

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2475,8 +2475,7 @@ dependencies = [
 [[package]]
 name = "handy-keys"
 version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c1bb519fbead4e7344bf0fe32718c4cea30fc05e03fc65c242df064f515b03"
+source = "git+https://github.com/fullstck/handy-keys?branch=fix%2Fmacos-fn-function-keys#ceab00e00c87e5bc5fcb5f4340f3505c69bdf9cb"
 dependencies = [
  "bitflags 2.11.0",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -70,7 +70,7 @@ tar = "0.4.44"
 flate2 = "1.0"
 sha2 = "0.10"
 transcribe-rs = { version = "0.3.2", features = ["whisper-cpp", "onnx"] }
-handy-keys = "0.2.4"
+handy-keys = { git = "https://github.com/fullstck/handy-keys", branch = "fix/macos-fn-function-keys" }
 ferrous-opencc = "0.2.3"
 clap = { version = "4", features = ["derive"] }
 specta = "=2.0.0-rc.22"

--- a/src-tauri/src/shortcut/handy_keys.rs
+++ b/src-tauri/src/shortcut/handy_keys.rs
@@ -27,8 +27,8 @@
 //! polled from a dedicated recording thread. Events are emitted to the frontend
 //! via Tauri's event system.
 
-use handy_keys::{Hotkey, HotkeyId, HotkeyManager, HotkeyState, Key, KeyboardListener, Modifiers};
-use log::{debug, error, info, warn};
+use handy_keys::{Hotkey, HotkeyId, HotkeyManager, HotkeyState, KeyboardListener};
+use log::{debug, error, info};
 use serde::Serialize;
 use specta::Type;
 use std::collections::HashMap;
@@ -39,40 +39,6 @@ use std::thread::{self, JoinHandle};
 use tauri::{AppHandle, Emitter, Manager};
 
 use crate::settings::{self, get_settings, ShortcutBinding};
-
-/// Check whether a key is a function key (F1-F20).
-///
-/// On macOS, function keys require holding `fn` on default keyboard settings
-/// (where the top row acts as media keys). The `fn` key sets the FN modifier
-/// flag, but it's a transport mechanism — not a meaningful modifier. We need
-/// to register both the FN and non-FN variants so that function key shortcuts
-/// work regardless of the user's keyboard configuration.
-#[cfg(target_os = "macos")]
-fn is_function_key(key: Key) -> bool {
-    matches!(
-        key,
-        Key::F1
-            | Key::F2
-            | Key::F3
-            | Key::F4
-            | Key::F5
-            | Key::F6
-            | Key::F7
-            | Key::F8
-            | Key::F9
-            | Key::F10
-            | Key::F11
-            | Key::F12
-            | Key::F13
-            | Key::F14
-            | Key::F15
-            | Key::F16
-            | Key::F17
-            | Key::F18
-            | Key::F19
-            | Key::F20
-    )
-}
 
 use super::handler::handle_shortcut_event;
 
@@ -240,44 +206,6 @@ impl HandyKeysState {
             "Registered handy-keys shortcut: {} -> {:?}",
             binding_id, hotkey
         );
-
-        // On macOS, register the FN-toggled variant for function key shortcuts.
-        // This ensures F-key shortcuts work regardless of whether the user's
-        // keyboard is in "media keys" mode (fn required) or "standard function
-        // keys" mode (fn not required).
-        #[cfg(target_os = "macos")]
-        if let Some(key) = hotkey.key {
-            if is_function_key(key) {
-                let alt_mods = if hotkey.modifiers.contains(Modifiers::FN) {
-                    hotkey.modifiers & !Modifiers::FN
-                } else {
-                    hotkey.modifiers | Modifiers::FN
-                };
-                if let Ok(alt_hotkey) = Hotkey::new(alt_mods, key) {
-                    match manager.register(alt_hotkey) {
-                        Ok(alt_id) => {
-                            let fn_binding_id = format!("{}__fn_variant", binding_id);
-                            binding_to_hotkey.insert(fn_binding_id, alt_id);
-                            hotkey_to_binding.insert(
-                                alt_id,
-                                (binding_id.to_string(), hotkey_string.to_string()),
-                            );
-                            debug!(
-                                "Registered FN-variant shortcut for {}: {:?}",
-                                binding_id, alt_hotkey
-                            );
-                        }
-                        Err(e) => {
-                            warn!(
-                                "Failed to register FN-variant for {}: {} (non-fatal)",
-                                binding_id, e
-                            );
-                        }
-                    }
-                }
-            }
-        }
-
         Ok(())
     }
 
@@ -295,15 +223,6 @@ impl HandyKeysState {
             hotkey_to_binding.remove(&id);
             debug!("Unregistered handy-keys shortcut: {}", binding_id);
         }
-
-        // Also unregister the FN-variant if it exists (macOS function key support)
-        let fn_binding_id = format!("{}__fn_variant", binding_id);
-        if let Some(fn_id) = binding_to_hotkey.remove(&fn_binding_id) {
-            let _ = manager.unregister(fn_id);
-            hotkey_to_binding.remove(&fn_id);
-            debug!("Unregistered FN-variant shortcut: {}", binding_id);
-        }
-
         Ok(())
     }
 
@@ -392,18 +311,6 @@ impl HandyKeysState {
             };
 
             if let Some(key_event) = event {
-                // On macOS, strip the FN modifier from function key events during
-                // recording. The fn key is a transport mechanism to access F-keys,
-                // not a meaningful modifier, so we record "f5" instead of "fn+f5".
-                #[cfg(target_os = "macos")]
-                let key_event = {
-                    let mut ke = key_event;
-                    if ke.key.map_or(false, is_function_key) {
-                        ke.modifiers = ke.modifiers & !Modifiers::FN;
-                    }
-                    ke
-                };
-
                 // Convert to frontend-friendly format
                 let frontend_event = FrontendKeyEvent {
                     modifiers: modifiers_to_strings(key_event.modifiers),

--- a/src-tauri/src/shortcut/handy_keys.rs
+++ b/src-tauri/src/shortcut/handy_keys.rs
@@ -27,8 +27,8 @@
 //! polled from a dedicated recording thread. Events are emitted to the frontend
 //! via Tauri's event system.
 
-use handy_keys::{Hotkey, HotkeyId, HotkeyManager, HotkeyState, KeyboardListener};
-use log::{debug, error, info};
+use handy_keys::{Hotkey, HotkeyId, HotkeyManager, HotkeyState, Key, KeyboardListener, Modifiers};
+use log::{debug, error, info, warn};
 use serde::Serialize;
 use specta::Type;
 use std::collections::HashMap;
@@ -39,6 +39,40 @@ use std::thread::{self, JoinHandle};
 use tauri::{AppHandle, Emitter, Manager};
 
 use crate::settings::{self, get_settings, ShortcutBinding};
+
+/// Check whether a key is a function key (F1-F20).
+///
+/// On macOS, function keys require holding `fn` on default keyboard settings
+/// (where the top row acts as media keys). The `fn` key sets the FN modifier
+/// flag, but it's a transport mechanism — not a meaningful modifier. We need
+/// to register both the FN and non-FN variants so that function key shortcuts
+/// work regardless of the user's keyboard configuration.
+#[cfg(target_os = "macos")]
+fn is_function_key(key: Key) -> bool {
+    matches!(
+        key,
+        Key::F1
+            | Key::F2
+            | Key::F3
+            | Key::F4
+            | Key::F5
+            | Key::F6
+            | Key::F7
+            | Key::F8
+            | Key::F9
+            | Key::F10
+            | Key::F11
+            | Key::F12
+            | Key::F13
+            | Key::F14
+            | Key::F15
+            | Key::F16
+            | Key::F17
+            | Key::F18
+            | Key::F19
+            | Key::F20
+    )
+}
 
 use super::handler::handle_shortcut_event;
 
@@ -206,6 +240,44 @@ impl HandyKeysState {
             "Registered handy-keys shortcut: {} -> {:?}",
             binding_id, hotkey
         );
+
+        // On macOS, register the FN-toggled variant for function key shortcuts.
+        // This ensures F-key shortcuts work regardless of whether the user's
+        // keyboard is in "media keys" mode (fn required) or "standard function
+        // keys" mode (fn not required).
+        #[cfg(target_os = "macos")]
+        if let Some(key) = hotkey.key {
+            if is_function_key(key) {
+                let alt_mods = if hotkey.modifiers.contains(Modifiers::FN) {
+                    hotkey.modifiers & !Modifiers::FN
+                } else {
+                    hotkey.modifiers | Modifiers::FN
+                };
+                if let Ok(alt_hotkey) = Hotkey::new(alt_mods, key) {
+                    match manager.register(alt_hotkey) {
+                        Ok(alt_id) => {
+                            let fn_binding_id = format!("{}__fn_variant", binding_id);
+                            binding_to_hotkey.insert(fn_binding_id, alt_id);
+                            hotkey_to_binding.insert(
+                                alt_id,
+                                (binding_id.to_string(), hotkey_string.to_string()),
+                            );
+                            debug!(
+                                "Registered FN-variant shortcut for {}: {:?}",
+                                binding_id, alt_hotkey
+                            );
+                        }
+                        Err(e) => {
+                            warn!(
+                                "Failed to register FN-variant for {}: {} (non-fatal)",
+                                binding_id, e
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -223,6 +295,15 @@ impl HandyKeysState {
             hotkey_to_binding.remove(&id);
             debug!("Unregistered handy-keys shortcut: {}", binding_id);
         }
+
+        // Also unregister the FN-variant if it exists (macOS function key support)
+        let fn_binding_id = format!("{}__fn_variant", binding_id);
+        if let Some(fn_id) = binding_to_hotkey.remove(&fn_binding_id) {
+            let _ = manager.unregister(fn_id);
+            hotkey_to_binding.remove(&fn_id);
+            debug!("Unregistered FN-variant shortcut: {}", binding_id);
+        }
+
         Ok(())
     }
 
@@ -311,6 +392,18 @@ impl HandyKeysState {
             };
 
             if let Some(key_event) = event {
+                // On macOS, strip the FN modifier from function key events during
+                // recording. The fn key is a transport mechanism to access F-keys,
+                // not a meaningful modifier, so we record "f5" instead of "fn+f5".
+                #[cfg(target_os = "macos")]
+                let key_event = {
+                    let mut ke = key_event;
+                    if ke.key.map_or(false, is_function_key) {
+                        ke.modifiers = ke.modifiers & !Modifiers::FN;
+                    }
+                    ke
+                };
+
                 // Convert to frontend-friendly format
                 let frontend_event = FrontendKeyEvent {
                     modifiers: modifiers_to_strings(key_event.modifiers),


### PR DESCRIPTION
## Summary

On macOS, pressing F5 (the mic/dictation key) can't be used as a transcribe shortcut because of how the `fn` modifier is handled during hotkey matching in `handy-keys`.

### Root Cause

On macOS, the top row keys default to media functions. To use F5 as a function key, users must hold `fn`, which sets the `FN` modifier flag. The `handy-keys` library does **exact matching** on FN in `Modifiers::matches()`, so a shortcut registered as `"f5"` never matches an `fn+F5` event.

### Fix

The fix is implemented at the **library level** in handy-keys ([handy-computer/handy-keys#16](https://github.com/handy-computer/handy-keys/pull/16)), where it benefits all consumers. The macOS listener now strips the FN modifier from function key events (F1-F20) before they reach the matching logic, since `fn` is a transport mechanism to access F-keys — not a meaningful modifier.

This PR simply points Handy's `handy-keys` dependency to the fixed version. No application-level workarounds are needed — function keys just work.

**Changes in this PR:**
- `Cargo.toml`: Point `handy-keys` to the fork with the fix
- `handy_keys.rs`: Revert to original (no workarounds needed)

**Once handy-computer/handy-keys#16 is merged and released**, this dependency should be updated to point to the published crate version.

## Test plan

- [ ] On macOS with default keyboard (media keys mode):
  - [ ] Record F5 as transcribe shortcut (press fn+F5) → should show "F5" not "fn+F5"
  - [ ] Press fn+F5 → should trigger transcription
- [ ] On macOS with "Use standard function keys" enabled:
  - [ ] Record F5 as transcribe shortcut (press F5 without fn) → should show "F5"
  - [ ] Press F5 → should trigger transcription
- [ ] Other F-keys (F1-F12) work as shortcuts
- [ ] Non-function-key shortcuts (e.g., Option+Space) are unaffected
- [ ] Modifier+F-key combos (e.g., Cmd+F5) work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)