### PR TITLE
Serialize history retries and preserve legacy post-processing

### DIFF
--- a/src-tauri/src/commands/history.rs
+++ b/src-tauri/src/commands/history.rs
@@ -81,6 +81,8 @@ pub async fn retry_history_entry_transcription(
         return Err("Recording has no audio samples".to_string());
     }
 
+    let should_post_process = entry.should_post_process_on_retry();
+
     transcription_manager.initiate_model_load();
 
     let tm = Arc::clone(&transcription_manager);
@@ -93,8 +95,7 @@ pub async fn retry_history_entry_transcription(
         return Err("Recording contains no speech".to_string());
     }
 
-    let processed =
-        process_transcription_output(&app, &transcription, entry.post_process_requested).await;
+    let processed = process_transcription_output(&app, &transcription, should_post_process).await;
     history_manager
         .update_transcription(
             id,

--- a/src-tauri/src/managers/history.rs
+++ b/src-tauri/src/managers/history.rs
@@ -31,6 +31,12 @@ static MIGRATIONS: &[M] = &[
     M::up("ALTER TABLE transcription_history ADD COLUMN post_processed_text TEXT;"),
     M::up("ALTER TABLE transcription_history ADD COLUMN post_process_prompt TEXT;"),
     M::up("ALTER TABLE transcription_history ADD COLUMN post_process_requested BOOLEAN NOT NULL DEFAULT 0;"),
+    M::up(
+        "UPDATE transcription_history
+         SET post_process_requested = 1
+         WHERE post_process_requested = 0
+           AND (post_process_prompt IS NOT NULL OR post_processed_text IS NOT NULL);",
+    ),
 ];
 
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
@@ -63,6 +69,14 @@ pub struct HistoryEntry {
     pub post_processed_text: Option<String>,
     pub post_process_prompt: Option<String>,
     pub post_process_requested: bool,
+}
+
+impl HistoryEntry {
+    pub fn should_post_process_on_retry(&self) -> bool {
+        self.post_process_requested
+            || self.post_process_prompt.is_some()
+            || self.post_processed_text.is_some()
+    }
 }
 
 pub struct HistoryManager {
@@ -697,6 +711,78 @@ mod tests {
             ],
         )
         .expect("insert history entry");
+    }
+
+    #[test]
+    fn should_post_process_on_retry_infers_legacy_rows() {
+        let entry = HistoryEntry {
+            id: 1,
+            file_name: "handy.wav".to_string(),
+            timestamp: 0,
+            saved: false,
+            title: "Recording".to_string(),
+            transcription_text: "text".to_string(),
+            post_processed_text: Some("processed".to_string()),
+            post_process_prompt: None,
+            post_process_requested: false,
+        };
+
+        assert!(entry.should_post_process_on_retry());
+    }
+
+    #[test]
+    fn migration_backfills_post_process_requested_for_legacy_rows() {
+        let mut conn = Connection::open_in_memory().expect("open in-memory db");
+        conn.execute_batch(
+            "CREATE TABLE transcription_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_name TEXT NOT NULL,
+                timestamp INTEGER NOT NULL,
+                saved BOOLEAN NOT NULL DEFAULT 0,
+                title TEXT NOT NULL,
+                transcription_text TEXT NOT NULL,
+                post_processed_text TEXT,
+                post_process_prompt TEXT,
+                post_process_requested BOOLEAN NOT NULL DEFAULT 0
+            );
+            INSERT INTO transcription_history (
+                file_name,
+                timestamp,
+                saved,
+                title,
+                transcription_text,
+                post_processed_text,
+                post_process_prompt,
+                post_process_requested
+            ) VALUES (
+                'handy.wav',
+                1,
+                0,
+                'Recording 1',
+                'raw',
+                'processed',
+                'prompt',
+                0
+            );",
+        )
+        .expect("seed legacy row");
+        conn.pragma_update(None, "user_version", 4)
+            .expect("set legacy schema version");
+
+        let migrations = Migrations::new(MIGRATIONS.to_vec());
+        migrations
+            .to_latest(&mut conn)
+            .expect("apply history migrations");
+
+        let post_process_requested: bool = conn
+            .query_row(
+                "SELECT post_process_requested FROM transcription_history WHERE id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .expect("fetch backfilled flag");
+
+        assert!(post_process_requested);
     }
 
     #[test]

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -71,6 +71,7 @@ pub struct TranscriptionManager {
     watcher_handle: Arc<Mutex<Option<thread::JoinHandle<()>>>>,
     is_loading: Arc<Mutex<bool>>,
     loading_condvar: Arc<Condvar>,
+    transcription_lock: Arc<Mutex<()>>,
 }
 
 impl TranscriptionManager {
@@ -85,6 +86,7 @@ impl TranscriptionManager {
             watcher_handle: Arc::new(Mutex::new(None)),
             is_loading: Arc::new(Mutex::new(false)),
             loading_condvar: Arc::new(Condvar::new()),
+            transcription_lock: Arc::new(Mutex::new(())),
         };
 
         // Start the idle watcher
@@ -172,6 +174,13 @@ impl TranscriptionManager {
     pub fn is_model_loaded(&self) -> bool {
         let engine = self.lock_engine();
         engine.is_some()
+    }
+
+    fn lock_transcription(&self) -> MutexGuard<'_, ()> {
+        self.transcription_lock.lock().unwrap_or_else(|poisoned| {
+            warn!("Transcription lock was poisoned by a previous panic, recovering");
+            poisoned.into_inner()
+        })
     }
 
     /// Atomically check whether a model load is in progress and, if not, mark
@@ -434,6 +443,11 @@ impl TranscriptionManager {
                 "Simulated transcription failure (HANDY_FORCE_TRANSCRIPTION_FAILURE)"
             ));
         }
+
+        // Serialize all engine use so history retries, hotkey transcriptions,
+        // and other callers never race while the loaded model is temporarily
+        // taken out of the engine slot during inference.
+        let _transcription_lock = self.lock_transcription();
 
         // Update last activity timestamp
         self.touch_activity();


### PR DESCRIPTION
## Summary
- serialize `TranscriptionManager::transcribe()` so history retries cannot race with other active transcriptions while the loaded engine is temporarily removed from the engine slot
- preserve legacy history retry behavior by treating existing `post_process_prompt` / `post_processed_text` rows as post-processing requests
- backfill `post_process_requested` for legacy rows during migration
- add coverage for the retry inference helper and migration backfill

## Validation
- `cd src-tauri && cargo test`
