### PR TITLE
feat: add preview before paste option for transcriptions

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -9,17 +9,19 @@ use crate::settings::{get_settings, AppSettings, APPLE_INTELLIGENCE_PROVIDER_ID}
 use crate::shortcut;
 use crate::tray::{change_tray_icon, TrayIconState};
 use crate::utils::{
-    self, show_processing_overlay, show_recording_overlay, show_transcribing_overlay,
+    self, show_preview_overlay, show_processing_overlay, show_recording_overlay,
+    show_transcribing_overlay,
 };
 use crate::TranscriptionCoordinator;
 use ferrous_opencc::{config::BuiltinConfig, OpenCC};
 use log::{debug, error, warn};
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tauri::Manager;
 use tauri::{AppHandle, Emitter};
+use tokio::sync::oneshot;
 
 #[derive(Clone, serde::Serialize)]
 struct RecordingErrorEvent {
@@ -37,6 +39,10 @@ impl Drop for FinishGuard {
         }
     }
 }
+
+/// Holds the sender half of a oneshot channel used to signal
+/// whether the user confirmed or cancelled the transcription preview.
+pub struct PreviewState(pub Mutex<Option<oneshot::Sender<bool>>>);
 
 // Shortcut Action Trait
 pub trait ShortcutAction: Send + Sync {
@@ -571,25 +577,48 @@ impl ShortcutAction for TranscribeAction {
                                 utils::hide_recording_overlay(&ah);
                                 change_tray_icon(&ah, TrayIconState::Idle);
                             } else {
-                                let ah_clone = ah.clone();
-                                let paste_time = Instant::now();
-                                let final_text = processed.final_text;
-                                ah.run_on_main_thread(move || {
-                                    match utils::paste(final_text, ah_clone.clone()) {
-                                        Ok(()) => debug!(
-                                            "Text pasted successfully in {:?}",
-                                            paste_time.elapsed()
-                                        ),
-                                        Err(e) => error!("Failed to paste transcription: {}", e),
+                                let settings = get_settings(&ah);
+                                let should_paste = if settings.preview_before_paste {
+                                    // Create oneshot channel for preview confirmation
+                                    let (tx, rx) = oneshot::channel::<bool>();
+                                    if let Some(ps) = ah.try_state::<PreviewState>() {
+                                        *ps.0.lock().unwrap() = Some(tx);
                                     }
-                                    utils::hide_recording_overlay(&ah_clone);
-                                    change_tray_icon(&ah_clone, TrayIconState::Idle);
-                                })
-                                .unwrap_or_else(|e| {
-                                    error!("Failed to run paste on main thread: {:?}", e);
+                                    // Show preview overlay with text
+                                    show_preview_overlay(&ah, &processed.final_text);
+                                    // Await user decision (FinishGuard stays alive)
+                                    rx.await.unwrap_or(false)
+                                } else {
+                                    true
+                                };
+
+                                if should_paste {
+                                    let ah_clone = ah.clone();
+                                    let paste_time = Instant::now();
+                                    let final_text = processed.final_text;
+                                    ah.run_on_main_thread(move || {
+                                        match utils::paste(final_text, ah_clone.clone()) {
+                                            Ok(()) => debug!(
+                                                "Text pasted successfully in {:?}",
+                                                paste_time.elapsed()
+                                            ),
+                                            Err(e) => {
+                                                error!("Failed to paste transcription: {}", e)
+                                            }
+                                        }
+                                        utils::hide_recording_overlay(&ah_clone);
+                                        change_tray_icon(&ah_clone, TrayIconState::Idle);
+                                    })
+                                    .unwrap_or_else(|e| {
+                                        error!("Failed to run paste on main thread: {:?}", e);
+                                        utils::hide_recording_overlay(&ah);
+                                        change_tray_icon(&ah, TrayIconState::Idle);
+                                    });
+                                } else {
+                                    debug!("Preview cancelled by user, discarding transcription");
                                     utils::hide_recording_overlay(&ah);
                                     change_tray_icon(&ah, TrayIconState::Idle);
-                                });
+                                }
                             }
                         }
                         Err(err) => {

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -16,6 +16,34 @@ pub fn cancel_operation(app: AppHandle) {
 
 #[tauri::command]
 #[specta::specta]
+pub fn confirm_preview(app: AppHandle) -> Result<(), String> {
+    use crate::actions::PreviewState;
+    let state = app.state::<PreviewState>();
+    let sender = state.0.lock().map_err(|e| e.to_string())?.take();
+    if let Some(tx) = sender {
+        let _ = tx.send(true);
+        Ok(())
+    } else {
+        Err("No preview pending".to_string())
+    }
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn cancel_preview(app: AppHandle) -> Result<(), String> {
+    use crate::actions::PreviewState;
+    let state = app.state::<PreviewState>();
+    let sender = state.0.lock().map_err(|e| e.to_string())?.take();
+    if let Some(tx) = sender {
+        let _ = tx.send(false);
+        Ok(())
+    } else {
+        Err("No preview pending".to_string())
+    }
+}
+
+#[tauri::command]
+#[specta::specta]
 pub fn is_portable() -> bool {
     crate::portable::is_portable()
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -361,6 +361,7 @@ pub fn run(cli_args: CliArgs) {
             shortcut::resume_binding,
             shortcut::change_mute_while_recording_setting,
             shortcut::change_append_trailing_space_setting,
+            shortcut::change_preview_before_paste_setting,
             shortcut::change_lazy_stream_close_setting,
             shortcut::change_app_language_setting,
             shortcut::change_update_checks_setting,
@@ -376,6 +377,8 @@ pub fn run(cli_args: CliArgs) {
             trigger_update_check,
             show_main_window_command,
             commands::cancel_operation,
+            commands::confirm_preview,
+            commands::cancel_preview,
             commands::is_portable,
             commands::get_app_dir_path,
             commands::get_app_settings,
@@ -538,6 +541,7 @@ pub fn run(cli_args: CliArgs) {
             FILE_LOG_LEVEL.store(file_log_level.to_level_filter() as u8, Ordering::Relaxed);
             let app_handle = app.handle().clone();
             app.manage(TranscriptionCoordinator::new(app_handle.clone()));
+            app.manage(actions::PreviewState(std::sync::Mutex::new(None)));
 
             initialize_core_logic(&app_handle);
 

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -33,6 +33,14 @@ tauri_panel! {
 const OVERLAY_WIDTH: f64 = 172.0;
 const OVERLAY_HEIGHT: f64 = 36.0;
 
+const PREVIEW_OVERLAY_WIDTH: f64 = 400.0;
+const PREVIEW_OVERLAY_HEIGHT: f64 = 120.0;
+
+#[derive(Clone, serde::Serialize)]
+pub struct PreviewPayload {
+    pub text: String,
+}
+
 #[cfg(target_os = "macos")]
 const OVERLAY_TOP_OFFSET: f64 = 46.0;
 #[cfg(any(target_os = "windows", target_os = "linux"))]
@@ -195,6 +203,14 @@ fn is_mouse_within_monitor(
 /// converts PhysicalPosition using the scale factor of the monitor the window
 /// is *currently* on, which is wrong when moving cross-monitor.
 fn calculate_overlay_position(app_handle: &AppHandle) -> Option<(f64, f64)> {
+    calculate_overlay_position_with_size(app_handle, OVERLAY_WIDTH, OVERLAY_HEIGHT)
+}
+
+fn calculate_overlay_position_with_size(
+    app_handle: &AppHandle,
+    width: f64,
+    height: f64,
+) -> Option<(f64, f64)> {
     let monitor = get_monitor_with_cursor(app_handle)?;
     let scale = monitor.scale_factor();
     let monitor_x = monitor.position().x as f64 / scale;
@@ -204,11 +220,11 @@ fn calculate_overlay_position(app_handle: &AppHandle) -> Option<(f64, f64)> {
 
     let settings = settings::get_settings(app_handle);
 
-    let x = monitor_x + (monitor_width - OVERLAY_WIDTH) / 2.0;
+    let x = monitor_x + (monitor_width - width) / 2.0;
     let y = match settings.overlay_position {
         OverlayPosition::Top => monitor_y + OVERLAY_TOP_OFFSET,
         OverlayPosition::Bottom | OverlayPosition::None => {
-            monitor_y + monitor_height - OVERLAY_HEIGHT - OVERLAY_BOTTOM_OFFSET
+            monitor_y + monitor_height - height - OVERLAY_BOTTOM_OFFSET
         }
     };
 
@@ -348,6 +364,42 @@ pub fn show_processing_overlay(app_handle: &AppHandle) {
     show_overlay_state(app_handle, "processing");
 }
 
+/// Shows the preview overlay with transcribed text for user confirmation
+pub fn show_preview_overlay(app_handle: &AppHandle, text: &str) {
+    let settings = settings::get_settings(app_handle);
+    if settings.overlay_position == OverlayPosition::None {
+        return;
+    }
+
+    if let Some(overlay_window) = app_handle.get_webview_window("recording_overlay") {
+        // Resize window for preview
+        let _ = overlay_window.set_size(tauri::Size::Logical(tauri::LogicalSize {
+            width: PREVIEW_OVERLAY_WIDTH,
+            height: PREVIEW_OVERLAY_HEIGHT,
+        }));
+
+        // Reposition centered with new width
+        if let Some((x, y)) =
+            calculate_overlay_position_with_size(app_handle, PREVIEW_OVERLAY_WIDTH, PREVIEW_OVERLAY_HEIGHT)
+        {
+            let _ = overlay_window
+                .set_position(tauri::Position::Logical(tauri::LogicalPosition { x, y }));
+        }
+
+        let _ = overlay_window.show();
+
+        #[cfg(target_os = "windows")]
+        force_overlay_topmost(&overlay_window);
+
+        let _ = overlay_window.emit(
+            "show-preview",
+            PreviewPayload {
+                text: text.to_string(),
+            },
+        );
+    }
+}
+
 /// Updates the overlay window position based on current settings
 pub fn update_overlay_position(app_handle: &AppHandle) {
     if let Some(overlay_window) = app_handle.get_webview_window("recording_overlay") {
@@ -375,6 +427,11 @@ pub fn hide_recording_overlay(app_handle: &AppHandle) {
         std::thread::spawn(move || {
             std::thread::sleep(std::time::Duration::from_millis(300));
             let _ = window_clone.hide();
+            // Reset size back to default pill dimensions for next use
+            let _ = window_clone.set_size(tauri::Size::Logical(tauri::LogicalSize {
+                width: OVERLAY_WIDTH,
+                height: OVERLAY_HEIGHT,
+            }));
         });
     }
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -376,6 +376,8 @@ pub struct AppSettings {
     pub mute_while_recording: bool,
     #[serde(default)]
     pub append_trailing_space: bool,
+    #[serde(default)]
+    pub preview_before_paste: bool,
     #[serde(default = "default_app_language")]
     pub app_language: String,
     #[serde(default)]
@@ -762,6 +764,7 @@ pub fn get_default_settings() -> AppSettings {
         post_process_selected_prompt_id: None,
         mute_while_recording: false,
         append_trailing_space: false,
+        preview_before_paste: false,
         app_language: default_app_language(),
         experimental_enabled: false,
         lazy_stream_close: false,

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -1062,6 +1062,15 @@ pub fn change_append_trailing_space_setting(app: AppHandle, enabled: bool) -> Re
 
 #[tauri::command]
 #[specta::specta]
+pub fn change_preview_before_paste_setting(app: AppHandle, enabled: bool) -> Result<(), String> {
+    let mut settings = settings::get_settings(&app);
+    settings.preview_before_paste = enabled;
+    settings::write_settings(&app, settings);
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
 pub fn change_lazy_stream_close_setting(app: AppHandle, enabled: bool) -> Result<(), String> {
     let mut settings = settings::get_settings(&app);
     settings.lazy_stream_close = enabled;

--- a/src-tauri/src/transcription_coordinator.rs
+++ b/src-tauri/src/transcription_coordinator.rs
@@ -1,4 +1,4 @@
-use crate::actions::ACTION_MAP;
+use crate::actions::{PreviewState, ACTION_MAP};
 use crate::managers::audio::AudioRecordingManager;
 use log::{debug, error, warn};
 use std::sync::mpsc::{self, Sender};
@@ -76,6 +76,16 @@ impl TranscriptionCoordinator {
                                     && matches!(&stage, Stage::Recording(id) if id == &binding_id)
                                 {
                                     stop(&app, &mut stage, &binding_id, &hotkey_string);
+                                } else if is_pressed && matches!(stage, Stage::Processing) {
+                                    // Confirm pending preview via push-to-talk press
+                                    if let Some(ps) = app.try_state::<PreviewState>() {
+                                        if let Ok(mut guard) = ps.0.lock() {
+                                            if let Some(tx) = guard.take() {
+                                                debug!("Confirming preview via push-to-talk shortcut");
+                                                let _ = tx.send(true);
+                                            }
+                                        }
+                                    }
                                 }
                             } else if is_pressed {
                                 match &stage {
@@ -84,6 +94,19 @@ impl TranscriptionCoordinator {
                                     }
                                     Stage::Recording(id) if id == &binding_id => {
                                         stop(&app, &mut stage, &binding_id, &hotkey_string);
+                                    }
+                                    Stage::Processing => {
+                                        // If a preview is pending, confirm it
+                                        if let Some(ps) = app.try_state::<PreviewState>() {
+                                            if let Ok(mut guard) = ps.0.lock() {
+                                                if let Some(tx) = guard.take() {
+                                                    debug!("Confirming preview via transcribe shortcut");
+                                                    let _ = tx.send(true);
+                                                    continue;
+                                                }
+                                            }
+                                        }
+                                        debug!("Ignoring press for '{binding_id}': pipeline busy")
                                     }
                                     _ => {
                                         debug!("Ignoring press for '{binding_id}': pipeline busy")

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -29,6 +29,15 @@ pub fn cancel_current_operation(app: &AppHandle) {
     change_tray_icon(app, crate::tray::TrayIconState::Idle);
     hide_recording_overlay(app);
 
+    // Cancel any pending preview
+    if let Some(ps) = app.try_state::<crate::actions::PreviewState>() {
+        if let Ok(mut guard) = ps.0.lock() {
+            if let Some(tx) = guard.take() {
+                let _ = tx.send(false);
+            }
+        }
+    }
+
     // Unload model if immediate unload is enabled
     let tm = app.state::<Arc<TranscriptionManager>>();
     tm.maybe_unload_immediately("cancellation");

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -311,6 +311,14 @@ async changeAppendTrailingSpaceSetting(enabled: boolean) : Promise<Result<null, 
     else return { status: "error", error: e  as any };
 }
 },
+async changePreviewBeforePasteSetting(enabled: boolean) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("change_preview_before_paste_setting", { enabled }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async changeLazyStreamCloseSetting(enabled: boolean) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("change_lazy_stream_close_setting", { enabled }) };
@@ -433,6 +441,22 @@ async showMainWindowCommand() : Promise<Result<null, string>> {
 },
 async cancelOperation() : Promise<void> {
     await TAURI_INVOKE("cancel_operation");
+},
+async confirmPreview() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("confirm_preview") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async cancelPreview() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("cancel_preview") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 },
 async isPortable() : Promise<boolean> {
     return await TAURI_INVOKE("is_portable");
@@ -797,10 +821,8 @@ async updateRecordingRetentionPeriod(period: string) : Promise<Result<null, stri
 }
 },
 /**
- * Checks if the Mac is a laptop by detecting battery presence
- * 
- * This uses pmset to check for battery information.
- * Returns true if a battery is detected (laptop), false otherwise (desktop)
+ * Stub implementation for non-macOS platforms
+ * Always returns false since laptop detection is macOS-specific
  */
 async isLaptop() : Promise<Result<boolean, string>> {
     try {
@@ -827,7 +849,7 @@ historyUpdatePayload: "history-update-payload"
 
 /** user-defined types **/
 
-export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk: boolean; audio_feedback: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; selected_model?: string; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: Partial<{ [key in string]: string }>; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; experimental_enabled?: boolean; lazy_stream_close?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool; external_script_path: string | null; custom_filler_words?: string[] | null; whisper_accelerator?: WhisperAcceleratorSetting; ort_accelerator?: OrtAcceleratorSetting; whisper_gpu_device?: number; extra_recording_buffer_ms?: number }
+export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk: boolean; audio_feedback: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; selected_model?: string; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: Partial<{ [key in string]: string }>; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; preview_before_paste?: boolean; app_language?: string; experimental_enabled?: boolean; lazy_stream_close?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool; external_script_path: string | null; custom_filler_words?: string[] | null; whisper_accelerator?: WhisperAcceleratorSetting; ort_accelerator?: OrtAcceleratorSetting; whisper_gpu_device?: number; extra_recording_buffer_ms?: number }
 export type AudioDevice = { index: string; name: string; is_default: boolean }
 export type AutoSubmitKey = "enter" | "ctrl_enter" | "cmd_enter"
 export type AvailableAccelerators = { whisper: string[]; ort: string[]; gpu_devices: GpuDeviceOption[] }

--- a/src/components/icons/CheckIcon.tsx
+++ b/src/components/icons/CheckIcon.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+interface CheckIconProps {
+  width?: number;
+  height?: number;
+  color?: string;
+  className?: string;
+}
+
+const CheckIcon: React.FC<CheckIconProps> = ({
+  width = 24,
+  height = 24,
+  color = "#4ade80",
+  className = "",
+}) => {
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <g fill={color}>
+        <path d="m9.99999 15.586-3.293-3.293c-.39053-.3905-1.02354-.3905-1.41407 0-.39052.3905-.39052 1.0236 0 1.4141l4 4c.39053.3905 1.02354.3905 1.41407 0l8.00001-8c.3905-.39053.3905-1.02354 0-1.41407-.3905-.39052-1.0236-.39052-1.4141 0z" />
+        <path
+          d="m20 12c0-4.41828-3.5817-8-8-8-4.41828 0-8 3.58172-8 8 0 4.4183 3.58172 8 8 8 4.4183 0 8-3.5817 8-8zm2 0c0 5.5228-4.4772 10-10 10-5.52285 0-10-4.4772-10-10 0-5.52285 4.47715-10 10-10 5.5228 0 10 4.47715 10 10z"
+          opacity=".4"
+        />
+      </g>
+    </svg>
+  );
+};
+
+export default CheckIcon;

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -1,3 +1,4 @@
 export { default as MicrophoneIcon } from "./MicrophoneIcon";
 export { default as TranscriptionIcon } from "./TranscriptionIcon";
 export { default as CancelIcon } from "./CancelIcon";
+export { default as CheckIcon } from "./CheckIcon";

--- a/src/components/settings/PreviewBeforePaste.tsx
+++ b/src/components/settings/PreviewBeforePaste.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { ToggleSwitch } from "../ui/ToggleSwitch";
+import { useSettings } from "../../hooks/useSettings";
+
+interface PreviewBeforePasteProps {
+  descriptionMode?: "inline" | "tooltip";
+  grouped?: boolean;
+}
+
+export const PreviewBeforePaste: React.FC<PreviewBeforePasteProps> =
+  React.memo(({ descriptionMode = "tooltip", grouped = false }) => {
+    const { t } = useTranslation();
+    const { getSetting, updateSetting, isUpdating } = useSettings();
+
+    const enabled = getSetting("preview_before_paste") ?? false;
+
+    return (
+      <ToggleSwitch
+        checked={enabled}
+        onChange={(enabled) => updateSetting("preview_before_paste", enabled)}
+        isUpdating={isUpdating("preview_before_paste")}
+        label={t("settings.advanced.previewBeforePaste.label")}
+        description={t("settings.advanced.previewBeforePaste.description")}
+        descriptionMode={descriptionMode}
+        grouped={grouped}
+      />
+    );
+  });

--- a/src/components/settings/advanced/AdvancedSettings.tsx
+++ b/src/components/settings/advanced/AdvancedSettings.tsx
@@ -11,6 +11,7 @@ import { PasteMethodSetting } from "../PasteMethod";
 import { TypingToolSetting } from "../TypingTool";
 import { ClipboardHandlingSetting } from "../ClipboardHandling";
 import { AutoSubmit } from "../AutoSubmit";
+import { PreviewBeforePaste } from "../PreviewBeforePaste";
 import { PostProcessingToggle } from "../PostProcessingToggle";
 import { AppendTrailingSpace } from "../AppendTrailingSpace";
 import { HistoryLimit } from "../HistoryLimit";
@@ -42,6 +43,7 @@ export const AdvancedSettings: React.FC = () => {
         <TypingToolSetting descriptionMode="tooltip" grouped={true} />
         <ClipboardHandlingSetting descriptionMode="tooltip" grouped={true} />
         <AutoSubmit descriptionMode="tooltip" grouped={true} />
+        <PreviewBeforePaste descriptionMode="tooltip" grouped={true} />
       </SettingsGroup>
 
       <SettingsGroup title={t("settings.advanced.groups.transcription")}>

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -251,6 +251,10 @@
         "label": "Keep Mic Open Between Transcriptions",
         "description": "Keeps the microphone stream open for 30 seconds after recording stops, reducing latency for back-to-back transcriptions. May degrade Bluetooth audio quality while active."
       },
+      "previewBeforePaste": {
+        "label": "Preview Before Paste",
+        "description": "Show transcribed text for review before pasting. Confirm to paste, cancel to discard."
+      },
       "acceleration": {
         "whisper": {
           "title": "Whisper Acceleration",

--- a/src/overlay/RecordingOverlay.css
+++ b/src/overlay/RecordingOverlay.css
@@ -93,3 +93,78 @@
 .cancel-button:active {
   transform: scale(0.95);
 }
+
+/* Preview mode */
+.recording-overlay.preview-mode {
+  width: 400px;
+  height: auto;
+  min-height: 60px;
+  max-height: 200px;
+  display: flex;
+  flex-direction: column;
+  padding: 12px;
+  border-radius: 12px;
+  grid-template-columns: none;
+}
+
+.preview-container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  min-height: 0;
+}
+
+.preview-text {
+  color: white;
+  font-size: 13px;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  line-height: 1.4;
+  max-height: 120px;
+  overflow-y: auto;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+}
+
+.preview-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.preview-button {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition:
+    background-color 150ms ease-out,
+    transform 100ms ease-out;
+}
+
+.preview-button:active {
+  transform: scale(0.95);
+}
+
+.preview-button.confirm {
+  background: #4ade8033;
+}
+
+.preview-button.confirm:hover {
+  background: #4ade8066;
+  transform: scale(1.05);
+}
+
+.preview-button.cancel {
+  background: transparent;
+}
+
+.preview-button.cancel:hover {
+  background: #faa2ca33;
+  transform: scale(1.05);
+}

--- a/src/overlay/RecordingOverlay.tsx
+++ b/src/overlay/RecordingOverlay.tsx
@@ -5,19 +5,21 @@ import {
   MicrophoneIcon,
   TranscriptionIcon,
   CancelIcon,
+  CheckIcon,
 } from "../components/icons";
 import "./RecordingOverlay.css";
 import { commands } from "@/bindings";
 import i18n, { syncLanguageFromSettings } from "@/i18n";
 import { getLanguageDirection } from "@/lib/utils/rtl";
 
-type OverlayState = "recording" | "transcribing" | "processing";
+type OverlayState = "recording" | "transcribing" | "processing" | "preview";
 
 const RecordingOverlay: React.FC = () => {
   const { t } = useTranslation();
   const [isVisible, setIsVisible] = useState(false);
   const [state, setState] = useState<OverlayState>("recording");
   const [levels, setLevels] = useState<number[]>(Array(16).fill(0));
+  const [previewText, setPreviewText] = useState("");
   const smoothedLevelsRef = useRef<number[]>(Array(16).fill(0));
   const direction = getLanguageDirection(i18n.language);
 
@@ -31,6 +33,17 @@ const RecordingOverlay: React.FC = () => {
         setState(overlayState);
         setIsVisible(true);
       });
+
+      // Listen for show-preview event from Rust
+      const unlistenPreview = await listen<{ text: string }>(
+        "show-preview",
+        async (event) => {
+          await syncLanguageFromSettings();
+          setPreviewText(event.payload.text);
+          setState("preview");
+          setIsVisible(true);
+        },
+      );
 
       // Listen for hide-overlay event from Rust
       const unlistenHide = await listen("hide-overlay", () => {
@@ -54,6 +67,7 @@ const RecordingOverlay: React.FC = () => {
       // Cleanup function
       return () => {
         unlistenShow();
+        unlistenPreview();
         unlistenHide();
         unlistenLevel();
       };
@@ -65,6 +79,8 @@ const RecordingOverlay: React.FC = () => {
   const getIcon = () => {
     if (state === "recording") {
       return <MicrophoneIcon />;
+    } else if (state === "preview") {
+      return null;
     } else {
       return <TranscriptionIcon />;
     }
@@ -73,46 +89,77 @@ const RecordingOverlay: React.FC = () => {
   return (
     <div
       dir={direction}
-      className={`recording-overlay ${isVisible ? "fade-in" : ""}`}
+      className={`recording-overlay ${isVisible ? "fade-in" : ""} ${state === "preview" ? "preview-mode" : ""}`}
     >
-      <div className="overlay-left">{getIcon()}</div>
+      {state === "preview" ? (
+        <div className="preview-container">
+          <div className="preview-text">{previewText}</div>
+          <div className="preview-actions">
+            <div
+              className="preview-button confirm"
+              onClick={() => {
+                commands.confirmPreview();
+              }}
+            >
+              <CheckIcon width={20} height={20} />
+            </div>
+            <div
+              className="preview-button cancel"
+              onClick={() => {
+                commands.cancelPreview();
+              }}
+            >
+              <CancelIcon width={20} height={20} />
+            </div>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="overlay-left">{getIcon()}</div>
 
-      <div className="overlay-middle">
-        {state === "recording" && (
-          <div className="bars-container">
-            {levels.map((v, i) => (
+          <div className="overlay-middle">
+            {state === "recording" && (
+              <div className="bars-container">
+                {levels.map((v, i) => (
+                  <div
+                    key={i}
+                    className="bar"
+                    style={{
+                      height: `${Math.min(20, 4 + Math.pow(v, 0.7) * 16)}px`, // Cap at 20px max height
+                      transition:
+                        "height 60ms ease-out, opacity 120ms ease-out",
+                      opacity: Math.max(0.2, v * 1.7), // Minimum opacity for visibility
+                    }}
+                  />
+                ))}
+              </div>
+            )}
+            {state === "transcribing" && (
+              <div className="transcribing-text">
+                {t("overlay.transcribing")}
+              </div>
+            )}
+            {state === "processing" && (
+              <div className="transcribing-text">
+                {t("overlay.processing")}
+              </div>
+            )}
+          </div>
+
+          <div className="overlay-right">
+            {state === "recording" && (
               <div
-                key={i}
-                className="bar"
-                style={{
-                  height: `${Math.min(20, 4 + Math.pow(v, 0.7) * 16)}px`, // Cap at 20px max height
-                  transition: "height 60ms ease-out, opacity 120ms ease-out",
-                  opacity: Math.max(0.2, v * 1.7), // Minimum opacity for visibility
+                className="cancel-button"
+                onClick={() => {
+                  commands.cancelOperation();
                 }}
-              />
-            ))}
+              >
+                <CancelIcon />
+              </div>
+            )}
           </div>
-        )}
-        {state === "transcribing" && (
-          <div className="transcribing-text">{t("overlay.transcribing")}</div>
-        )}
-        {state === "processing" && (
-          <div className="transcribing-text">{t("overlay.processing")}</div>
-        )}
-      </div>
-
-      <div className="overlay-right">
-        {state === "recording" && (
-          <div
-            className="cancel-button"
-            onClick={() => {
-              commands.cancelOperation();
-            }}
-          >
-            <CancelIcon />
-          </div>
-        )}
-      </div>
+        </>
+      )}
     </div>
   );
 };

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -137,6 +137,8 @@ const settingUpdaters: {
     commands.changeMuteWhileRecordingSetting(value as boolean),
   append_trailing_space: (value) =>
     commands.changeAppendTrailingSpaceSetting(value as boolean),
+  preview_before_paste: (value) =>
+    commands.changePreviewBeforePasteSetting(value as boolean),
   log_level: (value) => commands.setLogLevel(value as any),
   app_language: (value) => commands.changeAppLanguageSetting(value as string),
   experimental_enabled: (value) =>


### PR DESCRIPTION
This pull request adds the feature to show a preview window of the the post transcription text and allows you to accept or cancel it using the transcribe and cancel keybinds.

<img width="682" height="602" alt="preview-before-paste" src="https://github.com/user-attachments/assets/8ea8e11d-f2aa-4944-a50c-2ef2efabb5f6" />

<img width="399" height="77" alt="transcription-preview" src="https://github.com/user-attachments/assets/63cefa03-d3c2-4f41-a211-e1a548005d47" />

I use the transcribe and cancel functions, but without push the talk. I'm also using auto submit. I found this workflow with being able to preview the text before submitting it and using the same key bind as transcribe more elegant than transcribe without auto submit.

For example, I use auto submit while talking to Claude and then the preview window shows up and allows me to accept or reject the message before sending it. If I was using regular transcription without auto submit, it would paste the message, but then I would have to hit different keybinds to erase the message or send the message.

