### PR TITLE
docs: add manual release signature verification steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,41 @@ We're actively working on several features and improvements. Contributions and f
 - Abstract and organize Tauri command patterns
 - Investigate tauri-specta for improved type safety and organization
 
+## Verify Release Signatures
+
+Handy release artifacts are signed with Tauri's updater signature format. The public key is stored in [`src-tauri/tauri.conf.json`](src-tauri/tauri.conf.json) under `plugins.updater.pubkey`.
+
+To verify a release manually, set `ARTIFACT` to the filename you downloaded, save the `pubkey` value from `src-tauri/tauri.conf.json` to `handy.pub.b64`, then decode the public key and matching `.sig` file from base64 and verify the artifact with `minisign`:
+
+```bash
+# Replace with the file you downloaded
+ARTIFACT="Handy_0.8.1_amd64.AppImage"
+
+python3 - "$ARTIFACT" <<'PY'
+import base64, pathlib, sys
+
+artifact = sys.argv[1]
+
+pub = pathlib.Path("handy.pub.b64").read_text().strip()
+pathlib.Path("handy.pub").write_bytes(base64.b64decode(pub))
+
+sig = pathlib.Path(f"{artifact}.sig").read_text().strip()
+pathlib.Path(f"{artifact}.minisig").write_bytes(base64.b64decode(sig))
+PY
+
+minisign -Vm "$ARTIFACT" \
+  -p handy.pub \
+  -x "$ARTIFACT.minisig"
+```
+
+On success, `minisign` prints:
+
+```text
+Signature and comment signature verified
+```
+
+Do not use `gpg` for these `.sig` files.
+
 ## Troubleshooting
 
 ### Manual Model Installation (For Proxy Users or Network Restrictions)


### PR DESCRIPTION
## Summary

Add manual verification steps for release signatures to the README.

## Why
 
Issue #407 shows that the current verification flow is not obvious to users trying to verify downloaded release artifacts manually.

Handy's updater public key and generated `.sig` files are base64-encoded for Tauri, so they need to be decoded before verifying with`minisign`.

## Validation

Tested locally on macOS with the `v0.8.1` release by verifying:

- `Handy_0.8.1_amd64.AppImage`
- `Handy_0.8.1_amd64.AppImage.sig`

After decoding the public key and `.sig` file from base64, `minisign` verified the artifact successfully.

Related to #407