### PR TITLE
feat: add accent color picker to customize app theme

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -368,6 +368,7 @@ pub fn run(cli_args: CliArgs) {
             shortcut::change_keyboard_implementation_setting,
             shortcut::get_keyboard_implementation,
             shortcut::change_show_tray_icon_setting,
+            shortcut::change_accent_color_setting,
             shortcut::change_whisper_accelerator_setting,
             shortcut::change_ort_accelerator_setting,
             shortcut::change_whisper_gpu_device,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -423,6 +423,8 @@ pub struct AppSettings {
     #[serde(default)]
     pub custom_filler_words: Option<Vec<String>>,
     #[serde(default)]
+    pub accent_color: String,
+    #[serde(default)]
     pub whisper_accelerator: WhisperAcceleratorSetting,
     #[serde(default)]
     pub ort_accelerator: OrtAcceleratorSetting,
@@ -800,6 +802,7 @@ pub fn get_default_settings() -> AppSettings {
         typing_tool: default_typing_tool(),
         external_script_path: None,
         custom_filler_words: None,
+        accent_color: String::new(),
         whisper_accelerator: WhisperAcceleratorSetting::default(),
         ort_accelerator: OrtAcceleratorSetting::default(),
         whisper_gpu_device: default_whisper_gpu_device(),

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -1142,6 +1142,24 @@ pub fn change_whisper_gpu_device(app: AppHandle, device: i32) -> Result<(), Stri
     Ok(())
 }
 
+#[tauri::command]
+#[specta::specta]
+pub fn change_accent_color_setting(app: AppHandle, color: String) -> Result<(), String> {
+    // Empty string resets to default; otherwise must be #rrggbb
+    if !color.is_empty() {
+        let valid = color.len() == 7
+            && color.starts_with('#')
+            && color[1..].chars().all(|c| c.is_ascii_hexdigit());
+        if !valid {
+            return Err(format!("Invalid accent color: {color}"));
+        }
+    }
+    let mut s = settings::get_settings(&app);
+    s.accent_color = color;
+    settings::write_settings(&app, s);
+    Ok(())
+}
+
 /// Return which accelerators and GPU devices are available for this build.
 #[tauri::command]
 #[specta::specta]

--- a/src/App.css
+++ b/src/App.css
@@ -38,6 +38,10 @@
     transparent 70%
   );
 
+  /* Default accent colors for overlay */
+  --color-accent-bar: #ffe5ee;
+  --color-accent-hover: #faa2ca33;
+
   /* Apply colors */
   color: var(--color-text);
   background-color: var(--color-background);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { useSettings } from "./hooks/useSettings";
 import { useSettingsStore } from "./stores/settingsStore";
 import { commands } from "@/bindings";
 import { getLanguageDirection, initializeRTL } from "@/lib/utils/rtl";
+import { applyAccentColor } from "@/lib/utils/accentColor";
 
 type OnboardingStep = "accessibility" | "model" | "done";
 
@@ -54,6 +55,11 @@ function App() {
   useEffect(() => {
     initializeRTL(i18n.language);
   }, [i18n.language]);
+
+  // Apply accent color to root element
+  useEffect(() => {
+    applyAccentColor(settings?.accent_color);
+  }, [settings?.accent_color]);
 
   // Initialize Enigo, shortcuts, and refresh audio devices when main app loads
   useEffect(() => {

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -363,6 +363,14 @@ async changeShowTrayIconSetting(enabled: boolean) : Promise<Result<null, string>
     else return { status: "error", error: e  as any };
 }
 },
+async changeAccentColorSetting(color: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("change_accent_color_setting", { color }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async changeWhisperAcceleratorSetting(accelerator: WhisperAcceleratorSetting) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("change_whisper_accelerator_setting", { accelerator }) };
@@ -827,7 +835,7 @@ historyUpdatePayload: "history-update-payload"
 
 /** user-defined types **/
 
-export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk: boolean; audio_feedback: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; selected_model?: string; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: SecretMap; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; experimental_enabled?: boolean; lazy_stream_close?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool; external_script_path: string | null; custom_filler_words?: string[] | null; whisper_accelerator?: WhisperAcceleratorSetting; ort_accelerator?: OrtAcceleratorSetting; whisper_gpu_device?: number; extra_recording_buffer_ms?: number }
+export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk: boolean; audio_feedback: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; selected_model?: string; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: SecretMap; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; experimental_enabled?: boolean; lazy_stream_close?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool; external_script_path: string | null; custom_filler_words?: string[] | null; accent_color?: string; whisper_accelerator?: WhisperAcceleratorSetting; ort_accelerator?: OrtAcceleratorSetting; whisper_gpu_device?: number; extra_recording_buffer_ms?: number }
 export type AudioDevice = { index: string; name: string; is_default: boolean }
 export type AutoSubmitKey = "enter" | "ctrl_enter" | "cmd_enter"
 export type AvailableAccelerators = { whisper: string[]; ort: string[]; gpu_devices: GpuDeviceOption[] }

--- a/src/components/icons/CancelIcon.tsx
+++ b/src/components/icons/CancelIcon.tsx
@@ -10,7 +10,7 @@ interface CancelIconProps {
 const CancelIcon: React.FC<CancelIconProps> = ({
   width = 24,
   height = 24,
-  color = "#FAA2CA",
+  color = "var(--color-logo-primary, #FAA2CA)",
   className = "",
 }) => {
   return (

--- a/src/components/icons/MicrophoneIcon.tsx
+++ b/src/components/icons/MicrophoneIcon.tsx
@@ -10,7 +10,7 @@ interface MicrophoneIconProps {
 const MicrophoneIcon: React.FC<MicrophoneIconProps> = ({
   width = 24,
   height = 24,
-  color = "#FAA2CA",
+  color = "var(--color-logo-primary, #FAA2CA)",
   className = "",
 }) => {
   return (

--- a/src/components/icons/TranscriptionIcon.tsx
+++ b/src/components/icons/TranscriptionIcon.tsx
@@ -10,7 +10,7 @@ interface TranscriptionIconProps {
 const TranscriptionIcon: React.FC<TranscriptionIconProps> = ({
   width = 24,
   height = 24,
-  color = "#FAA2CA",
+  color = "var(--color-logo-primary, #FAA2CA)",
   className = "",
 }) => {
   return (

--- a/src/components/settings/AccentColorPicker.tsx
+++ b/src/components/settings/AccentColorPicker.tsx
@@ -1,0 +1,86 @@
+import React, { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { RotateCcw } from "lucide-react";
+import { SettingContainer } from "../ui/SettingContainer";
+import { useSettings } from "../../hooks/useSettings";
+
+const DEFAULT_COLOR = "#faa2ca";
+
+const stripHash = (hex: string) => hex.replace(/^#/, "");
+
+const normalizeHex = (value: string): string | null => {
+  const digits = value.replace(/^#+/, "");
+  return /^[0-9a-fA-F]{6}$/.test(digits) ? `#${digits}` : null;
+};
+
+export const AccentColorPicker: React.FC<{
+  descriptionMode?: "inline" | "tooltip";
+  grouped?: boolean;
+}> = ({ descriptionMode = "tooltip", grouped = false }) => {
+  const { t } = useTranslation();
+  const { getSetting, updateSetting } = useSettings();
+
+  const saved = getSetting("accent_color");
+  const isDefault = !saved || !saved.startsWith("#");
+  const currentColor = isDefault ? DEFAULT_COLOR : saved;
+
+  const [hexInput, setHexInput] = useState(stripHash(currentColor));
+
+  useEffect(() => {
+    setHexInput(stripHash(currentColor));
+  }, [currentColor]);
+
+  const applyHex = (value: string) => {
+    const hex = normalizeHex(value);
+    if (hex) {
+      setHexInput(stripHash(hex));
+      updateSetting("accent_color", hex);
+    } else {
+      setHexInput(stripHash(currentColor));
+    }
+  };
+
+  return (
+    <SettingContainer
+      title={t("settings.advanced.accentColor.label")}
+      description={t("settings.advanced.accentColor.description")}
+      descriptionMode={descriptionMode}
+      grouped={grouped}
+      layout="horizontal"
+    >
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => updateSetting("accent_color", "")}
+          className={`p-1.5 rounded transition-colors ${
+            isDefault
+              ? "text-mid-gray/30 cursor-default"
+              : "text-mid-gray hover:bg-mid-gray/20 cursor-pointer"
+          }`}
+          disabled={isDefault}
+          title={t("settings.advanced.accentColor.reset")}
+        >
+          <RotateCcw className="w-4 h-4" />
+        </button>
+        <input
+          type="text"
+          value={hexInput}
+          onChange={(e) => setHexInput(e.target.value)}
+          onBlur={() => applyHex(hexInput)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") applyHex(hexInput);
+          }}
+          maxLength={7}
+          className="w-[4.5rem] px-2 py-1 text-sm font-mono rounded border border-mid-gray/40 bg-mid-gray/10 focus:border-logo-primary focus:outline-none"
+          placeholder="faa2ca"
+        />
+        <input
+          type="color"
+          value={currentColor}
+          onChange={(e) => updateSetting("accent_color", e.target.value)}
+          className="w-8 h-8 rounded-full cursor-pointer border border-mid-gray/40 bg-transparent p-0 [&::-webkit-color-swatch-wrapper]:p-0 [&::-webkit-color-swatch]:rounded-full [&::-webkit-color-swatch]:border-none [&::-moz-color-swatch]:rounded-full [&::-moz-color-swatch]:border-none"
+        />
+      </div>
+    </SettingContainer>
+  );
+};

--- a/src/components/settings/advanced/AdvancedSettings.tsx
+++ b/src/components/settings/advanced/AdvancedSettings.tsx
@@ -16,6 +16,7 @@ import { AppendTrailingSpace } from "../AppendTrailingSpace";
 import { HistoryLimit } from "../HistoryLimit";
 import { RecordingRetentionPeriodSelector } from "../RecordingRetentionPeriod";
 import { ExperimentalToggle } from "../ExperimentalToggle";
+import { AccentColorPicker } from "../AccentColorPicker";
 import { useSettings } from "../../../hooks/useSettings";
 import { KeyboardImplementationSelector } from "../debug/KeyboardImplementationSelector";
 import { AccelerationSelector } from "../AccelerationSelector";
@@ -35,6 +36,10 @@ export const AdvancedSettings: React.FC = () => {
         <ShowOverlay descriptionMode="tooltip" grouped={true} />
         <ModelUnloadTimeoutSetting descriptionMode="tooltip" grouped={true} />
         <ExperimentalToggle descriptionMode="tooltip" grouped={true} />
+      </SettingsGroup>
+
+      <SettingsGroup title={t("settings.advanced.groups.appearance")}>
+        <AccentColorPicker descriptionMode="tooltip" grouped={true} />
       </SettingsGroup>
 
       <SettingsGroup title={t("settings.advanced.groups.output")}>

--- a/src/components/ui/AudioPlayer.tsx
+++ b/src/components/ui/AudioPlayer.tsx
@@ -260,7 +260,7 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = ({
           onTouchStart={handleSliderTouchStart}
           className={`flex-1 h-1 rounded-lg appearance-none cursor-pointer focus:outline-none focus:ring-1 focus:ring-logo-primary ${progressPercent >= 99.5 ? "[&::-webkit-slider-thumb]:translate-x-0.5 [&::-moz-range-thumb]:translate-x-0.5" : ""}`}
           style={{
-            background: `linear-gradient(to right, #FAA2CA 0%, #FAA2CA ${progressPercent}%, rgba(128, 128, 128, 0.2) ${progressPercent}%, rgba(128, 128, 128, 0.2) 100%)`,
+            background: `linear-gradient(to right, var(--color-logo-primary, #FAA2CA) 0%, var(--color-logo-primary, #FAA2CA) ${progressPercent}%, rgba(128, 128, 128, 0.2) ${progressPercent}%, rgba(128, 128, 128, 0.2) 100%)`,
           }}
         />
 

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -241,11 +241,17 @@
     "advanced": {
       "title": "Advanced",
       "groups": {
+        "appearance": "Appearance",
         "app": "App",
         "output": "Output",
         "transcription": "Transcription",
         "history": "History",
         "experimental": "Experimental"
+      },
+      "accentColor": {
+        "label": "Accent Color",
+        "description": "Choose the accent color used throughout the app.",
+        "reset": "Reset to default"
       },
       "experimentalToggle": {
         "label": "Experimental Features",

--- a/src/lib/utils/accentColor.ts
+++ b/src/lib/utils/accentColor.ts
@@ -1,0 +1,69 @@
+function hexToHsl(hex: string): [number, number, number] {
+  const n = parseInt(hex.replace("#", ""), 16);
+  const r = ((n >> 16) & 255) / 255,
+    g = ((n >> 8) & 255) / 255,
+    b = (n & 255) / 255;
+  const max = Math.max(r, g, b),
+    min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  if (max === min) return [0, 0, l * 100];
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  const h =
+    max === r
+      ? ((g - b) / d + (g < b ? 6 : 0)) / 6
+      : max === g
+        ? ((b - r) / d + 2) / 6
+        : ((r - g) / d + 4) / 6;
+  return [h * 360, s * 100, l * 100];
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+  const s1 = s / 100;
+  const l1 = l / 100;
+  const a = s1 * Math.min(l1, 1 - l1);
+  const f = (n: number) => {
+    const k = (n + h / 30) % 12;
+    const c = l1 - a * Math.max(-1, Math.min(k - 3, 9 - k, 1));
+    return Math.round(255 * Math.max(0, Math.min(1, c)))
+      .toString(16)
+      .padStart(2, "0");
+  };
+  return `#${f(0)}${f(8)}${f(4)}`;
+}
+
+const clamp = (v: number, min: number, max: number) =>
+  Math.min(max, Math.max(min, v));
+
+export function applyAccentColor(hex: string | undefined | null): void {
+  const root = document.documentElement;
+  const props = [
+    "--color-background-ui",
+    "--color-logo-primary",
+    "--color-logo-stroke",
+    "--color-accent-bar",
+    "--color-accent-hover",
+  ];
+
+  if (!hex || !/^#[0-9a-fA-F]{6}$/.test(hex)) {
+    props.forEach((p) => root.style.removeProperty(p));
+    return;
+  }
+
+  const [h, s, l] = hexToHsl(hex);
+
+  root.style.setProperty(
+    "--color-background-ui",
+    hslToHex(h, s, clamp(l - 15, 15, 85)),
+  );
+  root.style.setProperty("--color-logo-primary", hex);
+  root.style.setProperty(
+    "--color-logo-stroke",
+    hslToHex(h, s * 0.5, clamp(l - 35, 5, 70)),
+  );
+  root.style.setProperty(
+    "--color-accent-bar",
+    hslToHex(h, s * 0.35, clamp(l + 25, 50, 93)),
+  );
+  root.style.setProperty("--color-accent-hover", hex + "33");
+}

--- a/src/overlay/RecordingOverlay.css
+++ b/src/overlay/RecordingOverlay.css
@@ -1,3 +1,16 @@
+/* Default accent colors (pink) */
+:root {
+  --color-accent-bar: #ffe5ee;
+  --color-accent-hover: #faa2ca33;
+  --color-logo-primary: #faa2ca;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-logo-primary: #f28cbb;
+  }
+}
+
 .recording-overlay {
   height: 36px;
   width: 172px;
@@ -41,7 +54,7 @@
 
 .bar {
   width: 6px;
-  background: #ffe5ee;
+  background: var(--color-accent-bar, #ffe5ee);
   max-height: 20px;
   border-radius: 2px;
   transition: height 80ms linear;
@@ -86,7 +99,7 @@
 }
 
 .cancel-button:hover {
-  background: #faa2ca33;
+  background: var(--color-accent-hover, #faa2ca33);
   transform: scale(1.05);
 }
 

--- a/src/overlay/RecordingOverlay.tsx
+++ b/src/overlay/RecordingOverlay.tsx
@@ -9,6 +9,7 @@ import {
 import "./RecordingOverlay.css";
 import { commands } from "@/bindings";
 import i18n, { syncLanguageFromSettings } from "@/i18n";
+import { applyAccentColor } from "@/lib/utils/accentColor";
 import { getLanguageDirection } from "@/lib/utils/rtl";
 
 type OverlayState = "recording" | "transcribing" | "processing";
@@ -25,8 +26,12 @@ const RecordingOverlay: React.FC = () => {
     const setupEventListeners = async () => {
       // Listen for show-overlay event from Rust
       const unlistenShow = await listen("show-overlay", async (event) => {
-        // Sync language from settings each time overlay is shown
+        // Sync language and accent color from settings each time overlay is shown
         await syncLanguageFromSettings();
+        const result = await commands.getAppSettings();
+        if (result.status === "ok") {
+          applyAccentColor(result.data.accent_color);
+        }
         const overlayState = event.payload as OverlayState;
         setState(overlayState);
         setIsVisible(true);

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -83,6 +83,7 @@ const settingUpdaters: {
   audio_feedback_volume: (value) =>
     commands.changeAudioFeedbackVolumeSetting(value as number),
   sound_theme: (value) => commands.changeSoundThemeSetting(value as string),
+  accent_color: (value) => commands.changeAccentColorSetting(value as string),
   start_hidden: (value) => commands.changeStartHiddenSetting(value as boolean),
   autostart_enabled: (value) =>
     commands.changeAutostartSetting(value as boolean),


### PR DESCRIPTION
## Summary

Adds a color picker under **Advanced > Appearance** that lets users choose any accent color for the app. The default pink theme is preserved — users who don't touch the setting see no change.

- Pick any color via native color picker or paste a hex value
- Full palette (buttons, icons, sidebar, overlay, hover states) is derived automatically from a single color via HSL manipulation
- Reset button restores the original pink theme
- Setting is persisted in `AppSettings` and validated on both frontend and backend

## How it works

A single `accent_color` string field stores the hex value (empty = default pink). On the frontend, `applyAccentColor()` converts the chosen color into 5 CSS custom properties (`--color-background-ui`, `--color-logo-primary`, `--color-logo-stroke`, `--color-accent-bar`, `--color-accent-hover`) applied to `:root`. When reset, inline styles are removed and CSS defaults take over.

Hardcoded `#FAA2CA` references in icons and AudioPlayer now use `var(--color-logo-primary)` with fallback, so they respond to theme changes automatically.

## Changes

**Backend (3 files, +22 lines):**
- `settings.rs` — `accent_color: String` field with serde default
- `shortcut/mod.rs` — `change_accent_color_setting` command with hex validation
- `lib.rs` — command registration

**Frontend (14 files, +211 lines):**
- `accentColor.ts` — hex→HSL palette derivation + DOM application (69 lines)
- `AccentColorPicker.tsx` — color input + hex text field + reset button (86 lines)
- `AdvancedSettings.tsx` — new "Appearance" settings group
- `App.tsx` / `RecordingOverlay.tsx` — apply accent from settings
- Icons + AudioPlayer — `var(--color-logo-primary)` with fallback
- CSS — default `--color-accent-bar` / `--color-accent-hover` variables
- i18n, bindings, settingsStore — minimal wiring

## Screenshots

The color picker sits alongside other settings in the familiar horizontal layout:

<img width="734" height="616" alt="image" src="https://github.com/user-attachments/assets/52ce96c6-7a65-404d-b56c-4d4debd82c29" />