### PR TITLE
nix: set ALSA_PLUGIN_DIR via symlinkJoin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,13 @@
             ];
           };
           lib = pkgs.lib;
+          combinedAlsaPlugins = pkgs.symlinkJoin {
+            name = "combined-alsa-plugins";
+            paths = [
+              "${pkgs.pipewire}/lib/alsa-lib"
+              "${pkgs.alsa-plugins}/lib/alsa-lib"
+            ];
+          };
         in
         {
           handy = pkgs.rustPlatform.buildRustPackage {
@@ -178,7 +185,7 @@
             preFixup = ''
               gappsWrapperArgs+=(
                 --set WEBKIT_DISABLE_DMABUF_RENDERER 1
-                --set ALSA_PLUGIN_DIR "${pkgs.pipewire}/lib/alsa-lib:${pkgs.alsa-plugins}/lib/alsa-lib"
+                --set ALSA_PLUGIN_DIR "${combinedAlsaPlugins}"
                 --prefix LD_LIBRARY_PATH : "${
                   lib.makeLibraryPath [
                     pkgs.vulkan-loader


### PR DESCRIPTION
On non-NixOS with home-manager, Handy can error when ALSA_PLUGIN_DIR is set to a colon-separated list, e.g.
/nix/store/...-pipewire-1.6.2/lib/alsa-lib:/nix/store/...-alsa-plugins-1.2.12/lib/alsa-lib/libasound_module_pcm_pulse.so
Even though libasound_module_pcm_pulse.so exists in one of those dirs, ALSA treats the combined string as a single path and fails.
Use a symlinkJoin to present a single directory that contains both plugin trees.