### PR TITLE
feat(nix): add Cachix binary cache to CI

### DIFF
--- a/.github/workflows/nix-check.yml
+++ b/.github/workflows/nix-check.yml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: cachix/cachix-action@v15
         with:
-          name: handy
+          name: handy-computer
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       # Regenerate .nix/bun.nix from bun.lock and check if it matches

--- a/.github/workflows/nix-check.yml
+++ b/.github/workflows/nix-check.yml
@@ -4,7 +4,7 @@
 #    so compilation-breaking edits are caught by flake eval.
 # 2. Full nix build (~25 min) only runs when nix packaging files change.
 #
-# Setting up a Cachix binary cache would further reduce full-build times.
+# Build artifacts are pushed to Cachix so Nix users can skip local compilation.
 
 name: "nix build check"
 on:
@@ -48,7 +48,10 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
-      - uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
+      - uses: cachix/cachix-action@v15
+        with:
+          name: handy
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       # Regenerate .nix/bun.nix from bun.lock and check if it matches
       # what's committed. A diff means the developer forgot to run
@@ -121,7 +124,7 @@ jobs:
       # sandbox issues, compilation failures) that flake eval alone misses.
       # On PRs: only runs when nix packaging files change (~25 min with cold cache).
       # On push to main and workflow_dispatch: always runs so every commit on
-      # main has a verified nix build before release.
+      # main has a verified nix build. cachix-action auto-pushes artifacts.
       - name: Build handy
         if: steps.bun-check.outputs.outdated != 'true' && steps.eval.outputs.failed != 'true' && (steps.nix-files.outputs.changed == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'push')
         run: nix build .#handy -L --show-trace

--- a/.github/workflows/nix-check.yml
+++ b/.github/workflows/nix-check.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: cachix/cachix-action@v15
         with:
           name: handy
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       # Regenerate .nix/bun.nix from bun.lock and check if it matches
       # what's committed. A diff means the developer forgot to run

--- a/.github/workflows/nix-check.yml
+++ b/.github/workflows/nix-check.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
-      - uses: cachix/cachix-action@v15
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: handy-computer
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"


### PR DESCRIPTION
## Summary

- Replace `magic-nix-cache-action` (GitHub-local cache only) with `cachix/cachix-action` so build artifacts are pushed to a public Cachix binary cache
- Nix users can then pull pre-built binaries instead of compiling from source (~25 min build)

## Setup required

1. Create the cache: `cachix create handy`
2. Generate an auth token at https://app.cachix.org and add it as `CACHIX_AUTH_TOKEN` in the repo's GitHub Actions secrets
3. Once the cache exists, users add the substituter to their Nix config:
   ```nix
   nix.settings = {
     substituters = [ "https://handy.cachix.org" ];
     trusted-public-keys = [ "handy.cachix.org-1:<key from cachix create output>" ];
   };
   ```

The NixOS module (`programs.handy`) could also auto-add the substituter — happy to add that in a follow-up once the cache is created and the public key is known.