### PR TITLE
Preserve legacy portable installs during updates

### DIFF
--- a/src-tauri/nsis/installer.nsi
+++ b/src-tauri/nsis/installer.nsi
@@ -587,16 +587,20 @@ Function .onInit
 
 
   ; --- PORTABLE MODE --- Auto-detect portable mode during updates.
-  ; If the target directory already has a valid portable marker file, preserve
-  ; portable mode so the Tauri updater works without needing /PORTABLE.
-  ; We validate the magic string to avoid false-positives from stale empty files
-  ; left by scoop's NSIS extraction (dl.7z side-effect).
+  ; Preserve portable installs that use either the current magic-string marker
+  ; or the legacy empty marker created by older Handy releases. Require Data/
+  ; for the legacy empty-marker case so stale scoop side-effect files do not
+  ; accidentally opt an updater run into portable mode.
   ${If} $PortableMode <> 1
+  ${AndIf} $UpdateMode = 1
   ${AndIf} ${FileExists} "$INSTDIR\portable"
     FileOpen $1 "$INSTDIR\portable" r
     FileRead $1 $2
     FileClose $1
     ${If} $2 == "Handy Portable Mode"
+      StrCpy $PortableMode 1
+    ${OrIf} $2 == ""
+    ${AndIf} ${FileExists} "$INSTDIR\Data"
       StrCpy $PortableMode 1
     ${EndIf}
   ${EndIf}


### PR DESCRIPTION
## Summary
- preserve portable mode during updater-driven installs when the target directory still uses Handy's legacy empty `portable` marker
- keep the existing magic-string check for current portable installs
- limit the auto-detection path to `/UPDATE` runs

## Validation
- no practical automated coverage for the NSIS updater path
- code change is isolated to `src-tauri/nsis/installer.nsi`
