### PR TITLE
fix: macOS Bluetooth input fallback to prevent media pause during recording

### DIFF
--- a/src-tauri/src/managers/audio.rs
+++ b/src-tauri/src/managers/audio.rs
@@ -2,6 +2,10 @@ use crate::audio_toolkit::{list_input_devices, vad::SmoothedVad, AudioRecorder, 
 use crate::helpers::clamshell;
 use crate::settings::{get_settings, AppSettings};
 use crate::utils;
+#[cfg(target_os = "macos")]
+use cpal::traits::DeviceTrait;
+#[cfg(target_os = "macos")]
+use cpal::traits::HostTrait;
 use log::{debug, error, info};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -188,6 +192,25 @@ impl AudioRecordingManager {
 
     /* ---------- helper methods --------------------------------------------- */
 
+    #[cfg(target_os = "macos")]
+    fn is_likely_bluetooth_input(name: &str) -> bool {
+        let normalized = name.to_lowercase();
+        normalized.contains("airpods") || normalized.contains("bluetooth")
+    }
+
+    #[cfg(target_os = "macos")]
+    fn non_bluetooth_priority(name: &str) -> u8 {
+        let normalized = name.to_lowercase();
+        if normalized.contains("built-in")
+            || normalized.contains("internal")
+            || normalized.contains("macbook")
+        {
+            2
+        } else {
+            1
+        }
+    }
+
     fn get_effective_microphone_device(&self, settings: &AppSettings) -> Option<cpal::Device> {
         // Check if we're in clamshell mode and have a clamshell microphone configured
         let use_clamshell_mic = if let Ok(is_clamshell) = clamshell::is_clamshell() {
@@ -196,18 +219,54 @@ impl AudioRecordingManager {
             false
         };
 
-        let device_name = if use_clamshell_mic {
-            settings.clamshell_microphone.as_ref().unwrap()
-        } else {
-            settings.selected_microphone.as_ref()?
-        };
-
-        // Find the device by name
         match list_input_devices() {
-            Ok(devices) => devices
-                .into_iter()
-                .find(|d| d.name == *device_name)
-                .map(|d| d.device),
+            Ok(devices) => {
+                // Preserve explicit user choices exactly (selected/clamshell).
+                if use_clamshell_mic {
+                    let device_name = settings.clamshell_microphone.as_ref().unwrap();
+                    return devices
+                        .iter()
+                        .find(|d| d.name == *device_name)
+                        .map(|d| d.device.clone());
+                }
+
+                if let Some(device_name) = settings.selected_microphone.as_ref() {
+                    return devices
+                        .iter()
+                        .find(|d| d.name == *device_name)
+                        .map(|d| d.device.clone());
+                }
+
+                // For default mic on macOS, avoid Bluetooth input routes when possible.
+                // Opening a Bluetooth headset mic can trigger profile switches that pause
+                // or alter playback in some media apps.
+                #[cfg(target_os = "macos")]
+                {
+                    let host = crate::audio_toolkit::get_cpal_host();
+                    let default_name = host.default_input_device().and_then(|d| d.name().ok());
+
+                    if default_name
+                        .as_deref()
+                        .map(Self::is_likely_bluetooth_input)
+                        .unwrap_or(false)
+                    {
+                        if let Some(fallback) = devices
+                            .iter()
+                            .filter(|d| !Self::is_likely_bluetooth_input(&d.name))
+                            .max_by_key(|d| Self::non_bluetooth_priority(&d.name))
+                            .map(|d| d.device.clone())
+                        {
+                            info!(
+                                "Default microphone appears to be Bluetooth; using non-Bluetooth fallback"
+                            );
+                            return Some(fallback);
+                        }
+                    }
+                }
+
+                // Keep existing behavior for default mic: let recorder resolve host default.
+                None
+            }
             Err(e) => {
                 debug!("Failed to list devices, using default: {}", e);
                 None


### PR DESCRIPTION
Prevents audio pause/glitches during recording with any Bluetooth input device as the default microphone by prioritizing non-Bluetooth alternatives to avoid CoreAudio profile switches that some media apps interpret as route changes.

## Before Submitting This PR

<!--
HANDY IS UNDERGOING A FEATURE FREEZE. IF YOU ARE SUBMITTING A PR WHICH IS A NEW FEATURE THAT THE COMMUNITY HAS NOT ASKED FOR: PREPARE TO BE REJECTED. IF THE COMMUNITY HAS ASKED FOR IT, OR YOU HAVE EXPLICITLY GATEHRED SUPPORT IT MAY STILL BE CONSIDERED.

BUG FIXES ARE THE TOP PRIORITY. THERE ARE 60+ ISSUES TO FIX.
-->

**Please confirm you have done the following:**

- [X] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

<!-- Describe your changes clearly and concisely

Please write 2-3 sentences in your own words explaining:
- What problem you noticed or idea you had
- Why you think this change matters

This section should be YOUR thinking, not AI-generated text. Even if AI helped write the code, we want to hear from you directly. Your perspective as a human is what makes contributions meaningful. Your PR may be rejected if you do not
include a human-written description.
--> Recently started using Handy, however, I kept finding myself not using much as I wear airpods all day, and when I do wear airpods my experience with Handy has been far from perfect. 2 issues: 1st: when listening to music (on airpods) and then start recording with Handy, then the music becomes muffled and too loud, because a switch to CoreAudio profile occurs as if I am in a call, and the moment I stop recording (when the mic is not in use anymore), then it goes back to normal. 2nd: I use an app for white noise that auto pauses when CoreAudio profile switching occurs (e.g. when switching output sources, or start/end a call), and so each time I would trigger Handy, then the white noise would completely pause).
I fixed it by adding a fallback to non-bluetooth input devices on macOS when the default input is Bluetooth, preventing those switches that cause the problem.
I think it would be good to implement the fix on the official version of Handy. P.s. if necessary, I would be willing to also add it as a setting on the advanced settings page, for users to optionally opt for it or not, I know I personally would because I keep finding myself having to choose between using my airpods and using Handy, and I don't want to have to choose.

## Related Issues/Discussions

<!-- Link to related issues, discussions, or previous PRs -->
<!-- If reopening something previously closed, explain why this should be reconsidered -->

Fixes the unwanted behavior described in #646, where AirPods handoff is triggered by the use of Handy. Additionally, it addresses another issue reported in a comment of #646 (https://github.com/cjpais/Handy/issues/646#issuecomment-3879818081), where Airpods as mac audio output cause the sound volume to get too loud (and the quality to become muffled).

## Community Feedback

<!--
PRs with community support are much more likely to be merged.

For features: Link to a discussion where community members have expressed interest.
For bug fixes: Link to the issue where others have confirmed the bug.

If you haven't gathered feedback yet, consider starting a discussion first:
https://github.com/cjpais/Handy/discussions

It is not explicitly required to gather feedback, but it certainly helps your PR get merged.
--> I haven’t gathered community feedback yet. This fix is based on my own reproducible issue.

## Testing

<!-- Describe how you tested your changes and if you need help getting additional testing -->
MacOS 26.3.1 (and also MacOS 26.4), Handy version: v0.8.0.
I repeated the same tests that I initially did to pinpoint the point where the issue was:
- Used handy with Airpods and music playing on Apple Music on my mac, with and without "Mute while recording" on.
- used handy with Airpods and my white noise app, with and without "mute while recording" on.
- did the same thing but without airpods (system audio) this time.

After that I did another test to confirm the issue #646 is fixed:
- on Handy version v0.8.0 I managed to replicate the issue reported, by playing music on my iphone with output to my Airpods, and then triggered Handy on Mac. Handoff got triggered and the music on the iphone stopped playing, in favor of the Handy recording on Mac.
- Then tested it on my fixed version: played music on my iphone with output to my airpods, and then triggered Handy on my Mac. The music kept playing on the AirPods connected to the iPhone, while Handy handled the recording with the system's microphone.

In case it matters, the white noise app I use is called "Ooooo" on the mac app store, and it is what helped me pinpoint the source of the issue.
## Screenshots/Videos (if applicable)

<!-- Add screenshots or videos demonstrating the change -->

## AI Assistance

<!-- AI-assisted PRs are welcome! Just let us know so we can review appropriately. -->

- [ ] No AI was used in this PR
- [X] AI was used (please describe below)

**If AI was used:**

- Tools used: Github copilot
- How extensively: helped me in finding the file where the issue was and in debugging
