### PR TITLE
Surface model download failures immediately

### DIFF
--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -24,23 +24,14 @@ pub async fn get_model_info(
 #[tauri::command]
 #[specta::specta]
 pub async fn download_model(
-    app_handle: AppHandle,
+    _app_handle: AppHandle,
     model_manager: State<'_, Arc<ModelManager>>,
     model_id: String,
 ) -> Result<(), String> {
-    let result = model_manager
+    model_manager
         .download_model(&model_id)
         .await
-        .map_err(|e| e.to_string());
-
-    if let Err(ref error) = result {
-        let _ = app_handle.emit(
-            "model-download-failed",
-            serde_json::json!({ "model_id": &model_id, "error": error }),
-        );
-    }
-
-    result
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]

--- a/src/components/onboarding/Onboarding.tsx
+++ b/src/components/onboarding/Onboarding.tsx
@@ -65,8 +65,8 @@ const Onboarding: React.FC<OnboardingProps> = ({ onModelSelected }) => {
   const handleDownloadModel = async (modelId: string) => {
     setSelectedModelId(modelId);
 
-    // Error toast is handled centrally by the model-download-failed event listener
-    // in modelStore — no toast here to avoid duplicates.
+    // Error handling is centralized in modelStore so onboarding only needs to
+    // reset local state when the download request fails.
     const success = await downloadModel(modelId);
     if (!success) {
       setSelectedModelId(null);

--- a/src/i18n/languages.ts
+++ b/src/i18n/languages.ts
@@ -35,5 +35,5 @@ export const LANGUAGE_METADATA: Record<
   ar: { name: "Arabic", nativeName: "العربية", priority: 17, direction: "rtl" },
   he: { name: "Hebrew", nativeName: "עברית", priority: 18, direction: "rtl" },
   sv: { name: "Swedish", nativeName: "Svenska", priority: 19 },
-  bg: { name: "Bulgarian", nativeName: "Български", priority: 20 }
+  bg: { name: "Bulgarian", nativeName: "Български", priority: 20 },
 };

--- a/src/stores/modelStore.ts
+++ b/src/stores/modelStore.ts
@@ -165,6 +165,21 @@ export const useModelStore = create<ModelsStore>()(
     },
 
     downloadModel: async (modelId: string) => {
+      const failDownload = (message: string) => {
+        set(
+          produce((state) => {
+            delete state.downloadingModels[modelId];
+            delete state.verifyingModels[modelId];
+            delete state.extractingModels[modelId];
+            delete state.downloadProgress[modelId];
+            delete state.downloadStats[modelId];
+            state.error = message;
+          }),
+        );
+        toast.error(message);
+        return false;
+      };
+
       try {
         set({ error: null });
         set(
@@ -178,31 +193,18 @@ export const useModelStore = create<ModelsStore>()(
             };
           }),
         );
+
         const result = await commands.downloadModel(modelId);
         if (result.status !== "ok") {
-          // Fallback cleanup in case the model-download-failed event was not received
-          // (e.g. listener not yet registered). The event handler is a no-op if it
-          // arrives after this cleanup since deleting missing keys is safe.
-          set(
-            produce((state) => {
-              delete state.downloadingModels[modelId];
-              delete state.downloadProgress[modelId];
-              delete state.downloadStats[modelId];
-            }),
-          );
+          return failDownload(`Failed to download model: ${result.error}`);
         }
-        return result.status === "ok";
-      } catch {
-        // model-download-failed event won't fire for JS exceptions (e.g. IPC error),
-        // so clean up state here to avoid a stuck progress spinner.
-        set(
-          produce((state) => {
-            delete state.downloadingModels[modelId];
-            delete state.downloadProgress[modelId];
-            delete state.downloadStats[modelId];
-          }),
-        );
-        return false;
+
+        return true;
+      } catch (err) {
+        // Boundary-safe handling: IPC/invoke failures reject before the backend
+        // can emit model-download-failed, so surface the error here and clear
+        // transient download state instead of silently returning false.
+        return failDownload(`Failed to download model: ${err}`);
       }
     },
 
@@ -336,23 +338,6 @@ export const useModelStore = create<ModelsStore>()(
         );
         get().loadModels();
       });
-
-      listen<{ model_id: string; error: string }>(
-        "model-download-failed",
-        (event) => {
-          const { model_id: modelId, error } = event.payload;
-          set(
-            produce((state) => {
-              delete state.downloadingModels[modelId];
-              delete state.verifyingModels[modelId];
-              delete state.downloadProgress[modelId];
-              delete state.downloadStats[modelId];
-              state.error = error;
-            }),
-          );
-          toast.error(error);
-        },
-      );
 
       listen<string>("model-verification-started", (event) => {
         const modelId = event.payload;


### PR DESCRIPTION
## Summary
- surface model download failures directly from the frontend store instead of depending on a backend `model-download-failed` event race
- clear transient download / verification / extraction state on immediate failures
- show a toast and persist the error message when the invoke fails or returns an error
- keep onboarding's failure handling aligned with the centralized store behavior

## Validation
- `cd src-tauri && cargo test`
- `bun run build`
