### PR TITLE
feat: add FireRedASR-AED model option

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7013,6 +7013,7 @@ dependencies = [
 [[package]]
 name = "transcribe-rs"
 version = "0.3.2"
+source = "git+https://github.com/chiimagnus/transcribe-rs?rev=7b7c04a6a8506883e3d91e336e3cc259262dab67#7b7c04a6a8506883e3d91e336e3cc259262dab67"
 dependencies = [
  "base64 0.22.1",
  "derive_builder",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -600,6 +600,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cairo-rs"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2416,6 +2435,7 @@ name = "handy"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "bzip2",
  "chrono",
  "clap",
  "cpal",
@@ -6993,8 +7013,6 @@ dependencies = [
 [[package]]
 name = "transcribe-rs"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e2b882795f8cee1a97e70bb8f4265bc159b786421ee525a372ccc6bf990fce"
 dependencies = [
  "base64 0.22.1",
  "derive_builder",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -68,6 +68,7 @@ chrono = "0.4"
 rusqlite = { version = "0.37", features = ["bundled"] }
 tar = "0.4.44"
 flate2 = "1.0"
+bzip2 = "0.5"
 sha2 = "0.10"
 transcribe-rs = { version = "0.3.2", features = ["whisper-cpp", "onnx"] }
 handy-keys = "0.2.4"
@@ -111,6 +112,7 @@ transcribe-rs = { version = "0.3.2", features = ["whisper-vulkan"] }
 tauri-runtime = { git = "https://github.com/cjpais/tauri.git", branch = "handy-2.10.2" }
 tauri-runtime-wry = { git = "https://github.com/cjpais/tauri.git", branch = "handy-2.10.2" }
 tauri-utils = { git = "https://github.com/cjpais/tauri.git", branch = "handy-2.10.2" }
+transcribe-rs = { path = "../../transcribe-rs" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -112,7 +112,7 @@ transcribe-rs = { version = "0.3.2", features = ["whisper-vulkan"] }
 tauri-runtime = { git = "https://github.com/cjpais/tauri.git", branch = "handy-2.10.2" }
 tauri-runtime-wry = { git = "https://github.com/cjpais/tauri.git", branch = "handy-2.10.2" }
 tauri-utils = { git = "https://github.com/cjpais/tauri.git", branch = "handy-2.10.2" }
-transcribe-rs = { path = "../../transcribe-rs" }
+transcribe-rs = { git = "https://github.com/chiimagnus/transcribe-rs", rev = "7b7c04a6a8506883e3d91e336e3cc259262dab67" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/managers/model.rs
+++ b/src-tauri/src/managers/model.rs
@@ -483,8 +483,10 @@ impl ModelManager {
             "fire-red-asr-large-zh-en".to_string(),
             ModelInfo {
                 id: "fire-red-asr-large-zh-en".to_string(),
-                name: "FireRedASR Large (zh+en)".to_string(),
-                description: "Accurate Chinese + English speech recognition (offline).".to_string(),
+                name: "FireRedASR-AED Large (zh+en)".to_string(),
+                description:
+                    "Chinese-focused offline speech recognition (also supports English)."
+                        .to_string(),
                 filename: "fire-red-asr-large-zh-en".to_string(),
                 url: Some("https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-fire-red-asr-large-zh_en-2025-02-16.tar.bz2".to_string()),
                 // SHA256 not yet pinned; skip verification for now (local dev).

--- a/src-tauri/src/managers/model.rs
+++ b/src-tauri/src/managers/model.rs
@@ -1,5 +1,6 @@
 use crate::settings::{get_settings, write_settings};
 use anyhow::Result;
+use bzip2::read::BzDecoder;
 use flate2::read::GzDecoder;
 use futures_util::StreamExt;
 use log::{debug, info, warn};
@@ -24,6 +25,7 @@ pub enum EngineType {
     Moonshine,
     MoonshineStreaming,
     SenseVoice,
+    FireRedAsr,
     GigaAM,
     Canary,
 }
@@ -469,6 +471,36 @@ impl ModelManager {
                 is_recommended: false,
                 supported_languages: sense_voice_languages,
                 supports_language_selection: true,
+                is_custom: false,
+            },
+        );
+
+        // FireRedASR (AED) supported languages
+        let fire_red_asr_languages: Vec<String> =
+            vec!["zh", "zh-Hans", "zh-Hant", "en"].into_iter().map(String::from).collect();
+
+        available_models.insert(
+            "fire-red-asr-large-zh-en".to_string(),
+            ModelInfo {
+                id: "fire-red-asr-large-zh-en".to_string(),
+                name: "FireRedASR Large (zh+en)".to_string(),
+                description: "Accurate Chinese + English speech recognition (offline).".to_string(),
+                filename: "fire-red-asr-large-zh-en".to_string(),
+                url: Some("https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-fire-red-asr-large-zh_en-2025-02-16.tar.bz2".to_string()),
+                // SHA256 not yet pinned; skip verification for now (local dev).
+                sha256: None,
+                size_mb: 1401,
+                is_downloaded: false,
+                is_downloading: false,
+                partial_size: 0,
+                is_directory: true,
+                engine_type: EngineType::FireRedAsr,
+                accuracy_score: 0.90,
+                speed_score: 0.55,
+                supports_translation: false,
+                is_recommended: false,
+                supported_languages: fire_red_asr_languages,
+                supports_language_selection: false,
                 is_custom: false,
             },
         );
@@ -1197,10 +1229,19 @@ impl ModelManager {
             // Create temporary extraction directory
             fs::create_dir_all(&temp_extract_dir)?;
 
-            // Open the downloaded tar.gz file
-            let tar_gz = File::open(&partial_path)?;
-            let tar = GzDecoder::new(tar_gz);
-            let mut archive = Archive::new(tar);
+            // Open the downloaded archive (.tar.gz or .tar.bz2)
+            let archive_file = File::open(&partial_path)?;
+            let reader: Box<dyn Read> = if url.ends_with(".tar.gz") {
+                Box::new(GzDecoder::new(archive_file))
+            } else if url.ends_with(".tar.bz2") {
+                Box::new(BzDecoder::new(archive_file))
+            } else {
+                return Err(anyhow::anyhow!(
+                    "Unsupported archive format for directory-based model: {}",
+                    url
+                ));
+            };
+            let mut archive = Archive::new(reader);
 
             // Extract to the temporary directory first
             archive.unpack(&temp_extract_dir).map_err(|e| {

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -17,6 +17,7 @@ use tauri::{AppHandle, Emitter, Manager};
 use transcribe_rs::{
     onnx::{
         canary::CanaryModel,
+        fire_red_asr::FireRedAsrModel,
         gigaam::GigaAMModel,
         moonshine::{MoonshineModel, MoonshineVariant, StreamingModel},
         parakeet::{ParakeetModel, ParakeetParams, TimestampGranularity},
@@ -41,6 +42,7 @@ enum LoadedEngine {
     Moonshine(MoonshineModel),
     MoonshineStreaming(StreamingModel),
     SenseVoice(SenseVoiceModel),
+    FireRedAsr(FireRedAsrModel),
     GigaAM(GigaAMModel),
     Canary(CanaryModel),
 }
@@ -351,6 +353,16 @@ impl TranscriptionManager {
                     })?;
                 LoadedEngine::SenseVoice(engine)
             }
+            EngineType::FireRedAsr => {
+                let engine =
+                    FireRedAsrModel::load(&model_path, &Quantization::Int8).map_err(|e| {
+                        let error_msg =
+                            format!("Failed to load FireRedASR model {}: {}", model_id, e);
+                        emit_loading_failed(&error_msg);
+                        anyhow::anyhow!(error_msg)
+                    })?;
+                LoadedEngine::FireRedAsr(engine)
+            }
             EngineType::GigaAM => {
                 let engine = GigaAMModel::load(&model_path, &Quantization::Int8).map_err(|e| {
                     let error_msg = format!("Failed to load gigaam model {}: {}", model_id, e);
@@ -583,6 +595,11 @@ impl TranscriptionManager {
                                     anyhow::anyhow!("SenseVoice transcription failed: {}", e)
                                 })
                         }
+                        LoadedEngine::FireRedAsr(fire_red_asr_engine) => fire_red_asr_engine
+                            .transcribe(&audio, &TranscribeOptions::default())
+                            .map_err(|e| {
+                                anyhow::anyhow!("FireRedASR transcription failed: {}", e)
+                            }),
                         LoadedEngine::GigaAM(gigaam_engine) => gigaam_engine
                             .transcribe(&audio, &TranscribeOptions::default())
                             .map_err(|e| anyhow::anyhow!("GigaAM transcription failed: {}", e)),

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -815,7 +815,7 @@ export type AvailableAccelerators = { whisper: string[]; ort: string[] }
 export type BindingResponse = { success: boolean; binding: ShortcutBinding | null; error: string | null }
 export type ClipboardHandling = "dont_modify" | "copy_to_clipboard"
 export type CustomSounds = { start: boolean; stop: boolean }
-export type EngineType = "Whisper" | "Parakeet" | "Moonshine" | "MoonshineStreaming" | "SenseVoice" | "GigaAM" | "Canary"
+export type EngineType = "Whisper" | "Parakeet" | "Moonshine" | "MoonshineStreaming" | "SenseVoice" | "FireRedAsr" | "GigaAM" | "Canary"
 export type HistoryEntry = { id: number; file_name: string; timestamp: number; saved: boolean; title: string; transcription_text: string; post_processed_text: string | null; post_process_prompt: string | null; post_process_requested: boolean }
 export type HistoryUpdatePayload = { action: "added"; entry: HistoryEntry } | { action: "updated"; entry: HistoryEntry } | { action: "deleted"; id: number } | { action: "toggled"; id: number }
 /**

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -77,6 +77,10 @@
         "name": "SenseVoice",
         "description": "سريع جداً. الصينية، الإنجليزية، اليابانية، الكورية، الكانتونية."
       },
+      "fire-red-asr-large-zh-en": {
+        "name": "FireRedASR-AED Large (zh+en)",
+        "description": "Chinese-focused offline speech recognition (also supports English)."
+      },
       "gigaam-v3-e2e-ctc": {
         "name": "GigaAM v3",
         "description": "التعرف على الكلام الروسي. سريع ودقيق."

--- a/src/i18n/locales/bg/translation.json
+++ b/src/i18n/locales/bg/translation.json
@@ -77,6 +77,10 @@
         "name": "SenseVoice",
         "description": "Много бърз. Китайски, английски, японски, корейски, кантонски."
       },
+      "fire-red-asr-large-zh-en": {
+        "name": "FireRedASR-AED Large (zh+en)",
+        "description": "Chinese-focused offline speech recognition (also supports English)."
+      },
       "gigaam-v3-e2e-ctc": {
         "name": "GigaAM v3",
         "description": "Разпознаване на руска реч. Бърз и точен."

--- a/src/i18n/locales/cs/translation.json
+++ b/src/i18n/locales/cs/translation.json
@@ -77,6 +77,10 @@
         "name": "SenseVoice",
         "description": "Velmi rychlý. Čínština, angličtina, japonština, korejština, kantonština."
       },
+      "fire-red-asr-large-zh-en": {
+        "name": "FireRedASR-AED Large (zh+en)",
+        "description": "Chinese-focused offline speech recognition (also supports English)."
+      },
       "gigaam-v3-e2e-ctc": {
         "name": "GigaAM v3",
         "description": "Rozpoznávání ruské řeči. Rychlé a přesné."

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -77,6 +77,10 @@
         "name": "SenseVoice",
         "description": "Sehr schnell. Chinesisch, Englisch, Japanisch, Koreanisch, Kantonesisch."
       },
+      "fire-red-asr-large-zh-en": {
+        "name": "FireRedASR-AED Large (zh+en)",
+        "description": "Chinese-focused offline speech recognition (also supports English)."
+      },
       "gigaam-v3-e2e-ctc": {
         "name": "GigaAM v3",
         "description": "Russische Spracherkennung. Schnell und präzise."

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -77,6 +77,10 @@
         "name": "SenseVoice",
         "description": "Very fast. Chinese, English, Japanese, Korean, Cantonese."
       },
+      "fire-red-asr-large-zh-en": {
+        "name": "FireRedASR-AED Large (zh+en)",
+        "description": "Chinese-focused offline speech recognition (also supports English)."
+      },
       "gigaam-v3-e2e-ctc": {
         "name": "GigaAM v3",
         "description": "Russian speech recognition. Fast and accurate."

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -77,6 +77,10 @@
         "name": "SenseVoice",
         "description": "Muy rápido. Chino, inglés, japonés, coreano, cantonés."
       },
+      "fire-red-asr-large-zh-en": {
+        "name": "FireRedASR-AED Large (zh+en)",
+        "description": "Chinese-focused offline speech recognition (also supports English)."
+      },
       "gigaam-v3-e2e-ctc": {
         "name": "GigaAM v3",
         "description": "Reconocimiento de voz en ruso. Rápido y preciso."

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -77,6 +77,10 @@
         "name": "SenseVoice",
         "description": "Très rapide. Chinois, anglais, japonais, coréen, cantonais."
       },
+      "fire-red-asr-large-zh-en": {
+        "name": "FireRedASR-AED Large (zh+en)",
+        "description": "Chinese-focused offline speech recognition (also supports English)."
+      },
       "gigaam-v3-e2e-ctc": {
         "name": "GigaAM v3",
         "description": "Reconnaissance vocale en russe. Rapide et précis."

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -77,6 +77,10 @@
         "name": "SenseVoice",
         "description": "Molto veloce. Cinese, inglese, giapponese, coreano, cantonese."
       },
+      "fire-red-asr-large-zh-en": {
+        "name": "FireRedASR-AED Large (zh+en)",
+        "description": "Chinese-focused offline speech recognition (also supports English)."
+      },
       "gigaam-v3-e2e-ctc": {
         "name": "GigaAM v3",
         "description": "Riconoscimento vocale in russo. Veloce e preciso."

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -77,6 +77,10 @@
         "name": "SenseVoice",
         "description": "非常に高速。中国語、英語、日本語、韓国語、広東語。"
       },
+      "fire-red-asr-large-zh-en": {
+        "name": "FireRedASR-AED Large (zh+en)",
+        "description": "Chinese-focused offline speech recognition (also supports English)."
+      },
       "gigaam-v3-e2e-ctc": {
         "name": "GigaAM v3",
         "description": "ロシア語音声認識。高速かつ高精度。"

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -77,6 +77,10 @@
         "name": "SenseVoice",
         "description": "매우 빠름. 중국어, 영어, 일본어, 한국어, 광둥어."
       },
+      "fire-red-asr-large-zh-en": {
+        "name": "FireRedASR-AED Large (zh+en)",
+        "description": "Chinese-focused offline speech recognition (also supports English)."
+      },
       "gigaam-v3-e2e-ctc": {
         "name": "GigaAM v3",
         "description": "러시아어 음성 인식. 빠르고 정확함."

--- a/src/i18n/locales/pl/translation.json
+++ b/src/i18n/locales/pl/translation.json
@@ -77,6 +77,10 @@
         "name": "SenseVoice",
         "description": "Bardzo szybki. Chiński, angielski, japoński, koreański, kantoński."
       },
+      "fire-red-asr-large-zh-en": {
+        "name": "FireRedASR-AED Large (zh+en)",
+        "description": "Chinese-focused offline speech recognition (also supports English)."
+      },
       "gigaam-v3-e2e-ctc": {
         "name": "GigaAM v3",
         "description": "Rozpoznawanie mowy rosyjskiej. Szybkie i dokładne."

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -77,6 +77,10 @@
         "name": "SenseVoice",
         "description": "Muito rápido. Chinês, inglês, japonês, coreano, cantonês."
       },
+      "fire-red-asr-large-zh-en": {
+        "name": "FireRedASR-AED Large (zh+en)",
+        "description": "Chinese-focused offline speech recognition (also supports English)."
+      },
       "gigaam-v3-e2e-ctc": {
         "name": "GigaAM v3",
         "description": "Reconhecimento de voz em russo. Rápido e preciso."

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -77,6 +77,10 @@
         "name": "SenseVoice",
         "description": "Очень быстрая. Китайский, английский, японский, корейский, кантонский."
       },
+      "fire-red-asr-large-zh-en": {
+        "name": "FireRedASR-AED Large (zh+en)",
+        "description": "Chinese-focused offline speech recognition (also supports English)."
+      },
       "gigaam-v3-e2e-ctc": {
         "name": "GigaAM v3",
         "description": "Распознавание русской речи. Быстро и точно."

--- a/src/i18n/locales/sv/translation.json
+++ b/src/i18n/locales/sv/translation.json
@@ -77,6 +77,10 @@
         "name": "SenseVoice",
         "description": "Mycket snabb. Kinesiska, engelska, japanska, koreanska, kantonesiska."
       },
+      "fire-red-asr-large-zh-en": {
+        "name": "FireRedASR-AED Large (zh+en)",
+        "description": "Chinese-focused offline speech recognition (also supports English)."
+      },
       "gigaam-v3-e2e-ctc": {
         "name": "GigaAM v3",
         "description": "Rysk taligenkänning. Snabb och noggrann."

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -77,6 +77,10 @@
         "name": "SenseVoice",
         "description": "Çok hızlı. Çince, İngilizce, Japonca, Korece, Kantonca."
       },
+      "fire-red-asr-large-zh-en": {
+        "name": "FireRedASR-AED Large (zh+en)",
+        "description": "Chinese-focused offline speech recognition (also supports English)."
+      },
       "gigaam-v3-e2e-ctc": {
         "name": "GigaAM v3",
         "description": "Rusça konuşma tanıma. Hızlı ve doğru."

--- a/src/i18n/locales/uk/translation.json
+++ b/src/i18n/locales/uk/translation.json
@@ -77,6 +77,10 @@
         "name": "SenseVoice",
         "description": "Дуже швидкий. Китайська, англійська, японська, корейська, кантонська."
       },
+      "fire-red-asr-large-zh-en": {
+        "name": "FireRedASR-AED Large (zh+en)",
+        "description": "Chinese-focused offline speech recognition (also supports English)."
+      },
       "gigaam-v3-e2e-ctc": {
         "name": "GigaAM v3",
         "description": "Розпізнавання російського мовлення. Швидко і точно."

--- a/src/i18n/locales/vi/translation.json
+++ b/src/i18n/locales/vi/translation.json
@@ -77,6 +77,10 @@
         "name": "SenseVoice",
         "description": "Rất nhanh. Tiếng Trung, tiếng Anh, tiếng Nhật, tiếng Hàn, tiếng Quảng Đông."
       },
+      "fire-red-asr-large-zh-en": {
+        "name": "FireRedASR-AED Large (zh+en)",
+        "description": "Chinese-focused offline speech recognition (also supports English)."
+      },
       "gigaam-v3-e2e-ctc": {
         "name": "GigaAM v3",
         "description": "Nhận dạng giọng nói tiếng Nga. Nhanh và chính xác."

--- a/src/i18n/locales/zh-TW/translation.json
+++ b/src/i18n/locales/zh-TW/translation.json
@@ -77,6 +77,10 @@
         "name": "SenseVoice",
         "description": "速度極快。支援中文、英語、日語、韓語、粵語。"
       },
+      "fire-red-asr-large-zh-en": {
+        "name": "FireRedASR-AED Large（中英）",
+        "description": "以中文為主的離線語音辨識（也支援英文）。"
+      },
       "gigaam-v3-e2e-ctc": {
         "name": "GigaAM v3",
         "description": "俄語語音辨識。快速且準確。"

--- a/src/i18n/locales/zh/translation.json
+++ b/src/i18n/locales/zh/translation.json
@@ -77,6 +77,10 @@
         "name": "SenseVoice",
         "description": "非常快速。支持中文、英语、日语、韩语、粤语。"
       },
+      "fire-red-asr-large-zh-en": {
+        "name": "FireRedASR-AED Large（中英）",
+        "description": "中文优先的离线语音识别（也支持英文）。"
+      },
       "gigaam-v3-e2e-ctc": {
         "name": "GigaAM v3",
         "description": "俄语语音识别。快速且准确。"


### PR DESCRIPTION
Adds a new offline ONNX transcription engine/model option: FireRedASR-AED Large (zh+en).

Changes:
- Adds `EngineType::FireRedAsr` and model loading via `transcribe-rs`.
- Adds FireRedASR model entry in the model registry and supports downloading + extracting `.tar.bz2` archives.
- Adds i18n entries for the new model name/description.

Dependency note:
- This PR temporarily patches `transcribe-rs` to `chiimagnus/transcribe-rs@7b7c04a` (the PR adding FireRedASR). Once that PR is merged/released upstream, I can follow up to remove the patch and pin to the released version.

Upstream dependency:
- cjpais/transcribe-rs PR: https://github.com/cjpais/transcribe-rs/pull/65