### PR TITLE
fix(tray): set tray tooltip text on Windows

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -201,6 +201,7 @@ fn initialize_core_logic(app_handle: &AppHandle) {
             )
             .unwrap(),
         )
+        .tooltip(tray::tray_tooltip())
         .show_menu_on_left_click(true)
         .icon_as_template(true)
         .on_menu_event(|app, event| match event.id.as_ref() {

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -81,6 +81,18 @@ pub fn change_tray_icon(app: &AppHandle, icon: TrayIconState) {
     update_tray_menu(app, &icon, None);
 }
 
+pub fn tray_tooltip() -> String {
+    version_label()
+}
+
+fn version_label() -> String {
+    if cfg!(debug_assertions) {
+        format!("Handy v{} (Dev)", env!("CARGO_PKG_VERSION"))
+    } else {
+        format!("Handy v{}", env!("CARGO_PKG_VERSION"))
+    }
+}
+
 pub fn update_tray_menu(app: &AppHandle, state: &TrayIconState, locale: Option<&str>) {
     let settings = settings::get_settings(app);
 
@@ -94,11 +106,7 @@ pub fn update_tray_menu(app: &AppHandle, state: &TrayIconState, locale: Option<&
     let (settings_accelerator, quit_accelerator) = (Some("Ctrl+,"), Some("Ctrl+Q"));
 
     // Create common menu items
-    let version_label = if cfg!(debug_assertions) {
-        format!("Handy v{} (Dev)", env!("CARGO_PKG_VERSION"))
-    } else {
-        format!("Handy v{}", env!("CARGO_PKG_VERSION"))
-    };
+    let version_label = version_label();
     let version_i = MenuItem::with_id(app, "version", &version_label, false, None::<&str>)
         .expect("failed to create version item");
     let settings_i = MenuItem::with_id(
@@ -212,6 +220,7 @@ pub fn update_tray_menu(app: &AppHandle, state: &TrayIconState, locale: Option<&
     let tray = app.state::<TrayIcon>();
     let _ = tray.set_menu(Some(menu));
     let _ = tray.set_icon_as_template(true);
+    let _ = tray.set_tooltip(Some(version_label));
 }
 
 fn last_transcript_text(entry: &HistoryEntry) -> &str {


### PR DESCRIPTION
Fixes #1184.

The tray icon was created and refreshed without setting a tooltip, which caused Windows to show an empty hover tooltip.

This change sets the tooltip when building the tray icon and refreshes it during tray menu updates using the existing version label.

## Before Submitting This PR

- [x] I have searched existing issues and pull requests (including closed ones) to ensure this isn't a duplicate
- [x] I have read CONTRIBUTING.md

## Description

I noticed that hovering the Handy tray icon on Windows showed an empty tooltip bubble instead of useful text. This looked like a small but clear UI bug, so I checked the tray setup and found that the icon was never given a tooltip string. I fixed it by setting the tooltip both when the tray icon is created and when the tray menu is refreshed.

## Community Feedback

Issue: #1184

## Testing

Tested locally on Windows 11.

## AI Assistance

- [x] No AI was used in this PR
- [ ] AI was used (please describe below)
