### PR TITLE
Use a more conservative OpenCC conversion for zh-Hant transcription

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -295,7 +295,7 @@ async fn maybe_convert_chinese_variant(
         BuiltinConfig::Tw2sp
     } else {
         // Convert Simplified Chinese to Traditional Chinese
-        BuiltinConfig::S2twp
+        BuiltinConfig::S2tw
     };
 
     match OpenCC::from_config(config) {


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

I noticed that when I use Handy for `zh-Hant` transcription, it consistently rewrites certain words into more Taiwan-localized wording.

For example, when I say "文件" (document), Handy always converts it to "檔案" (file).

In most cases, I want the transcription output to preserve the original wording I used.

After doing some experiments and reading the source code, I found that this is not caused by post-processing, but by the OpenCC configuration.

Using `S2twp` can introduce this kind of Taiwan-specific vocabulary rewriting, while `S2tw` produces a more conservative result.

In my opinion, a speech-to-text input application should not rewrite vocabulary this aggressively by default. That is why I think `S2tw` would be a better default.

## Related Issues/Discussions

Discussion: https://github.com/cjpais/Handy/discussions/1170

## Community Feedback

I started a discussion first, and the maintainer said they would be open to a PR for this change.

## Testing

I tested this locally on macOS and confirmed that `zh-Hant` transcription still works correctly, while avoiding unnecessary rewriting of Traditional Chinese wording.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex, ChatGPT
- How extensively: Helped me identify the issue in the code and helped me write this PR.