### PR TITLE
[codex] Add optional ElevenLabs transcription provider

### DIFF
--- a/docs/aa-wer-comparison.svg
+++ b/docs/aa-wer-comparison.svg
@@ -1,0 +1,71 @@
+<svg width="920" height="420" viewBox="0 0 920 420" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Artificial Analysis AA-WER comparison</title>
+  <desc id="desc">Bar chart comparing Scribe v2, Parakeet V3, Whisper Large, and Whisper Turbo on reference AA-WER. Lower is better.</desc>
+  <rect width="920" height="420" rx="16" fill="#0D1117"/>
+  <text x="40" y="42" fill="#F0F6FC" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="28" font-weight="700">
+    Artificial Analysis AA-WER reference
+  </text>
+  <text x="40" y="70" fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="16">
+    Lower is better. Scribe v2 is highlighted in green.
+  </text>
+
+  <line x1="110" y1="100" x2="110" y2="340" stroke="#30363D" stroke-width="2"/>
+  <line x1="110" y1="340" x2="870" y2="340" stroke="#30363D" stroke-width="2"/>
+
+  <g fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="14">
+    <text x="78" y="345">0</text>
+    <text x="78" y="307">1</text>
+    <text x="78" y="269">2</text>
+    <text x="78" y="231">3</text>
+    <text x="78" y="193">4</text>
+    <text x="78" y="155">5</text>
+    <text x="78" y="117">6</text>
+  </g>
+
+  <g stroke="#21262D" stroke-width="1">
+    <line x1="110" y1="302" x2="870" y2="302"/>
+    <line x1="110" y1="264" x2="870" y2="264"/>
+    <line x1="110" y1="226" x2="870" y2="226"/>
+    <line x1="110" y1="188" x2="870" y2="188"/>
+    <line x1="110" y1="150" x2="870" y2="150"/>
+    <line x1="110" y1="112" x2="870" y2="112"/>
+  </g>
+
+  <line x1="110" y1="252.6" x2="870" y2="252.6" stroke="#2DA44E" stroke-width="2" stroke-dasharray="8 8" opacity="0.6"/>
+  <text x="876" y="257" fill="#2DA44E" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="12" font-weight="600" text-anchor="end">
+    Scribe baseline 2.3
+  </text>
+
+  <g font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">
+    <rect x="155" y="252.6" width="120" height="87.4" rx="8" fill="#2DA44E"/>
+    <text x="215" y="240" fill="#F0F6FC" font-size="16" font-weight="700" text-anchor="middle">2.3%</text>
+    <text x="215" y="368" fill="#F0F6FC" font-size="16" font-weight="600" text-anchor="middle">Scribe v2</text>
+    <text x="215" y="388" fill="#8B949E" font-size="13" text-anchor="middle">ElevenLabs</text>
+
+    <rect x="335" y="180.4" width="120" height="159.6" rx="8" fill="#8B949E"/>
+    <text x="395" y="168" fill="#F0F6FC" font-size="16" font-weight="700" text-anchor="middle">4.2%</text>
+    <text x="395" y="368" fill="#F0F6FC" font-size="16" font-weight="600" text-anchor="middle">Parakeet V3</text>
+    <text x="395" y="388" fill="#8B949E" font-size="13" text-anchor="middle">local</text>
+
+    <rect x="515" y="180.4" width="120" height="159.6" rx="8" fill="#8B949E"/>
+    <text x="575" y="168" fill="#F0F6FC" font-size="16" font-weight="700" text-anchor="middle">4.2%</text>
+    <text x="575" y="368" fill="#F0F6FC" font-size="16" font-weight="600" text-anchor="middle">Whisper Large</text>
+    <text x="575" y="388" fill="#8B949E" font-size="13" text-anchor="middle">v3 reference</text>
+
+    <rect x="695" y="157.6" width="120" height="182.4" rx="8" fill="#8B949E"/>
+    <text x="755" y="145" fill="#F0F6FC" font-size="16" font-weight="700" text-anchor="middle">4.8%</text>
+    <text x="755" y="368" fill="#F0F6FC" font-size="16" font-weight="600" text-anchor="middle">Whisper Turbo</text>
+    <text x="755" y="388" fill="#8B949E" font-size="13" text-anchor="middle">v3 turbo ref</text>
+  </g>
+
+  <text x="26" y="230" transform="rotate(-90 26 230)" fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="15" font-weight="600">
+    AA-WER %
+  </text>
+
+  <g transform="translate(40 92)">
+    <rect x="0" y="0" width="18" height="18" rx="4" fill="#2DA44E"/>
+    <text x="28" y="14" fill="#F0F6FC" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="13">Scribe v2</text>
+    <rect x="118" y="0" width="18" height="18" rx="4" fill="#8B949E"/>
+    <text x="146" y="14" fill="#F0F6FC" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="13">local references</text>
+  </g>
+</svg>

--- a/docs/aa-wer-comparison.svg
+++ b/docs/aa-wer-comparison.svg
@@ -1,7 +1,7 @@
-<svg width="920" height="420" viewBox="0 0 920 420" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+<svg width="920" height="450" viewBox="0 0 920 450" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
   <title id="title">Artificial Analysis AA-WER comparison</title>
   <desc id="desc">Bar chart comparing Scribe v2, Parakeet V3, Whisper Large, and Whisper Turbo on reference AA-WER. Lower is better.</desc>
-  <rect width="920" height="420" rx="16" fill="#0D1117"/>
+  <rect width="920" height="450" rx="16" fill="#0D1117"/>
   <text x="40" y="42" fill="#F0F6FC" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="28" font-weight="700">
     Artificial Analysis AA-WER reference
   </text>
@@ -17,52 +17,52 @@
   </g>
 
   <g fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="14">
-    <text x="78" y="347">0</text>
-    <text x="78" y="312">1</text>
-    <text x="78" y="277">2</text>
-    <text x="78" y="242">3</text>
-    <text x="78" y="207">4</text>
-    <text x="78" y="172">5</text>
+    <text x="78" y="365">0</text>
+    <text x="78" y="327">1</text>
+    <text x="78" y="289">2</text>
+    <text x="78" y="251">3</text>
+    <text x="78" y="213">4</text>
+    <text x="78" y="175">5</text>
     <text x="78" y="137">6</text>
   </g>
 
   <g stroke="#21262D" stroke-width="1">
-    <line x1="110" y1="307" x2="870" y2="307"/>
-    <line x1="110" y1="272" x2="870" y2="272"/>
-    <line x1="110" y1="237" x2="870" y2="237"/>
-    <line x1="110" y1="202" x2="870" y2="202"/>
-    <line x1="110" y1="167" x2="870" y2="167"/>
+    <line x1="110" y1="322" x2="870" y2="322"/>
+    <line x1="110" y1="284" x2="870" y2="284"/>
+    <line x1="110" y1="246" x2="870" y2="246"/>
+    <line x1="110" y1="208" x2="870" y2="208"/>
+    <line x1="110" y1="170" x2="870" y2="170"/>
     <line x1="110" y1="132" x2="870" y2="132"/>
   </g>
 
-  <line x1="110" y1="132" x2="110" y2="342" stroke="#30363D" stroke-width="2"/>
-  <line x1="110" y1="342" x2="870" y2="342" stroke="#30363D" stroke-width="2"/>
+  <line x1="110" y1="360" x2="870" y2="360" stroke="#30363D" stroke-width="2"/>
+  <line x1="110" y1="132" x2="110" y2="360" stroke="#30363D" stroke-width="2"/>
 
   <g font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">
-    <rect x="155" y="261.5" width="120" height="80.5" rx="8" fill="#2DA44E"/>
-    <text x="215" y="249" fill="#F0F6FC" font-size="16" font-weight="700" text-anchor="middle">2.3%</text>
-    <text x="215" y="369" fill="#F0F6FC" font-size="16" font-weight="600" text-anchor="middle">Scribe v2</text>
-    <text x="215" y="389" fill="#8B949E" font-size="13" text-anchor="middle">cloud</text>
+    <rect x="155" y="272.6" width="120" height="87.4" rx="8" fill="#2DA44E"/>
+    <text x="215" y="260" fill="#F0F6FC" font-size="16" font-weight="700" text-anchor="middle">2.3%</text>
+    <text x="215" y="389" fill="#F0F6FC" font-size="16" font-weight="600" text-anchor="middle">Scribe v2</text>
+    <text x="215" y="409" fill="#8B949E" font-size="13" text-anchor="middle">cloud</text>
 
-    <rect x="335" y="195" width="120" height="147" rx="8" fill="#8B949E"/>
-    <text x="395" y="183" fill="#F0F6FC" font-size="16" font-weight="700" text-anchor="middle">4.2%</text>
-    <text x="395" y="369" fill="#F0F6FC" font-size="16" font-weight="600" text-anchor="middle">Parakeet V3</text>
-    <text x="395" y="389" fill="#8B949E" font-size="13" text-anchor="middle">local</text>
+    <rect x="335" y="200.4" width="120" height="159.6" rx="8" fill="#8B949E"/>
+    <text x="395" y="188" fill="#F0F6FC" font-size="16" font-weight="700" text-anchor="middle">4.2%</text>
+    <text x="395" y="389" fill="#F0F6FC" font-size="16" font-weight="600" text-anchor="middle">Parakeet V3</text>
+    <text x="395" y="409" fill="#8B949E" font-size="13" text-anchor="middle">local</text>
 
-    <rect x="515" y="195" width="120" height="147" rx="8" fill="#8B949E"/>
-    <text x="575" y="183" fill="#F0F6FC" font-size="16" font-weight="700" text-anchor="middle">4.2%</text>
-    <text x="575" y="369" fill="#F0F6FC" font-size="16" font-weight="600" text-anchor="middle">Whisper Large</text>
-    <text x="575" y="389" fill="#8B949E" font-size="13" text-anchor="middle">local</text>
+    <rect x="515" y="200.4" width="120" height="159.6" rx="8" fill="#8B949E"/>
+    <text x="575" y="188" fill="#F0F6FC" font-size="16" font-weight="700" text-anchor="middle">4.2%</text>
+    <text x="575" y="389" fill="#F0F6FC" font-size="16" font-weight="600" text-anchor="middle">Whisper Large</text>
+    <text x="575" y="409" fill="#8B949E" font-size="13" text-anchor="middle">local</text>
 
-    <rect x="695" y="174" width="120" height="168" rx="8" fill="#8B949E"/>
-    <text x="755" y="162" fill="#F0F6FC" font-size="16" font-weight="700" text-anchor="middle">4.8%</text>
-    <text x="755" y="369" fill="#F0F6FC" font-size="16" font-weight="600" text-anchor="middle">Whisper Turbo</text>
-    <text x="755" y="389" fill="#8B949E" font-size="13" text-anchor="middle">local</text>
+    <rect x="695" y="177.6" width="120" height="182.4" rx="8" fill="#8B949E"/>
+    <text x="755" y="165" fill="#F0F6FC" font-size="16" font-weight="700" text-anchor="middle">4.8%</text>
+    <text x="755" y="389" fill="#F0F6FC" font-size="16" font-weight="600" text-anchor="middle">Whisper Turbo</text>
+    <text x="755" y="409" fill="#8B949E" font-size="13" text-anchor="middle">local</text>
   </g>
 
-  <line x1="110" y1="261.5" x2="870" y2="261.5" stroke="#2DA44E" stroke-width="2.5" stroke-dasharray="10 8" opacity="0.9"/>
-  <rect x="718" y="247" width="136" height="22" rx="11" fill="#0D1117" stroke="#2DA44E" stroke-width="1"/>
-  <text x="786" y="262" fill="#2DA44E" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="12" font-weight="700" text-anchor="middle">
+  <line x1="110" y1="272.6" x2="870" y2="272.6" stroke="#2DA44E" stroke-width="2.5" stroke-dasharray="10 8" opacity="0.9"/>
+  <rect x="718" y="258" width="136" height="22" rx="11" fill="#0D1117" stroke="#2DA44E" stroke-width="1"/>
+  <text x="786" y="273" fill="#2DA44E" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="12" font-weight="700" text-anchor="middle">
     baseline 2.3
   </text>
 

--- a/docs/aa-wer-comparison.svg
+++ b/docs/aa-wer-comparison.svg
@@ -9,63 +9,64 @@
     Lower is better. Scribe v2 is highlighted in green.
   </text>
 
-  <line x1="110" y1="100" x2="110" y2="340" stroke="#30363D" stroke-width="2"/>
-  <line x1="110" y1="340" x2="870" y2="340" stroke="#30363D" stroke-width="2"/>
-
-  <g fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="14">
-    <text x="78" y="345">0</text>
-    <text x="78" y="307">1</text>
-    <text x="78" y="269">2</text>
-    <text x="78" y="231">3</text>
-    <text x="78" y="193">4</text>
-    <text x="78" y="155">5</text>
-    <text x="78" y="117">6</text>
-  </g>
-
-  <g stroke="#21262D" stroke-width="1">
-    <line x1="110" y1="302" x2="870" y2="302"/>
-    <line x1="110" y1="264" x2="870" y2="264"/>
-    <line x1="110" y1="226" x2="870" y2="226"/>
-    <line x1="110" y1="188" x2="870" y2="188"/>
-    <line x1="110" y1="150" x2="870" y2="150"/>
-    <line x1="110" y1="112" x2="870" y2="112"/>
-  </g>
-
-  <line x1="110" y1="252.6" x2="870" y2="252.6" stroke="#2DA44E" stroke-width="2" stroke-dasharray="8 8" opacity="0.6"/>
-  <text x="876" y="257" fill="#2DA44E" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="12" font-weight="600" text-anchor="end">
-    Scribe baseline 2.3
-  </text>
-
-  <g font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">
-    <rect x="155" y="252.6" width="120" height="87.4" rx="8" fill="#2DA44E"/>
-    <text x="215" y="240" fill="#F0F6FC" font-size="16" font-weight="700" text-anchor="middle">2.3%</text>
-    <text x="215" y="368" fill="#F0F6FC" font-size="16" font-weight="600" text-anchor="middle">Scribe v2</text>
-    <text x="215" y="388" fill="#8B949E" font-size="13" text-anchor="middle">ElevenLabs</text>
-
-    <rect x="335" y="180.4" width="120" height="159.6" rx="8" fill="#8B949E"/>
-    <text x="395" y="168" fill="#F0F6FC" font-size="16" font-weight="700" text-anchor="middle">4.2%</text>
-    <text x="395" y="368" fill="#F0F6FC" font-size="16" font-weight="600" text-anchor="middle">Parakeet V3</text>
-    <text x="395" y="388" fill="#8B949E" font-size="13" text-anchor="middle">local</text>
-
-    <rect x="515" y="180.4" width="120" height="159.6" rx="8" fill="#8B949E"/>
-    <text x="575" y="168" fill="#F0F6FC" font-size="16" font-weight="700" text-anchor="middle">4.2%</text>
-    <text x="575" y="368" fill="#F0F6FC" font-size="16" font-weight="600" text-anchor="middle">Whisper Large</text>
-    <text x="575" y="388" fill="#8B949E" font-size="13" text-anchor="middle">v3 reference</text>
-
-    <rect x="695" y="157.6" width="120" height="182.4" rx="8" fill="#8B949E"/>
-    <text x="755" y="145" fill="#F0F6FC" font-size="16" font-weight="700" text-anchor="middle">4.8%</text>
-    <text x="755" y="368" fill="#F0F6FC" font-size="16" font-weight="600" text-anchor="middle">Whisper Turbo</text>
-    <text x="755" y="388" fill="#8B949E" font-size="13" text-anchor="middle">v3 turbo ref</text>
-  </g>
-
-  <text x="26" y="230" transform="rotate(-90 26 230)" fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="15" font-weight="600">
-    AA-WER %
-  </text>
-
   <g transform="translate(40 92)">
     <rect x="0" y="0" width="18" height="18" rx="4" fill="#2DA44E"/>
     <text x="28" y="14" fill="#F0F6FC" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="13">Scribe v2</text>
     <rect x="118" y="0" width="18" height="18" rx="4" fill="#8B949E"/>
     <text x="146" y="14" fill="#F0F6FC" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="13">local references</text>
   </g>
+
+  <g fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="14">
+    <text x="78" y="347">0</text>
+    <text x="78" y="312">1</text>
+    <text x="78" y="277">2</text>
+    <text x="78" y="242">3</text>
+    <text x="78" y="207">4</text>
+    <text x="78" y="172">5</text>
+    <text x="78" y="137">6</text>
+  </g>
+
+  <g stroke="#21262D" stroke-width="1">
+    <line x1="110" y1="307" x2="870" y2="307"/>
+    <line x1="110" y1="272" x2="870" y2="272"/>
+    <line x1="110" y1="237" x2="870" y2="237"/>
+    <line x1="110" y1="202" x2="870" y2="202"/>
+    <line x1="110" y1="167" x2="870" y2="167"/>
+    <line x1="110" y1="132" x2="870" y2="132"/>
+  </g>
+
+  <line x1="110" y1="132" x2="110" y2="342" stroke="#30363D" stroke-width="2"/>
+  <line x1="110" y1="342" x2="870" y2="342" stroke="#30363D" stroke-width="2"/>
+
+  <g font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">
+    <rect x="155" y="261.5" width="120" height="80.5" rx="8" fill="#2DA44E"/>
+    <text x="215" y="249" fill="#F0F6FC" font-size="16" font-weight="700" text-anchor="middle">2.3%</text>
+    <text x="215" y="369" fill="#F0F6FC" font-size="16" font-weight="600" text-anchor="middle">Scribe v2</text>
+    <text x="215" y="389" fill="#8B949E" font-size="13" text-anchor="middle">ElevenLabs</text>
+
+    <rect x="335" y="195" width="120" height="147" rx="8" fill="#8B949E"/>
+    <text x="395" y="183" fill="#F0F6FC" font-size="16" font-weight="700" text-anchor="middle">4.2%</text>
+    <text x="395" y="369" fill="#F0F6FC" font-size="16" font-weight="600" text-anchor="middle">Parakeet V3</text>
+    <text x="395" y="389" fill="#8B949E" font-size="13" text-anchor="middle">local</text>
+
+    <rect x="515" y="195" width="120" height="147" rx="8" fill="#8B949E"/>
+    <text x="575" y="183" fill="#F0F6FC" font-size="16" font-weight="700" text-anchor="middle">4.2%</text>
+    <text x="575" y="369" fill="#F0F6FC" font-size="16" font-weight="600" text-anchor="middle">Whisper Large</text>
+    <text x="575" y="389" fill="#8B949E" font-size="13" text-anchor="middle">v3 reference</text>
+
+    <rect x="695" y="174" width="120" height="168" rx="8" fill="#8B949E"/>
+    <text x="755" y="162" fill="#F0F6FC" font-size="16" font-weight="700" text-anchor="middle">4.8%</text>
+    <text x="755" y="369" fill="#F0F6FC" font-size="16" font-weight="600" text-anchor="middle">Whisper Turbo</text>
+    <text x="755" y="389" fill="#8B949E" font-size="13" text-anchor="middle">v3 turbo ref</text>
+  </g>
+
+  <line x1="110" y1="261.5" x2="870" y2="261.5" stroke="#2DA44E" stroke-width="2.5" stroke-dasharray="10 8" opacity="0.9"/>
+  <rect x="718" y="247" width="136" height="22" rx="11" fill="#0D1117" stroke="#2DA44E" stroke-width="1"/>
+  <text x="786" y="262" fill="#2DA44E" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="12" font-weight="700" text-anchor="middle">
+    baseline 2.3
+  </text>
+
+  <text x="26" y="230" transform="rotate(-90 26 230)" fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="15" font-weight="600">
+    AA-WER %
+  </text>
 </svg>

--- a/docs/aa-wer-comparison.svg
+++ b/docs/aa-wer-comparison.svg
@@ -42,7 +42,7 @@
     <rect x="155" y="261.5" width="120" height="80.5" rx="8" fill="#2DA44E"/>
     <text x="215" y="249" fill="#F0F6FC" font-size="16" font-weight="700" text-anchor="middle">2.3%</text>
     <text x="215" y="369" fill="#F0F6FC" font-size="16" font-weight="600" text-anchor="middle">Scribe v2</text>
-    <text x="215" y="389" fill="#8B949E" font-size="13" text-anchor="middle">ElevenLabs</text>
+    <text x="215" y="389" fill="#8B949E" font-size="13" text-anchor="middle">cloud</text>
 
     <rect x="335" y="195" width="120" height="147" rx="8" fill="#8B949E"/>
     <text x="395" y="183" fill="#F0F6FC" font-size="16" font-weight="700" text-anchor="middle">4.2%</text>
@@ -52,12 +52,12 @@
     <rect x="515" y="195" width="120" height="147" rx="8" fill="#8B949E"/>
     <text x="575" y="183" fill="#F0F6FC" font-size="16" font-weight="700" text-anchor="middle">4.2%</text>
     <text x="575" y="369" fill="#F0F6FC" font-size="16" font-weight="600" text-anchor="middle">Whisper Large</text>
-    <text x="575" y="389" fill="#8B949E" font-size="13" text-anchor="middle">v3 reference</text>
+    <text x="575" y="389" fill="#8B949E" font-size="13" text-anchor="middle">local</text>
 
     <rect x="695" y="174" width="120" height="168" rx="8" fill="#8B949E"/>
     <text x="755" y="162" fill="#F0F6FC" font-size="16" font-weight="700" text-anchor="middle">4.8%</text>
     <text x="755" y="369" fill="#F0F6FC" font-size="16" font-weight="600" text-anchor="middle">Whisper Turbo</text>
-    <text x="755" y="389" fill="#8B949E" font-size="13" text-anchor="middle">v3 turbo ref</text>
+    <text x="755" y="389" fill="#8B949E" font-size="13" text-anchor="middle">local</text>
   </g>
 
   <line x1="110" y1="261.5" x2="870" y2="261.5" stroke="#2DA44E" stroke-width="2.5" stroke-dasharray="10 8" opacity="0.9"/>

--- a/docs/free-tier-comparison.svg
+++ b/docs/free-tier-comparison.svg
@@ -1,0 +1,81 @@
+<svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Speech-to-text free tier comparison</title>
+  <desc id="desc">Horizontal bar chart comparing approximate monthly free-tier transcription capacity for Azure Speech, ElevenLabs Scribe, Google Cloud Speech-to-Text, Amazon Transcribe, and Wispr Flow Basic. ElevenLabs is highlighted in green.</desc>
+  <rect width="960" height="540" rx="18" fill="#0D1117"/>
+
+  <text x="40" y="46" fill="#F0F6FC" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="30" font-weight="700">
+    Free-tier offer comparison
+  </text>
+  <text x="40" y="76" fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="16">
+    Approximate monthly transcription capacity normalized to minutes. ElevenLabs is highlighted in green.
+  </text>
+  <text x="40" y="98" fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="13">
+    Wispr Flow is converted from 2,000 desktop words/week at ~150 wpm. Amazon's free tier is limited to the first 12 months.
+  </text>
+
+  <g transform="translate(40 116)">
+    <rect x="0" y="0" width="16" height="16" rx="4" fill="#2DA44E"/>
+    <text x="26" y="12.5" fill="#F0F6FC" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="13">ElevenLabs</text>
+    <rect x="116" y="0" width="16" height="16" rx="4" fill="#98A2AE"/>
+    <text x="142" y="12.5" fill="#F0F6FC" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="13">other providers</text>
+  </g>
+
+  <g stroke="#21262D" stroke-width="1">
+    <line x1="360" y1="158" x2="360" y2="474"/>
+    <line x1="464" y1="158" x2="464" y2="474"/>
+    <line x1="568" y1="158" x2="568" y2="474"/>
+    <line x1="672" y1="158" x2="672" y2="474"/>
+    <line x1="776" y1="158" x2="776" y2="474"/>
+    <line x1="880" y1="158" x2="880" y2="474"/>
+  </g>
+
+  <g stroke="#30363D" stroke-width="2">
+    <line x1="360" y1="158" x2="360" y2="474"/>
+    <line x1="360" y1="474" x2="880" y2="474"/>
+  </g>
+
+  <g fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="13">
+    <text x="360" y="502" text-anchor="middle">0</text>
+    <text x="464" y="502" text-anchor="middle">60</text>
+    <text x="568" y="502" text-anchor="middle">120</text>
+    <text x="672" y="502" text-anchor="middle">180</text>
+    <text x="776" y="502" text-anchor="middle">240</text>
+    <text x="880" y="502" text-anchor="middle">300 min / mo</text>
+  </g>
+
+  <g font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">
+    <text x="40" y="185" fill="#F0F6FC" font-size="18" font-weight="600">Azure Speech F0</text>
+    <text x="40" y="208" fill="#8B949E" font-size="13">cloud API</text>
+    <rect x="360" y="166" width="520" height="32" rx="10" fill="#98A2AE"/>
+    <rect x="892" y="165" width="56" height="34" rx="10" fill="#161B22" stroke="#30363D"/>
+    <text x="920" y="187" fill="#F0F6FC" font-size="14" font-weight="700" text-anchor="middle">300</text>
+
+    <text x="40" y="249" fill="#F0F6FC" font-size="18" font-weight="600">ElevenLabs Scribe</text>
+    <text x="40" y="272" fill="#8B949E" font-size="13">cloud API</text>
+    <rect x="360" y="230" width="260" height="32" rx="10" fill="#2DA44E"/>
+    <rect x="892" y="229" width="56" height="34" rx="10" fill="#152A1B" stroke="#2DA44E"/>
+    <text x="920" y="251" fill="#F0F6FC" font-size="14" font-weight="700" text-anchor="middle">150</text>
+
+    <text x="40" y="313" fill="#F0F6FC" font-size="18" font-weight="600">Google Cloud STT</text>
+    <text x="40" y="336" fill="#8B949E" font-size="13">cloud API</text>
+    <rect x="360" y="294" width="104" height="32" rx="10" fill="#98A2AE"/>
+    <rect x="892" y="293" width="56" height="34" rx="10" fill="#161B22" stroke="#30363D"/>
+    <text x="920" y="315" fill="#F0F6FC" font-size="14" font-weight="700" text-anchor="middle">60</text>
+
+    <text x="40" y="377" fill="#F0F6FC" font-size="18" font-weight="600">Amazon Transcribe</text>
+    <text x="40" y="400" fill="#8B949E" font-size="13">cloud API • 12-mo free tier</text>
+    <rect x="360" y="358" width="104" height="32" rx="10" fill="#98A2AE"/>
+    <rect x="892" y="357" width="56" height="34" rx="10" fill="#161B22" stroke="#30363D"/>
+    <text x="920" y="379" fill="#F0F6FC" font-size="14" font-weight="700" text-anchor="middle">60</text>
+
+    <text x="40" y="441" fill="#F0F6FC" font-size="18" font-weight="600">Wispr Flow Basic</text>
+    <text x="40" y="464" fill="#8B949E" font-size="13">desktop dictation</text>
+    <rect x="360" y="422" width="100" height="32" rx="10" fill="#98A2AE"/>
+    <rect x="892" y="421" width="56" height="34" rx="10" fill="#161B22" stroke="#30363D"/>
+    <text x="920" y="443" fill="#F0F6FC" font-size="14" font-weight="700" text-anchor="middle">58</text>
+  </g>
+
+  <text x="620" y="528" fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="12" text-anchor="middle">
+    Approximate free usage per month, normalized to minutes where possible
+  </text>
+</svg>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1935,6 +1935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -3330,6 +3331,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minicov"
@@ -4869,6 +4880,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -4882,6 +4894,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -7124,6 +7137,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -58,7 +58,7 @@ tokio = "1.43.0"
 vad-rs = { git = "https://github.com/cjpais/vad-rs", default-features = false }
 enigo = "0.6.1"
 rodio = { git = "https://github.com/cjpais/rodio.git" }
-reqwest = { version = "0.12", features = ["json", "stream"] }
+reqwest = { version = "0.12", features = ["blocking", "json", "multipart", "stream"] }
 futures-util = "0.3"
 rustfft = "6.4.0"
 strsim = "0.11.0"

--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -27,6 +27,11 @@ struct RecordingErrorEvent {
     detail: Option<String>,
 }
 
+#[derive(Clone, serde::Serialize)]
+struct TranscriptionErrorEvent {
+    detail: Option<String>,
+}
+
 /// Drop guard that notifies the [`TranscriptionCoordinator`] when the
 /// transcription pipeline finishes — whether it completes normally or panics.
 struct FinishGuard(AppHandle);
@@ -61,6 +66,47 @@ fn strip_invisible_chars(s: &str) -> String {
 /// Removes `${output}` placeholder since the transcription is sent as the user message.
 fn build_system_prompt(prompt_template: &str) -> String {
     prompt_template.replace("${output}", "").trim().to_string()
+}
+
+fn summarize_transcription_error_for_overlay(error_message: &str) -> String {
+    let normalized = error_message.trim();
+    let lowercase = normalized.to_lowercase();
+
+    if lowercase.contains("quota") || lowercase.contains("credits remaining") {
+        return "ElevenLabs quota exceeded".to_string();
+    }
+
+    if lowercase.contains("rate limit") {
+        return "ElevenLabs rate limited".to_string();
+    }
+
+    if lowercase.contains("missing speech-to-text permissions") {
+        return "ElevenLabs STT permission missing".to_string();
+    }
+
+    if lowercase.contains("authentication failed") {
+        return "ElevenLabs authentication failed".to_string();
+    }
+
+    if lowercase.contains("currently unavailable") {
+        return "ElevenLabs unavailable".to_string();
+    }
+
+    if lowercase.contains("timed out") {
+        return "ElevenLabs request timed out".to_string();
+    }
+
+    if lowercase.contains("couldn't reach elevenlabs")
+        || lowercase.contains("failed to reach elevenlabs")
+    {
+        return "No connection to ElevenLabs".to_string();
+    }
+
+    if lowercase.contains("elevenlabs request failed") {
+        return "ElevenLabs request failed".to_string();
+    }
+
+    "Transcription failed".to_string()
 }
 
 async fn post_process_transcription(settings: &AppSettings, transcription: &str) -> Option<String> {
@@ -518,9 +564,18 @@ impl ShortcutAction for TranscribeAction {
                         crate::audio_toolkit::save_wav_file(&wav_path, &samples_for_wav)
                     });
 
-                    // Transcribe concurrently with WAV save
+                    // Transcribe concurrently with WAV save on a blocking worker thread.
+                    // This avoids running sync network/model work on Tauri's async runtime.
                     let transcription_time = Instant::now();
-                    let transcription_result = tm.transcribe(samples);
+                    let tm_for_transcription = Arc::clone(&tm);
+                    let transcription_handle = tauri::async_runtime::spawn_blocking(move || {
+                        tm_for_transcription.transcribe(samples)
+                    });
+
+                    let transcription_result = match transcription_handle.await {
+                        Ok(result) => result,
+                        Err(e) => Err(anyhow::anyhow!("Transcription task panicked: {}", e)),
+                    };
 
                     // Await WAV save and verify
                     let wav_saved = match wav_handle.await {
@@ -601,6 +656,7 @@ impl ShortcutAction for TranscribeAction {
                         }
                         Err(err) => {
                             debug!("Global Shortcut Transcription error: {}", err);
+                            let error_message = err.to_string();
                             // Save entry with empty text so user can retry
                             if wav_saved {
                                 if let Err(save_err) = hm.save_entry(
@@ -613,7 +669,16 @@ impl ShortcutAction for TranscribeAction {
                                     error!("Failed to save failed history entry: {}", save_err);
                                 }
                             }
-                            utils::hide_recording_overlay(&ah);
+                            let _ = ah.emit(
+                                "transcription-error",
+                                TranscriptionErrorEvent {
+                                    detail: Some(error_message.clone()),
+                                },
+                            );
+                            utils::show_error_overlay(
+                                &ah,
+                                summarize_transcription_error_for_overlay(&error_message),
+                            );
                             change_tray_icon(&ah, TrayIconState::Idle);
                         }
                     }
@@ -691,3 +756,46 @@ pub static ACTION_MAP: Lazy<HashMap<String, Arc<dyn ShortcutAction>>> = Lazy::ne
     );
     map
 });
+
+#[cfg(test)]
+mod tests {
+    use super::summarize_transcription_error_for_overlay;
+
+    #[test]
+    fn summarizes_quota_errors_for_overlay() {
+        assert_eq!(
+            summarize_transcription_error_for_overlay(
+                "ElevenLabs authentication failed: quota exceeded",
+            ),
+            "ElevenLabs quota exceeded"
+        );
+    }
+
+    #[test]
+    fn summarizes_connectivity_errors_for_overlay() {
+        assert_eq!(
+            summarize_transcription_error_for_overlay(
+                "Failed to reach ElevenLabs speech-to-text API: connection reset",
+            ),
+            "No connection to ElevenLabs"
+        );
+    }
+
+    #[test]
+    fn summarizes_provider_availability_errors_for_overlay() {
+        assert_eq!(
+            summarize_transcription_error_for_overlay(
+                "ElevenLabs is currently unavailable. Please try again in a moment.",
+            ),
+            "ElevenLabs unavailable"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_generic_overlay_error_message() {
+        assert_eq!(
+            summarize_transcription_error_for_overlay("something unexpected happened"),
+            "Transcription failed"
+        );
+    }
+}

--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -1,6 +1,10 @@
+use crate::elevenlabs_stt;
 use crate::managers::model::{ModelInfo, ModelManager};
 use crate::managers::transcription::{ModelStateEvent, TranscriptionManager};
-use crate::settings::{get_settings, write_settings, ModelUnloadTimeout};
+use crate::settings::{
+    get_settings, write_settings, ModelUnloadTimeout, ELEVENLABS_TRANSCRIPTION_PROVIDER_ID,
+    LOCAL_TRANSCRIPTION_PROVIDER_ID,
+};
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter, Manager, State};
 
@@ -19,6 +23,26 @@ pub async fn get_model_info(
     model_id: String,
 ) -> Result<Option<ModelInfo>, String> {
     Ok(model_manager.get_model_info(&model_id))
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn verify_transcription_provider_api_key(
+    provider_id: String,
+    api_key: String,
+) -> Result<(), String> {
+    match provider_id.as_str() {
+        ELEVENLABS_TRANSCRIPTION_PROVIDER_ID => {
+            tauri::async_runtime::spawn_blocking(move || elevenlabs_stt::verify_api_key(&api_key))
+                .await
+                .map_err(|error| error.to_string())?
+                .map_err(|error| error.to_string())
+        }
+        _ => Err(format!(
+            "Unsupported remote transcription provider '{}'",
+            provider_id
+        )),
+    }
 }
 
 #[tauri::command]
@@ -102,6 +126,7 @@ pub fn switch_active_model(app: &AppHandle, model_id: &str) -> Result<(), String
     // when it reacts to events emitted by load_model.
     let mut settings = settings;
     settings.selected_model = model_id.to_string();
+    settings.transcription_provider_id = LOCAL_TRANSCRIPTION_PROVIDER_ID.to_string();
 
     // Reset language to auto if the new model doesn't support the currently selected language.
     // This prevents stale language settings from causing errors (e.g. Canary receiving zh-Hans)
@@ -193,20 +218,43 @@ pub async fn is_model_loading(
 #[tauri::command]
 #[specta::specta]
 pub async fn has_any_models_available(
+    app_handle: AppHandle,
     model_manager: State<'_, Arc<ModelManager>>,
 ) -> Result<bool, String> {
     let models = model_manager.get_available_models();
-    Ok(models.iter().any(|m| m.is_downloaded))
+    if models.iter().any(|m| m.is_downloaded) {
+        return Ok(true);
+    }
+
+    let settings = get_settings(&app_handle);
+    let has_elevenlabs = settings
+        .transcription_api_keys
+        .get(ELEVENLABS_TRANSCRIPTION_PROVIDER_ID)
+        .map(|api_key| !api_key.trim().is_empty())
+        .unwrap_or(false);
+
+    Ok(has_elevenlabs)
 }
 
 #[tauri::command]
 #[specta::specta]
 pub async fn has_any_models_or_downloads(
+    app_handle: AppHandle,
     model_manager: State<'_, Arc<ModelManager>>,
 ) -> Result<bool, String> {
     let models = model_manager.get_available_models();
-    // Return true if any models are downloaded OR if any downloads are in progress
-    Ok(models.iter().any(|m| m.is_downloaded))
+    if models.iter().any(|m| m.is_downloaded || m.is_downloading) {
+        return Ok(true);
+    }
+
+    let settings = get_settings(&app_handle);
+    let has_elevenlabs = settings
+        .transcription_api_keys
+        .get(ELEVENLABS_TRANSCRIPTION_PROVIDER_ID)
+        .map(|api_key| !api_key.trim().is_empty())
+        .unwrap_or(false);
+
+    Ok(has_elevenlabs)
 }
 
 #[tauri::command]

--- a/src-tauri/src/elevenlabs_stt.rs
+++ b/src-tauri/src/elevenlabs_stt.rs
@@ -1,0 +1,350 @@
+use crate::settings::{
+    AppSettings, ELEVENLABS_DEFAULT_MODEL_ID, ELEVENLABS_TRANSCRIPTION_PROVIDER_ID,
+};
+use anyhow::{bail, Context, Result};
+use hound::{SampleFormat, WavSpec, WavWriter};
+use reqwest::blocking::multipart::{Form, Part};
+use reqwest::blocking::Client;
+use reqwest::{Error as ReqwestError, StatusCode};
+use serde::Deserialize;
+use serde_json::Value;
+use std::io::Cursor;
+use std::time::Duration;
+
+const ELEVENLABS_SPEECH_TO_TEXT_URL: &str = "https://api.elevenlabs.io/v1/speech-to-text";
+const ELEVENLABS_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const ELEVENLABS_REQUEST_TIMEOUT: Duration = Duration::from_secs(90);
+const ELEVENLABS_PERMISSION_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+const ELEVENLABS_PERMISSION_PROBE_SAMPLES: usize = 1_600;
+const MAX_KEYTERMS: usize = 1000;
+
+#[derive(Deserialize)]
+struct ElevenLabsTranscriptionResponse {
+    text: String,
+}
+
+pub fn verify_api_key(api_key: &str) -> Result<()> {
+    let api_key = api_key.trim();
+
+    if api_key.is_empty() {
+        bail!("Enter your ElevenLabs API key.");
+    }
+
+    let wav_bytes = encode_wav(&vec![0.0; ELEVENLABS_PERMISSION_PROBE_SAMPLES])?;
+    let audio_part = Part::bytes(wav_bytes)
+        .file_name("permission-probe.wav")
+        .mime_str("audio/wav")
+        .context("Failed to prepare ElevenLabs verification payload")?;
+
+    let form = Form::new()
+        .text("model_id", ELEVENLABS_DEFAULT_MODEL_ID.to_string())
+        .part("file", audio_part);
+
+    let client = build_client(ELEVENLABS_PERMISSION_PROBE_TIMEOUT)?;
+    let response = client
+        .post(ELEVENLABS_SPEECH_TO_TEXT_URL)
+        .header("xi-api-key", api_key)
+        .multipart(form)
+        .send()
+        .map_err(|error| anyhow::anyhow!(build_request_error_message(&error)))?;
+
+    let status = response.status();
+    let body = response
+        .text()
+        .context("Failed to read ElevenLabs verification response body")?;
+
+    if matches!(status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN) {
+        bail!("{}", build_error_message(status, &body));
+    }
+
+    if status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error() {
+        bail!("{}", build_error_message(status, &body));
+    }
+
+    if matches!(
+        status,
+        StatusCode::BAD_REQUEST
+            | StatusCode::UNSUPPORTED_MEDIA_TYPE
+            | StatusCode::UNPROCESSABLE_ENTITY
+    ) {
+        return Ok(());
+    }
+
+    if !status.is_success() {
+        bail!("{}", build_error_message(status, &body));
+    }
+
+    Ok(())
+}
+
+pub fn transcribe(audio: &[f32], settings: &AppSettings) -> Result<String> {
+    let api_key = settings
+        .transcription_api_keys
+        .get(ELEVENLABS_TRANSCRIPTION_PROVIDER_ID)
+        .map(String::as_str)
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+
+    if api_key.is_empty() {
+        bail!(
+            "ElevenLabs API key is missing. Add it in Settings > Models > External Speech-to-Text Providers."
+        );
+    }
+
+    let wav_bytes = encode_wav(audio)?;
+    let audio_part = Part::bytes(wav_bytes)
+        .file_name("handy-recording.wav")
+        .mime_str("audio/wav")
+        .context("Failed to prepare ElevenLabs audio payload")?;
+
+    let mut form = Form::new()
+        .text("model_id", ELEVENLABS_DEFAULT_MODEL_ID.to_string())
+        .part("file", audio_part);
+
+    if let Some(language_code) = normalize_language_code(&settings.selected_language) {
+        form = form.text("language_code", language_code);
+    }
+
+    for keyterm in collect_keyterms(&settings.custom_words) {
+        form = form.text("keyterms", keyterm);
+    }
+
+    let client = build_client(ELEVENLABS_REQUEST_TIMEOUT)?;
+
+    let response = client
+        .post(ELEVENLABS_SPEECH_TO_TEXT_URL)
+        .header("xi-api-key", api_key)
+        .multipart(form)
+        .send()
+        .map_err(|error| anyhow::anyhow!(build_request_error_message(&error)))?;
+
+    let status = response.status();
+    let body = response
+        .text()
+        .context("Failed to read ElevenLabs response body")?;
+
+    if !status.is_success() {
+        bail!("{}", build_error_message(status, &body));
+    }
+
+    let payload: ElevenLabsTranscriptionResponse =
+        serde_json::from_str(&body).context("Failed to parse ElevenLabs response")?;
+
+    Ok(payload.text.trim().to_string())
+}
+
+fn build_client(timeout: Duration) -> Result<Client> {
+    Client::builder()
+        .connect_timeout(ELEVENLABS_CONNECT_TIMEOUT)
+        .timeout(timeout)
+        .build()
+        .context("Failed to create ElevenLabs HTTP client")
+}
+
+fn encode_wav(audio: &[f32]) -> Result<Vec<u8>> {
+    let spec = WavSpec {
+        channels: 1,
+        sample_rate: 16_000,
+        bits_per_sample: 16,
+        sample_format: SampleFormat::Int,
+    };
+
+    let mut cursor = Cursor::new(Vec::new());
+    {
+        let mut writer =
+            WavWriter::new(&mut cursor, spec).context("Failed to create WAV encoder")?;
+
+        for sample in audio {
+            let sample = sample.clamp(-1.0, 1.0);
+            writer
+                .write_sample((sample * i16::MAX as f32) as i16)
+                .context("Failed to encode WAV sample")?;
+        }
+
+        writer
+            .finalize()
+            .context("Failed to finalize WAV payload")?;
+    }
+
+    Ok(cursor.into_inner())
+}
+
+fn normalize_language_code(language: &str) -> Option<String> {
+    match language.trim() {
+        "" | "auto" => None,
+        "zh-Hans" | "zh-Hant" => Some("zh".to_string()),
+        "jw" => Some("jv".to_string()),
+        language => Some(language.to_string()),
+    }
+}
+
+fn collect_keyterms(custom_words: &[String]) -> Vec<String> {
+    custom_words
+        .iter()
+        .map(|term| term.trim())
+        .filter(|term| !term.is_empty())
+        .take(MAX_KEYTERMS)
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn build_error_message(status: StatusCode, body: &str) -> String {
+    let detail = extract_provider_detail(body);
+
+    if matches!(status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN) {
+        if is_missing_speech_to_text_permission(body) {
+            return "ElevenLabs API key is missing speech-to-text permissions.".to_string();
+        }
+
+        if let Some(detail) = detail {
+            return format!("ElevenLabs authentication failed: {}", detail);
+        }
+
+        return "ElevenLabs authentication failed. Check the configured API key.".to_string();
+    }
+
+    if status == StatusCode::TOO_MANY_REQUESTS {
+        return detail
+            .map(|detail| format!("ElevenLabs rate limit exceeded: {}", detail))
+            .unwrap_or_else(|| "ElevenLabs rate limit exceeded.".to_string());
+    }
+
+    if status.is_server_error() {
+        return detail
+            .map(|detail| format!("ElevenLabs is currently unavailable: {}", detail))
+            .unwrap_or_else(|| {
+                "ElevenLabs is currently unavailable. Please try again in a moment.".to_string()
+            });
+    }
+
+    detail
+        .map(|detail| {
+            format!(
+                "ElevenLabs request failed ({}): {}",
+                status.as_u16(),
+                detail
+            )
+        })
+        .unwrap_or_else(|| format!("ElevenLabs request failed with status {}.", status.as_u16()))
+}
+
+fn build_request_error_message(error: &ReqwestError) -> String {
+    if error.is_timeout() {
+        return "ElevenLabs request timed out. Please try again.".to_string();
+    }
+
+    if error.is_connect() {
+        return "Couldn't reach ElevenLabs. Check your internet connection and try again."
+            .to_string();
+    }
+
+    format!("Failed to reach ElevenLabs speech-to-text API: {}", error)
+}
+
+fn extract_provider_detail(body: &str) -> Option<String> {
+    let value = serde_json::from_str::<Value>(body).ok()?;
+
+    match value.get("detail") {
+        Some(Value::String(message)) => Some(message.clone()),
+        Some(Value::Object(detail)) => detail
+            .get("message")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        _ => None,
+    }
+    .or_else(|| {
+        let trimmed = body.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    })
+}
+
+fn is_missing_speech_to_text_permission(body: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<Value>(body) else {
+        return false;
+    };
+
+    let Some(detail) = value.get("detail").and_then(Value::as_object) else {
+        return false;
+    };
+
+    let Some(status) = detail.get("status").and_then(Value::as_str) else {
+        return false;
+    };
+    let Some(message) = detail.get("message").and_then(Value::as_str) else {
+        return false;
+    };
+
+    status == "missing_permissions" && message.contains("speech_to_text")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_error_message, collect_keyterms, is_missing_speech_to_text_permission,
+        normalize_language_code,
+    };
+    use reqwest::StatusCode;
+
+    #[test]
+    fn language_code_normalization_handles_auto_and_chinese() {
+        assert_eq!(normalize_language_code("auto"), None);
+        assert_eq!(normalize_language_code("zh-Hans"), Some("zh".to_string()));
+        assert_eq!(normalize_language_code("zh-Hant"), Some("zh".to_string()));
+        assert_eq!(normalize_language_code("de"), Some("de".to_string()));
+    }
+
+    #[test]
+    fn collect_keyterms_ignores_blank_entries() {
+        let keyterms =
+            collect_keyterms(&["alpha".to_string(), "  ".to_string(), "beta".to_string()]);
+
+        assert_eq!(keyterms, vec!["alpha".to_string(), "beta".to_string()]);
+    }
+
+    #[test]
+    fn build_error_message_detects_missing_speech_to_text_permission() {
+        let body = r#"{
+          "detail": {
+            "status": "missing_permissions",
+            "message": "missing permission: speech_to_text"
+          }
+        }"#;
+
+        assert!(is_missing_speech_to_text_permission(body));
+        assert_eq!(
+            build_error_message(StatusCode::FORBIDDEN, body),
+            "ElevenLabs API key is missing speech-to-text permissions."
+        );
+    }
+
+    #[test]
+    fn build_error_message_surfaces_authentication_detail() {
+        let body = r#"{"detail":"invalid api key"}"#;
+
+        assert_eq!(
+            build_error_message(StatusCode::UNAUTHORIZED, body),
+            "ElevenLabs authentication failed: invalid api key"
+        );
+    }
+
+    #[test]
+    fn build_error_message_surfaces_rate_limit_detail() {
+        let body = r#"{"detail":"quota exceeded"}"#;
+
+        assert_eq!(
+            build_error_message(StatusCode::TOO_MANY_REQUESTS, body),
+            "ElevenLabs rate limit exceeded: quota exceeded"
+        );
+    }
+
+    #[test]
+    fn build_error_message_surfaces_provider_unavailability() {
+        let body = r#"{"detail":"temporary outage"}"#;
+
+        assert_eq!(
+            build_error_message(StatusCode::BAD_GATEWAY, body),
+            "ElevenLabs is currently unavailable: temporary outage"
+        );
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ pub mod audio_toolkit;
 pub mod cli;
 mod clipboard;
 mod commands;
+mod elevenlabs_stt;
 mod helpers;
 mod input;
 mod llm_client;
@@ -348,6 +349,8 @@ pub fn run(cli_args: CliArgs) {
             shortcut::change_auto_submit_key_setting,
             shortcut::change_post_process_enabled_setting,
             shortcut::change_experimental_enabled_setting,
+            shortcut::change_transcription_provider_setting,
+            shortcut::change_transcription_api_key_setting,
             shortcut::change_post_process_base_url_setting,
             shortcut::change_post_process_api_key_setting,
             shortcut::change_post_process_model_setting,
@@ -391,6 +394,7 @@ pub fn run(cli_args: CliArgs) {
             commands::initialize_shortcuts,
             commands::models::get_available_models,
             commands::models::get_model_info,
+            commands::models::verify_transcription_provider_api_key,
             commands::models::download_model,
             commands::models::delete_model,
             commands::models::cancel_download,

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -1,8 +1,10 @@
 use crate::audio_toolkit::{apply_custom_words, filter_transcription_output};
+use crate::elevenlabs_stt;
 use crate::managers::audio::AudioRecordingManager;
 use crate::managers::model::{EngineType, ModelManager};
 use crate::settings::{
     get_settings, ModelUnloadTimeout, OrtAcceleratorSetting, WhisperAcceleratorSetting,
+    ELEVENLABS_TRANSCRIPTION_PROVIDER_ID,
 };
 use anyhow::Result;
 use log::{debug, error, info, warn};
@@ -414,6 +416,13 @@ impl TranscriptionManager {
 
     /// Kicks off the model loading in a background thread if it's not already loaded
     pub fn initiate_model_load(&self) {
+        let settings = get_settings(&self.app_handle);
+        if !settings.uses_local_transcription_provider()
+            || settings.selected_model.trim().is_empty()
+        {
+            return;
+        }
+
         let mut is_loading = self.is_loading.lock().unwrap();
         if *is_loading || self.is_model_loaded() {
             return;
@@ -422,7 +431,6 @@ impl TranscriptionManager {
         *is_loading = true;
         let self_clone = self.clone();
         thread::spawn(move || {
-            let settings = get_settings(&self_clone.app_handle);
             if let Err(e) = self_clone.load_model(&settings.selected_model) {
                 error!("Failed to load model: {}", e);
             }
@@ -458,6 +466,44 @@ impl TranscriptionManager {
             return Ok(String::new());
         }
 
+        // Get current settings for configuration
+        let settings = get_settings(&self.app_handle);
+
+        if !settings.uses_local_transcription_provider() {
+            let raw_result = match settings.transcription_provider_id.as_str() {
+                ELEVENLABS_TRANSCRIPTION_PROVIDER_ID => {
+                    elevenlabs_stt::transcribe(&audio, &settings)?
+                }
+                other => {
+                    return Err(anyhow::anyhow!(
+                        "Unsupported transcription provider configured: {}",
+                        other
+                    ));
+                }
+            };
+
+            let filtered_result = filter_transcription_output(
+                &raw_result,
+                &settings.app_language,
+                &settings.custom_filler_words,
+            );
+
+            let et = std::time::Instant::now();
+            info!(
+                "Transcription completed in {}ms via {}",
+                (et - st).as_millis(),
+                settings.transcription_provider_id
+            );
+
+            if filtered_result.is_empty() {
+                info!("Transcription result is empty");
+            } else {
+                info!("Transcription result: {}", filtered_result);
+            }
+
+            return Ok(filtered_result);
+        }
+
         // Check if model is loaded, if not try to load it
         {
             // If the model is loading, wait for it to complete.
@@ -471,9 +517,6 @@ impl TranscriptionManager {
                 return Err(anyhow::anyhow!("Model is not loaded for transcription."));
             }
         }
-
-        // Get current settings for configuration
-        let settings = get_settings(&self.app_handle);
 
         // Validate selected language against the model's supported languages.
         // If the language isn't supported, fall back to "auto" to prevent errors.

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -1,6 +1,8 @@
 use crate::input;
 use crate::settings;
 use crate::settings::OverlayPosition;
+use serde::Serialize;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tauri::{AppHandle, Emitter, Manager, PhysicalPosition, PhysicalSize};
 
 #[cfg(not(target_os = "macos"))]
@@ -32,6 +34,14 @@ tauri_panel! {
 
 const OVERLAY_WIDTH: f64 = 172.0;
 const OVERLAY_HEIGHT: f64 = 36.0;
+const OVERLAY_ERROR_WIDTH: f64 = 360.0;
+const OVERLAY_ERROR_HEIGHT: f64 = 56.0;
+static OVERLAY_VISIBILITY_TOKEN: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, Serialize)]
+struct OverlayErrorPayload {
+    message: String,
+}
 
 #[cfg(target_os = "macos")]
 const OVERLAY_TOP_OFFSET: f64 = 46.0;
@@ -194,7 +204,11 @@ fn is_mouse_within_monitor(
 /// We must use LogicalPosition (not PhysicalPosition) because Tauri/tao
 /// converts PhysicalPosition using the scale factor of the monitor the window
 /// is *currently* on, which is wrong when moving cross-monitor.
-fn calculate_overlay_position(app_handle: &AppHandle) -> Option<(f64, f64)> {
+fn calculate_overlay_position_for_size(
+    app_handle: &AppHandle,
+    width: f64,
+    height: f64,
+) -> Option<(f64, f64)> {
     let monitor = get_monitor_with_cursor(app_handle)?;
     let scale = monitor.scale_factor();
     let monitor_x = monitor.position().x as f64 / scale;
@@ -204,15 +218,34 @@ fn calculate_overlay_position(app_handle: &AppHandle) -> Option<(f64, f64)> {
 
     let settings = settings::get_settings(app_handle);
 
-    let x = monitor_x + (monitor_width - OVERLAY_WIDTH) / 2.0;
+    let x = monitor_x + (monitor_width - width) / 2.0;
     let y = match settings.overlay_position {
         OverlayPosition::Top => monitor_y + OVERLAY_TOP_OFFSET,
         OverlayPosition::Bottom | OverlayPosition::None => {
-            monitor_y + monitor_height - OVERLAY_HEIGHT - OVERLAY_BOTTOM_OFFSET
+            monitor_y + monitor_height - height - OVERLAY_BOTTOM_OFFSET
         }
     };
 
     Some((x, y))
+}
+
+fn calculate_overlay_position(app_handle: &AppHandle) -> Option<(f64, f64)> {
+    calculate_overlay_position_for_size(app_handle, OVERLAY_WIDTH, OVERLAY_HEIGHT)
+}
+
+fn next_overlay_token() -> u64 {
+    OVERLAY_VISIBILITY_TOKEN.fetch_add(1, Ordering::Relaxed) + 1
+}
+
+fn resize_overlay_window(app_handle: &AppHandle, width: f64, height: f64) {
+    if let Some(overlay_window) = app_handle.get_webview_window("recording_overlay") {
+        let _ = overlay_window.set_size(tauri::Size::Logical(tauri::LogicalSize { width, height }));
+
+        if let Some((x, y)) = calculate_overlay_position_for_size(app_handle, width, height) {
+            let _ = overlay_window
+                .set_position(tauri::Position::Logical(tauri::LogicalPosition { x, y }));
+        }
+    }
 }
 
 /// Creates the recording overlay window and keeps it hidden by default
@@ -320,7 +353,8 @@ fn show_overlay_state(app_handle: &AppHandle, state: &str) {
         return;
     }
 
-    update_overlay_position(app_handle);
+    let _token = next_overlay_token();
+    resize_overlay_window(app_handle, OVERLAY_WIDTH, OVERLAY_HEIGHT);
 
     if let Some(overlay_window) = app_handle.get_webview_window("recording_overlay") {
         let _ = overlay_window.show();
@@ -348,6 +382,39 @@ pub fn show_processing_overlay(app_handle: &AppHandle) {
     show_overlay_state(app_handle, "processing");
 }
 
+pub fn show_error_overlay(app_handle: &AppHandle, message: String) {
+    let settings = settings::get_settings(app_handle);
+    if settings.overlay_position == OverlayPosition::None {
+        return;
+    }
+
+    let token = next_overlay_token();
+    resize_overlay_window(app_handle, OVERLAY_ERROR_WIDTH, OVERLAY_ERROR_HEIGHT);
+
+    if let Some(overlay_window) = app_handle.get_webview_window("recording_overlay") {
+        let _ = overlay_window.show();
+
+        #[cfg(target_os = "windows")]
+        force_overlay_topmost(&overlay_window);
+
+        let _ = overlay_window.emit("show-overlay-error", OverlayErrorPayload { message });
+
+        let window_clone = overlay_window.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(3200));
+            if OVERLAY_VISIBILITY_TOKEN.load(Ordering::Relaxed) != token {
+                return;
+            }
+            let _ = window_clone.emit("hide-overlay", ());
+            std::thread::sleep(std::time::Duration::from_millis(300));
+            if OVERLAY_VISIBILITY_TOKEN.load(Ordering::Relaxed) != token {
+                return;
+            }
+            let _ = window_clone.hide();
+        });
+    }
+}
+
 /// Updates the overlay window position based on current settings
 pub fn update_overlay_position(app_handle: &AppHandle) {
     if let Some(overlay_window) = app_handle.get_webview_window("recording_overlay") {
@@ -365,6 +432,7 @@ pub fn update_overlay_position(app_handle: &AppHandle) {
 
 /// Hides the recording overlay window with fade-out animation
 pub fn hide_recording_overlay(app_handle: &AppHandle) {
+    let token = next_overlay_token();
     // Always hide the overlay regardless of settings - if setting was changed while recording,
     // we still want to hide it properly
     if let Some(overlay_window) = app_handle.get_webview_window("recording_overlay") {
@@ -374,6 +442,9 @@ pub fn hide_recording_overlay(app_handle: &AppHandle) {
         let window_clone = overlay_window.clone();
         std::thread::spawn(move || {
             std::thread::sleep(std::time::Duration::from_millis(300));
+            if OVERLAY_VISIBILITY_TOKEN.load(Ordering::Relaxed) != token {
+                return;
+            }
             let _ = window_clone.hide();
         });
     }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -9,6 +9,9 @@ use tauri_plugin_store::StoreExt;
 
 pub const APPLE_INTELLIGENCE_PROVIDER_ID: &str = "apple_intelligence";
 pub const APPLE_INTELLIGENCE_DEFAULT_MODEL_ID: &str = "Apple Intelligence";
+pub const LOCAL_TRANSCRIPTION_PROVIDER_ID: &str = "local";
+pub const ELEVENLABS_TRANSCRIPTION_PROVIDER_ID: &str = "elevenlabs";
+pub const ELEVENLABS_DEFAULT_MODEL_ID: &str = "scribe_v2";
 
 #[derive(Serialize, Debug, Clone, Copy, PartialEq, Eq, Type)]
 #[serde(rename_all = "lowercase")]
@@ -351,6 +354,10 @@ pub struct AppSettings {
     pub update_checks_enabled: bool,
     #[serde(default = "default_model")]
     pub selected_model: String,
+    #[serde(default = "default_transcription_provider_id")]
+    pub transcription_provider_id: String,
+    #[serde(default = "default_transcription_api_keys")]
+    pub transcription_api_keys: SecretMap,
     #[serde(default = "default_always_on_microphone")]
     pub always_on_microphone: bool,
     #[serde(default)]
@@ -434,6 +441,19 @@ pub struct AppSettings {
 
 fn default_model() -> String {
     "".to_string()
+}
+
+fn default_transcription_provider_id() -> String {
+    LOCAL_TRANSCRIPTION_PROVIDER_ID.to_string()
+}
+
+fn default_transcription_api_keys() -> SecretMap {
+    let mut map = HashMap::new();
+    map.insert(
+        ELEVENLABS_TRANSCRIPTION_PROVIDER_ID.to_string(),
+        String::new(),
+    );
+    SecretMap(map)
 }
 
 fn default_always_on_microphone() -> bool {
@@ -700,6 +720,30 @@ fn ensure_post_process_defaults(settings: &mut AppSettings) -> bool {
     changed
 }
 
+fn ensure_transcription_defaults(settings: &mut AppSettings) -> bool {
+    let mut changed = false;
+
+    if settings.transcription_provider_id != LOCAL_TRANSCRIPTION_PROVIDER_ID
+        && settings.transcription_provider_id != ELEVENLABS_TRANSCRIPTION_PROVIDER_ID
+    {
+        settings.transcription_provider_id = default_transcription_provider_id();
+        changed = true;
+    }
+
+    if !settings
+        .transcription_api_keys
+        .contains_key(ELEVENLABS_TRANSCRIPTION_PROVIDER_ID)
+    {
+        settings.transcription_api_keys.insert(
+            ELEVENLABS_TRANSCRIPTION_PROVIDER_ID.to_string(),
+            String::new(),
+        );
+        changed = true;
+    }
+
+    changed
+}
+
 pub const SETTINGS_STORE_PATH: &str = "settings_store.json";
 
 pub fn get_default_settings() -> AppSettings {
@@ -764,6 +808,8 @@ pub fn get_default_settings() -> AppSettings {
         autostart_enabled: default_autostart_enabled(),
         update_checks_enabled: default_update_checks_enabled(),
         selected_model: "".to_string(),
+        transcription_provider_id: default_transcription_provider_id(),
+        transcription_api_keys: default_transcription_api_keys(),
         always_on_microphone: false,
         selected_microphone: None,
         clamshell_microphone: None,
@@ -808,6 +854,10 @@ pub fn get_default_settings() -> AppSettings {
 }
 
 impl AppSettings {
+    pub fn uses_local_transcription_provider(&self) -> bool {
+        self.transcription_provider_id == LOCAL_TRANSCRIPTION_PROVIDER_ID
+    }
+
     pub fn active_post_process_provider(&self) -> Option<&PostProcessProvider> {
         self.post_process_providers
             .iter()
@@ -874,7 +924,7 @@ pub fn load_or_create_app_settings(app: &AppHandle) -> AppSettings {
         default_settings
     };
 
-    if ensure_post_process_defaults(&mut settings) {
+    if ensure_post_process_defaults(&mut settings) | ensure_transcription_defaults(&mut settings) {
         store.set("settings", serde_json::to_value(&settings).unwrap());
     }
 
@@ -898,7 +948,7 @@ pub fn get_settings(app: &AppHandle) -> AppSettings {
         default_settings
     };
 
-    if ensure_post_process_defaults(&mut settings) {
+    if ensure_post_process_defaults(&mut settings) | ensure_transcription_defaults(&mut settings) {
         store.set("settings", serde_json::to_value(&settings).unwrap());
     }
 
@@ -954,6 +1004,10 @@ mod tests {
         settings
             .post_process_api_keys
             .insert("openai".to_string(), "sk-proj-secret-key-12345".to_string());
+        settings.transcription_api_keys.insert(
+            ELEVENLABS_TRANSCRIPTION_PROVIDER_ID.to_string(),
+            "el-secret-key-12345".to_string(),
+        );
         settings.post_process_api_keys.insert(
             "anthropic".to_string(),
             "sk-ant-secret-key-67890".to_string(),
@@ -966,6 +1020,7 @@ mod tests {
 
         assert!(!debug_output.contains("sk-proj-secret-key-12345"));
         assert!(!debug_output.contains("sk-ant-secret-key-67890"));
+        assert!(!debug_output.contains("el-secret-key-12345"));
         assert!(debug_output.contains("[REDACTED]"));
     }
 
@@ -975,5 +1030,17 @@ mod tests {
         let out = format!("{:?}", map);
         assert!(!out.contains("secret"));
         assert!(out.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn transcription_defaults_include_elevenlabs() {
+        let settings = get_default_settings();
+        assert_eq!(
+            settings.transcription_provider_id,
+            LOCAL_TRANSCRIPTION_PROVIDER_ID
+        );
+        assert!(settings
+            .transcription_api_keys
+            .contains_key(ELEVENLABS_TRANSCRIPTION_PROVIDER_ID));
     }
 }

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -16,15 +16,18 @@ mod tauri_impl;
 use log::{error, info, warn};
 use serde::Serialize;
 use specta::Type;
+use std::sync::Arc;
 use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_autostart::ManagerExt;
 
+use crate::managers::transcription::TranscriptionManager;
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 use crate::settings::APPLE_INTELLIGENCE_DEFAULT_MODEL_ID;
 use crate::settings::{
     self, get_settings, AutoSubmitKey, ClipboardHandling, KeyboardImplementation, LLMPrompt,
     OverlayPosition, PasteMethod, ShortcutBinding, SoundTheme, TypingTool,
-    APPLE_INTELLIGENCE_PROVIDER_ID,
+    APPLE_INTELLIGENCE_PROVIDER_ID, ELEVENLABS_TRANSCRIPTION_PROVIDER_ID,
+    LOCAL_TRANSCRIPTION_PROVIDER_ID,
 };
 use crate::tray;
 
@@ -820,6 +823,67 @@ pub fn change_post_process_enabled_setting(app: AppHandle, enabled: bool) -> Res
 pub fn change_experimental_enabled_setting(app: AppHandle, enabled: bool) -> Result<(), String> {
     let mut settings = settings::get_settings(&app);
     settings.experimental_enabled = enabled;
+    settings::write_settings(&app, settings);
+    Ok(())
+}
+
+fn validate_transcription_provider(provider_id: &str) -> Result<(), String> {
+    match provider_id {
+        LOCAL_TRANSCRIPTION_PROVIDER_ID | ELEVENLABS_TRANSCRIPTION_PROVIDER_ID => Ok(()),
+        _ => Err(format!(
+            "Unsupported transcription provider '{}'",
+            provider_id
+        )),
+    }
+}
+
+fn validate_remote_transcription_provider(provider_id: &str) -> Result<(), String> {
+    match provider_id {
+        ELEVENLABS_TRANSCRIPTION_PROVIDER_ID => Ok(()),
+        _ => Err(format!(
+            "Unsupported remote transcription provider '{}'",
+            provider_id
+        )),
+    }
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn change_transcription_provider_setting(
+    app: AppHandle,
+    provider_id: String,
+) -> Result<(), String> {
+    validate_transcription_provider(&provider_id)?;
+
+    let mut settings = settings::get_settings(&app);
+    settings.transcription_provider_id = provider_id.clone();
+    settings::write_settings(&app, settings);
+
+    if provider_id != LOCAL_TRANSCRIPTION_PROVIDER_ID {
+        if let Some(transcription_manager) = app.try_state::<Arc<TranscriptionManager>>() {
+            if let Err(error) = transcription_manager.unload_model() {
+                warn!(
+                    "Failed to unload local model after switching transcription provider: {}",
+                    error
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn change_transcription_api_key_setting(
+    app: AppHandle,
+    provider_id: String,
+    api_key: String,
+) -> Result<(), String> {
+    validate_remote_transcription_provider(&provider_id)?;
+
+    let mut settings = settings::get_settings(&app);
+    settings.transcription_api_keys.insert(provider_id, api_key);
     settings::write_settings(&app, settings);
     Ok(())
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,11 @@ import {
   checkAccessibilityPermission,
   checkMicrophonePermission,
 } from "tauri-plugin-macos-permissions-api";
-import { ModelStateEvent, RecordingErrorEvent } from "./lib/types/events";
+import {
+  ModelStateEvent,
+  RecordingErrorEvent,
+  TranscriptionErrorEvent,
+} from "./lib/types/events";
 import "./App.css";
 import AccessibilityPermissions from "./components/AccessibilityPermissions";
 import Footer from "./components/footer";
@@ -137,6 +141,21 @@ function App() {
         );
       }
     });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [t]);
+
+  useEffect(() => {
+    const unlisten = listen<TranscriptionErrorEvent>(
+      "transcription-error",
+      (event) => {
+        toast.error(t("errors.transcriptionFailedTitle"), {
+          description:
+            event.payload.detail || t("errors.transcriptionFailedDefault"),
+        });
+      },
+    );
     return () => {
       unlisten.then((fn) => fn());
     };

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -192,6 +192,22 @@ async changeExperimentalEnabledSetting(enabled: boolean) : Promise<Result<null, 
     else return { status: "error", error: e  as any };
 }
 },
+async changeTranscriptionProviderSetting(providerId: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("change_transcription_provider_setting", { providerId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async changeTranscriptionApiKeySetting(providerId: string, apiKey: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("change_transcription_api_key_setting", { providerId, apiKey }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async changePostProcessBaseUrlSetting(providerId: string, baseUrl: string) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("change_post_process_base_url_setting", { providerId, baseUrl }) };
@@ -827,7 +843,7 @@ historyUpdatePayload: "history-update-payload"
 
 /** user-defined types **/
 
-export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk: boolean; audio_feedback: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; selected_model?: string; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: SecretMap; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; experimental_enabled?: boolean; lazy_stream_close?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool; external_script_path: string | null; custom_filler_words?: string[] | null; whisper_accelerator?: WhisperAcceleratorSetting; ort_accelerator?: OrtAcceleratorSetting; whisper_gpu_device?: number; extra_recording_buffer_ms?: number }
+export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk: boolean; audio_feedback: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; selected_model?: string; transcription_provider_id?: string; transcription_api_keys?: SecretMap; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: SecretMap; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; experimental_enabled?: boolean; lazy_stream_close?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool; external_script_path: string | null; custom_filler_words?: string[] | null; whisper_accelerator?: WhisperAcceleratorSetting; ort_accelerator?: OrtAcceleratorSetting; whisper_gpu_device?: number; extra_recording_buffer_ms?: number }
 export type AudioDevice = { index: string; name: string; is_default: boolean }
 export type AutoSubmitKey = "enter" | "ctrl_enter" | "cmd_enter"
 export type AvailableAccelerators = { whisper: string[]; ort: string[]; gpu_devices: GpuDeviceOption[] }

--- a/src/components/model-selector/ModelDropdown.tsx
+++ b/src/components/model-selector/ModelDropdown.tsx
@@ -9,12 +9,20 @@ import {
 interface ModelDropdownProps {
   models: ModelInfo[];
   currentModelId: string;
+  externalOption?: {
+    id: string;
+    label: string;
+    description: string;
+    isActive: boolean;
+    onSelect: () => void;
+  };
   onModelSelect: (modelId: string) => void;
 }
 
 const ModelDropdown: React.FC<ModelDropdownProps> = ({
   models,
   currentModelId,
+  externalOption,
   onModelSelect,
 }) => {
   const { t } = useTranslation();
@@ -26,6 +34,41 @@ const ModelDropdown: React.FC<ModelDropdownProps> = ({
 
   return (
     <div className="absolute bottom-full start-0 mb-2 w-64 max-h-[60vh] overflow-y-auto bg-background border border-mid-gray/20 rounded-lg shadow-lg py-2 z-50">
+      {externalOption && (
+        <div
+          onClick={externalOption.onSelect}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              externalOption.onSelect();
+            }
+          }}
+          tabIndex={0}
+          role="button"
+          className={`w-full px-3 py-2 text-start hover:bg-mid-gray/10 transition-colors cursor-pointer focus:outline-none ${
+            externalOption.isActive
+              ? "bg-logo-primary/10 text-logo-primary"
+              : ""
+          }`}
+        >
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="text-sm text-text/80">{externalOption.label}</div>
+              <div className="text-xs text-text/40 italic pe-4">
+                {externalOption.description}
+              </div>
+            </div>
+            {externalOption.isActive && (
+              <div className="text-xs text-logo-primary">
+                {t("modelSelector.active")}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+      {externalOption && downloadedModels.length > 0 && (
+        <div className="my-2 border-t border-mid-gray/20" />
+      )}
       {downloadedModels.length > 0 ? (
         <div>
           {downloadedModels.map((model) => (

--- a/src/components/model-selector/ModelSelector.tsx
+++ b/src/components/model-selector/ModelSelector.tsx
@@ -4,11 +4,18 @@ import { listen } from "@tauri-apps/api/event";
 import { commands } from "@/bindings";
 import { getTranslatedModelName } from "../../lib/utils/modelTranslation";
 import { useModelStore } from "../../stores/modelStore";
+import { useSettings } from "../../hooks/useSettings";
 import ModelStatusButton from "./ModelStatusButton";
 import ModelDropdown from "./ModelDropdown";
 import DownloadProgressDisplay from "./DownloadProgressDisplay";
 
 import { ModelStateEvent } from "@/lib/types/events";
+import {
+  ELEVENLABS_TRANSCRIPTION_PROVIDER_ID,
+  getActiveTranscriptionModelDisplayName,
+  getElevenLabsModelProfile,
+  hasTranscriptionProviderApiKey,
+} from "@/lib/utils/externalTranscriptionModel";
 
 type ModelStatus =
   | "ready"
@@ -26,6 +33,7 @@ interface ModelSelectorProps {
 
 const ModelSelector: React.FC<ModelSelectorProps> = ({ onError }) => {
   const { t } = useTranslation();
+  const { getSetting, updateSetting } = useSettings();
   const {
     models,
     currentModel,
@@ -43,12 +51,26 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ onError }) => {
   const [pendingModelId, setPendingModelId] = useState<string | null>(null);
 
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const transcriptionProviderId =
+    getSetting("transcription_provider_id") || "local";
+  const transcriptionApiKeys = getSetting("transcription_api_keys") || {};
+  const isElevenLabsSelected =
+    transcriptionProviderId === ELEVENLABS_TRANSCRIPTION_PROVIDER_ID;
+  const hasElevenLabsApiKey = hasTranscriptionProviderApiKey(
+    ELEVENLABS_TRANSCRIPTION_PROVIDER_ID,
+    transcriptionApiKeys,
+  );
 
   const displayModelId = pendingModelId || currentModel;
 
   // Check model status when currentModel changes
   useEffect(() => {
     const checkStatus = async () => {
+      if (isElevenLabsSelected) {
+        setModelStatus(hasElevenLabsApiKey ? "ready" : "none");
+        return;
+      }
+
       if (currentModel) {
         try {
           const statusResult = await commands.getTranscriptionModelStatus();
@@ -66,7 +88,7 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ onError }) => {
       }
     };
     checkStatus();
-  }, [currentModel]);
+  }, [currentModel, hasElevenLabsApiKey, isElevenLabsSelected]);
 
   useEffect(() => {
     // Listen for model loading lifecycle events
@@ -153,6 +175,22 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ onError }) => {
     }
   };
 
+  const handleExternalSelect = async () => {
+    setShowModelDropdown(false);
+    setModelError(null);
+    try {
+      await updateSetting(
+        "transcription_provider_id",
+        ELEVENLABS_TRANSCRIPTION_PROVIDER_ID,
+      );
+      setModelStatus(hasElevenLabsApiKey ? "ready" : "none");
+    } catch (error) {
+      setModelStatus("error");
+      setModelError(String(error));
+      onError?.("Failed to switch transcription provider");
+    }
+  };
+
   const getModelDisplayText = (): string => {
     const verifyingKeys = Object.keys(verifyingModels);
     if (verifyingKeys.length > 0) {
@@ -198,6 +236,15 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ onError }) => {
           count: progressValues.length,
         });
       }
+    }
+
+    if (isElevenLabsSelected) {
+      return hasElevenLabsApiKey
+        ? getActiveTranscriptionModelDisplayName(transcriptionProviderId) ||
+            getElevenLabsModelProfile().fullLabel
+        : t("settings.models.external.addApiKey", {
+            defaultValue: "ElevenLabs - Add API key",
+          });
     }
 
     const currentModelInfo = models.find((m) => m.id === displayModelId);
@@ -257,7 +304,21 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ onError }) => {
         {showModelDropdown && (
           <ModelDropdown
             models={models}
-            currentModelId={displayModelId}
+            currentModelId={isElevenLabsSelected ? "" : displayModelId}
+            externalOption={
+              hasElevenLabsApiKey || isElevenLabsSelected
+                ? {
+                    id: ELEVENLABS_TRANSCRIPTION_PROVIDER_ID,
+                    label:
+                      getActiveTranscriptionModelDisplayName(
+                        ELEVENLABS_TRANSCRIPTION_PROVIDER_ID,
+                      ) || getElevenLabsModelProfile().fullLabel,
+                    description: getElevenLabsModelProfile().description,
+                    isActive: isElevenLabsSelected,
+                    onSelect: handleExternalSelect,
+                  }
+                : undefined
+            }
             onModelSelect={handleModelSelect}
           />
         )}

--- a/src/components/settings/general/ModelSettingsCard.tsx
+++ b/src/components/settings/general/ModelSettingsCard.tsx
@@ -4,13 +4,34 @@ import { SettingsGroup } from "../../ui/SettingsGroup";
 import { LanguageSelector } from "../LanguageSelector";
 import { TranslateToEnglish } from "../TranslateToEnglish";
 import { useModelStore } from "../../../stores/modelStore";
+import { useSettings } from "../../../hooks/useSettings";
 import type { ModelInfo } from "@/bindings";
+import { getActiveTranscriptionModelDisplayName } from "@/lib/utils/externalTranscriptionModel";
 
 export const ModelSettingsCard: React.FC = () => {
   const { t } = useTranslation();
   const { currentModel, models } = useModelStore();
+  const { getSetting } = useSettings();
+  const transcriptionProviderId =
+    getSetting("transcription_provider_id") || "local";
+  const isElevenLabsSelected = transcriptionProviderId === "elevenlabs";
 
   const currentModelInfo = models.find((m: ModelInfo) => m.id === currentModel);
+
+  if (isElevenLabsSelected) {
+    return (
+      <SettingsGroup
+        title={t("settings.modelSettings.external.title", {
+          defaultValue: "{{model}} Settings",
+          model:
+            getActiveTranscriptionModelDisplayName(transcriptionProviderId) ||
+            "ElevenLabs",
+        })}
+      >
+        <LanguageSelector descriptionMode="tooltip" grouped={true} />
+      </SettingsGroup>
+    );
+  }
 
   const supportsLanguageSelection =
     currentModelInfo?.supports_language_selection ?? false;

--- a/src/components/settings/models/ExternalTranscriptionModelCard.tsx
+++ b/src/components/settings/models/ExternalTranscriptionModelCard.tsx
@@ -1,0 +1,308 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { Check, Cloud, Globe, Loader2, Pencil, Trash2 } from "lucide-react";
+import Badge from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import type { ExternalTranscriptionModelProfile } from "@/lib/utils/externalTranscriptionModel";
+
+interface ExternalTranscriptionModelCardProps {
+  profile: ExternalTranscriptionModelProfile;
+  isActive: boolean;
+  isInstalled: boolean;
+  savedApiKey: string;
+  apiKeySaving?: boolean;
+  apiKeyError?: string | null;
+  isSwitching?: boolean;
+  onSelect: () => void;
+  onSaveApiKey: (value: string) => Promise<void> | void;
+  onRemoveApiKey: () => Promise<void> | void;
+}
+
+export const ExternalTranscriptionModelCard: React.FC<
+  ExternalTranscriptionModelCardProps
+> = ({
+  profile,
+  isActive,
+  isInstalled,
+  savedApiKey,
+  apiKeySaving = false,
+  apiKeyError = null,
+  isSwitching = false,
+  onSelect,
+  onSaveApiKey,
+  onRemoveApiKey,
+}) => {
+  const { t } = useTranslation();
+  const [isEditing, setIsEditing] = React.useState(!isInstalled);
+  const [draftApiKey, setDraftApiKey] = React.useState(savedApiKey);
+
+  React.useEffect(() => {
+    setDraftApiKey(savedApiKey);
+  }, [savedApiKey]);
+
+  React.useEffect(() => {
+    if (!isInstalled) {
+      setIsEditing(true);
+      return;
+    }
+
+    if (savedApiKey.trim()) {
+      setIsEditing(false);
+    }
+  }, [isInstalled, savedApiKey]);
+
+  const isBusy = apiKeySaving || isSwitching;
+  const isClickable = isInstalled && !isActive && !isBusy && !isEditing;
+  const trimmedDraftApiKey = draftApiKey.trim();
+
+  const maskApiKey = (apiKey: string) => {
+    const trimmedApiKey = apiKey.trim();
+    if (!trimmedApiKey) {
+      return "";
+    }
+
+    const suffix = trimmedApiKey.slice(-4);
+    return `••••••••${suffix}`;
+  };
+
+  const handleClick = () => {
+    if (!isClickable) return;
+    onSelect();
+  };
+
+  const handleSave = async () => {
+    if (!trimmedDraftApiKey || isBusy) {
+      return;
+    }
+
+    await onSaveApiKey(trimmedDraftApiKey);
+  };
+
+  const handleCancelEdit = () => {
+    setDraftApiKey(savedApiKey);
+    setIsEditing(false);
+  };
+
+  return (
+    <div
+      onClick={handleClick}
+      onKeyDown={(event) => {
+        if (!isClickable) return;
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onSelect();
+        }
+      }}
+      role={isClickable ? "button" : undefined}
+      tabIndex={isClickable ? 0 : undefined}
+      className={[
+        "flex flex-col rounded-xl px-4 py-3 gap-2 text-left transition-all duration-200 border-2",
+        isActive
+          ? "border-logo-primary/50 bg-logo-primary/10"
+          : "border-mid-gray/20",
+        isClickable
+          ? "cursor-pointer hover:border-logo-primary/50 hover:bg-logo-primary/5 hover:shadow-lg hover:scale-[1.01] active:scale-[0.99] group"
+          : "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      <div className="flex justify-between items-center w-full">
+        <div className="flex flex-col items-start flex-1 min-w-0">
+          <div className="flex items-center gap-3 flex-wrap">
+            <h3
+              className={`text-base font-semibold text-text ${isClickable ? "group-hover:text-logo-primary" : ""} transition-colors`}
+            >
+              {profile.fullLabel}
+            </h3>
+            {isActive && (
+              <Badge variant="primary">
+                <Check className="w-3 h-3 mr-1" />
+                {t("modelSelector.active")}
+              </Badge>
+            )}
+            {isSwitching && (
+              <Badge variant="secondary">
+                <Loader2 className="w-3 h-3 mr-1 animate-spin" />
+                {t("modelSelector.switching")}
+              </Badge>
+            )}
+          </div>
+          <p className="text-text/60 text-sm leading-relaxed">
+            {profile.description}
+          </p>
+        </div>
+
+        <div className="hidden sm:flex items-center ms-4">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <p className="text-xs text-text/60 w-24 text-end">
+                {t("onboarding.modelCard.accuracy")}
+              </p>
+              <div className="w-16 h-1.5 bg-mid-gray/20 rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-logo-primary rounded-full"
+                  style={{ width: `${profile.accuracyScore * 100}%` }}
+                />
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <p className="text-xs text-text/60 w-24 text-end">
+                {t("onboarding.modelCard.speed")}
+              </p>
+              <div className="w-16 h-1.5 bg-mid-gray/20 rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-logo-primary rounded-full"
+                  style={{ width: `${profile.speedScore * 100}%` }}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <hr className="w-full border-mid-gray/20" />
+
+      <div className="flex items-center gap-3 w-full -mb-0.5 mt-0.5 min-h-5">
+        <div className="flex items-center gap-1 text-xs text-text/50">
+          <Globe className="w-3.5 h-3.5" />
+          <span>{t("modelSelector.capabilities.multiLanguage")}</span>
+        </div>
+        <div className="flex items-center gap-1 text-xs text-text/50 ms-auto">
+          <Cloud className="w-3.5 h-3.5" />
+          <span>
+            {t("settings.models.external.cloudStorage", {
+              defaultValue: "Cloud",
+            })}
+          </span>
+        </div>
+      </div>
+
+      <div
+        className="mt-2 pt-2 border-t border-mid-gray/20"
+        onClick={(event) => event.stopPropagation()}
+      >
+        {isInstalled && !isEditing ? (
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="min-w-0">
+              <p className="text-xs text-text/60">
+                {t("settings.models.external.apiKey.title", {
+                  defaultValue: "API key",
+                })}
+              </p>
+              <p className="text-sm font-medium text-text/80 tracking-[0.18em] truncate">
+                {maskApiKey(savedApiKey)}
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={isBusy}
+                className="flex items-center gap-1.5"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setIsEditing(true);
+                }}
+              >
+                <Pencil className="w-3.5 h-3.5" />
+                <span>{t("common.edit")}</span>
+              </Button>
+              <Button
+                type="button"
+                variant="danger-ghost"
+                size="sm"
+                disabled={isBusy}
+                className="flex items-center gap-1.5"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  void onRemoveApiKey();
+                }}
+              >
+                <Trash2 className="w-3.5 h-3.5" />
+                <span>{t("common.remove")}</span>
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            <p className="text-xs text-text/60">
+              {t("settings.models.external.apiKey.title", {
+                defaultValue: "API key",
+              })}
+            </p>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <Input
+                type="password"
+                value={draftApiKey}
+                onChange={(event) => setDraftApiKey(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    void handleSave();
+                  }
+                }}
+                disabled={isBusy}
+                placeholder={t("settings.models.external.apiKey.placeholder", {
+                  defaultValue: "Enter your ElevenLabs API key",
+                })}
+                className="flex-1 min-w-0 sm:min-w-[320px]"
+              />
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="primary-soft"
+                  size="sm"
+                  disabled={!trimmedDraftApiKey || isBusy}
+                  className="flex items-center gap-1.5"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    void handleSave();
+                  }}
+                >
+                  {apiKeySaving ? (
+                    <>
+                      <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                      <span>
+                        {t("settings.models.external.apiKey.verifying", {
+                          defaultValue: "Verifying...",
+                        })}
+                      </span>
+                    </>
+                  ) : (
+                    <span>
+                      {isInstalled
+                        ? t("common.save")
+                        : t("settings.models.external.addApiKey", {
+                            defaultValue: "Add API key",
+                          })}
+                    </span>
+                  )}
+                </Button>
+                {isInstalled && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    disabled={isBusy}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      handleCancelEdit();
+                    }}
+                  >
+                    {t("common.cancel")}
+                  </Button>
+                )}
+              </div>
+            </div>
+            {apiKeyError && (
+              <p className="text-xs text-red-400">{apiKeyError}</p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/settings/models/ModelsSettings.tsx
+++ b/src/components/settings/models/ModelsSettings.tsx
@@ -1,12 +1,20 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ask } from "@tauri-apps/plugin-dialog";
+import { invoke } from "@tauri-apps/api/core";
 import { ChevronDown, Globe } from "lucide-react";
 import type { ModelCardStatus } from "@/components/onboarding";
 import { ModelCard } from "@/components/onboarding";
+import { commands, type ModelInfo } from "@/bindings";
 import { useModelStore } from "@/stores/modelStore";
 import { LANGUAGES } from "@/lib/constants/languages.ts";
-import type { ModelInfo } from "@/bindings";
+import { useSettings } from "../../../hooks/useSettings";
+import { ExternalTranscriptionModelCard } from "./ExternalTranscriptionModelCard";
+import {
+  ELEVENLABS_TRANSCRIPTION_PROVIDER_ID,
+  getElevenLabsModelProfile,
+  hasTranscriptionProviderApiKey,
+} from "@/lib/utils/externalTranscriptionModel";
 
 // check if model supports a language based on its supported_languages list
 const modelSupportsLanguage = (model: ModelInfo, langCode: string): boolean => {
@@ -19,8 +27,13 @@ export const ModelsSettings: React.FC = () => {
   const [languageFilter, setLanguageFilter] = useState("all");
   const [languageDropdownOpen, setLanguageDropdownOpen] = useState(false);
   const [languageSearch, setLanguageSearch] = useState("");
+  const [elevenLabsApiKeySaving, setElevenLabsApiKeySaving] = useState(false);
+  const [elevenLabsApiKeyError, setElevenLabsApiKeyError] = useState<
+    string | null
+  >(null);
   const languageDropdownRef = useRef<HTMLDivElement>(null);
   const languageSearchInputRef = useRef<HTMLInputElement>(null);
+  const { getSetting, updateSetting, refreshSettings } = useSettings();
   const {
     models,
     currentModel,
@@ -35,6 +48,17 @@ export const ModelsSettings: React.FC = () => {
     selectModel,
     deleteModel,
   } = useModelStore();
+  const transcriptionProviderId =
+    getSetting("transcription_provider_id") || "local";
+  const transcriptionApiKeys = getSetting("transcription_api_keys") || {};
+  const usesLocalProvider = transcriptionProviderId === "local";
+  const isElevenLabsSelected =
+    transcriptionProviderId === ELEVENLABS_TRANSCRIPTION_PROVIDER_ID;
+  const hasElevenLabsApiKey = hasTranscriptionProviderApiKey(
+    ELEVENLABS_TRANSCRIPTION_PROVIDER_ID,
+    transcriptionApiKeys,
+  );
+  const elevenLabsProfile = getElevenLabsModelProfile();
 
   // click outside handler for language dropdown
   useEffect(() => {
@@ -88,7 +112,7 @@ export const ModelsSettings: React.FC = () => {
     if (switchingModelId === modelId) {
       return "switching";
     }
-    if (modelId === currentModel) {
+    if (usesLocalProvider && modelId === currentModel) {
       return "active";
     }
     const model = models.find((m: ModelInfo) => m.id === modelId);
@@ -153,6 +177,94 @@ export const ModelsSettings: React.FC = () => {
     }
   };
 
+  const getErrorMessage = (error: unknown) => {
+    if (typeof error === "string") {
+      return error;
+    }
+
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    return t("settings.models.external.apiKey.saveFailed", {
+      defaultValue: "Failed to save API key.",
+    });
+  };
+
+  const handleElevenLabsSelect = async () => {
+    setElevenLabsApiKeyError(null);
+    await updateSetting(
+      "transcription_provider_id",
+      ELEVENLABS_TRANSCRIPTION_PROVIDER_ID,
+    );
+  };
+
+  const handleElevenLabsApiKeySave = async (apiKey: string) => {
+    const trimmedApiKey = apiKey.trim();
+
+    if (!trimmedApiKey) {
+      setElevenLabsApiKeyError(
+        t("settings.models.external.apiKey.required", {
+          defaultValue: "Enter your ElevenLabs API key.",
+        }),
+      );
+      return;
+    }
+
+    setElevenLabsApiKeySaving(true);
+    setElevenLabsApiKeyError(null);
+
+    try {
+      await invoke("verify_transcription_provider_api_key", {
+        providerId: ELEVENLABS_TRANSCRIPTION_PROVIDER_ID,
+        apiKey: trimmedApiKey,
+      });
+
+      const saveResult = await commands.changeTranscriptionApiKeySetting(
+        ELEVENLABS_TRANSCRIPTION_PROVIDER_ID,
+        trimmedApiKey,
+      );
+      if (saveResult.status !== "ok") {
+        throw new Error(saveResult.error);
+      }
+
+      await refreshSettings();
+      await updateSetting(
+        "transcription_provider_id",
+        ELEVENLABS_TRANSCRIPTION_PROVIDER_ID,
+      );
+    } catch (error) {
+      setElevenLabsApiKeyError(getErrorMessage(error));
+    } finally {
+      setElevenLabsApiKeySaving(false);
+    }
+  };
+
+  const handleElevenLabsApiKeyRemove = async () => {
+    setElevenLabsApiKeySaving(true);
+    setElevenLabsApiKeyError(null);
+
+    try {
+      if (isElevenLabsSelected) {
+        await updateSetting("transcription_provider_id", "local");
+      }
+
+      const saveResult = await commands.changeTranscriptionApiKeySetting(
+        ELEVENLABS_TRANSCRIPTION_PROVIDER_ID,
+        "",
+      );
+      if (saveResult.status !== "ok") {
+        throw new Error(saveResult.error);
+      }
+
+      await refreshSettings();
+    } catch (error) {
+      setElevenLabsApiKeyError(getErrorMessage(error));
+    } finally {
+      setElevenLabsApiKeySaving(false);
+    }
+  };
+
   // Filter models based on language filter
   const filteredModels = useMemo(() => {
     return models.filter((model: ModelInfo) => {
@@ -183,8 +295,8 @@ export const ModelsSettings: React.FC = () => {
 
     // Sort: active model first, then non-custom, then custom at the bottom
     downloaded.sort((a, b) => {
-      if (a.id === currentModel) return -1;
-      if (b.id === currentModel) return 1;
+      if (usesLocalProvider && a.id === currentModel) return -1;
+      if (usesLocalProvider && b.id === currentModel) return 1;
       if (a.is_custom !== b.is_custom) return a.is_custom ? 1 : -1;
       return 0;
     });
@@ -215,108 +327,146 @@ export const ModelsSettings: React.FC = () => {
           {t("settings.models.description")}
         </p>
       </div>
-      {filteredModels.length > 0 ? (
-        <div className="space-y-6">
-          {/* Downloaded Models Section — header always visible so filter stays accessible */}
-          <div className="space-y-3">
-            <div className="flex items-center justify-between">
-              <h2 className="text-sm font-medium text-text/60">
-                {t("settings.models.yourModels")}
-              </h2>
-              {/* Language filter dropdown */}
-              <div className="relative" ref={languageDropdownRef}>
-                <button
-                  type="button"
-                  onClick={() => setLanguageDropdownOpen(!languageDropdownOpen)}
-                  className={`flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg transition-colors ${
-                    languageFilter !== "all"
-                      ? "bg-logo-primary/20 text-logo-primary"
-                      : "bg-mid-gray/10 text-text/60 hover:bg-mid-gray/20"
+      <div className="space-y-6">
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-medium text-text/60">
+              {t("settings.models.yourModels")}
+            </h2>
+            <div className="relative" ref={languageDropdownRef}>
+              <button
+                type="button"
+                onClick={() => setLanguageDropdownOpen(!languageDropdownOpen)}
+                className={`flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg transition-colors ${
+                  languageFilter !== "all"
+                    ? "bg-logo-primary/20 text-logo-primary"
+                    : "bg-mid-gray/10 text-text/60 hover:bg-mid-gray/20"
+                }`}
+              >
+                <Globe className="w-3.5 h-3.5" />
+                <span className="max-w-[120px] truncate">
+                  {selectedLanguageLabel}
+                </span>
+                <ChevronDown
+                  className={`w-3.5 h-3.5 transition-transform ${
+                    languageDropdownOpen ? "rotate-180" : ""
                   }`}
-                >
-                  <Globe className="w-3.5 h-3.5" />
-                  <span className="max-w-[120px] truncate">
-                    {selectedLanguageLabel}
-                  </span>
-                  <ChevronDown
-                    className={`w-3.5 h-3.5 transition-transform ${
-                      languageDropdownOpen ? "rotate-180" : ""
-                    }`}
-                  />
-                </button>
+                />
+              </button>
 
-                {languageDropdownOpen && (
-                  <div className="absolute top-full right-0 mt-1 w-56 bg-background border border-mid-gray/80 rounded-lg shadow-lg z-50 overflow-hidden">
-                    <div className="p-2 border-b border-mid-gray/40">
-                      <input
-                        ref={languageSearchInputRef}
-                        type="text"
-                        value={languageSearch}
-                        onChange={(e) => setLanguageSearch(e.target.value)}
-                        onKeyDown={(e) => {
-                          if (
-                            e.key === "Enter" &&
-                            filteredLanguages.length > 0
-                          ) {
-                            setLanguageFilter(filteredLanguages[0].value);
-                            setLanguageDropdownOpen(false);
-                            setLanguageSearch("");
-                          } else if (e.key === "Escape") {
-                            setLanguageDropdownOpen(false);
-                            setLanguageSearch("");
-                          }
-                        }}
-                        placeholder={t(
-                          "settings.general.language.searchPlaceholder",
-                        )}
-                        className="w-full px-2 py-1 text-sm bg-mid-gray/10 border border-mid-gray/40 rounded-md focus:outline-none focus:ring-1 focus:ring-logo-primary"
-                      />
-                    </div>
-                    <div className="max-h-48 overflow-y-auto">
+              {languageDropdownOpen && (
+                <div className="absolute top-full right-0 mt-1 w-56 bg-background border border-mid-gray/80 rounded-lg shadow-lg z-50 overflow-hidden">
+                  <div className="p-2 border-b border-mid-gray/40">
+                    <input
+                      ref={languageSearchInputRef}
+                      type="text"
+                      value={languageSearch}
+                      onChange={(e) => setLanguageSearch(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" && filteredLanguages.length > 0) {
+                          setLanguageFilter(filteredLanguages[0].value);
+                          setLanguageDropdownOpen(false);
+                          setLanguageSearch("");
+                        } else if (e.key === "Escape") {
+                          setLanguageDropdownOpen(false);
+                          setLanguageSearch("");
+                        }
+                      }}
+                      placeholder={t(
+                        "settings.general.language.searchPlaceholder",
+                      )}
+                      className="w-full px-2 py-1 text-sm bg-mid-gray/10 border border-mid-gray/40 rounded-md focus:outline-none focus:ring-1 focus:ring-logo-primary"
+                    />
+                  </div>
+                  <div className="max-h-48 overflow-y-auto">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setLanguageFilter("all");
+                        setLanguageDropdownOpen(false);
+                        setLanguageSearch("");
+                      }}
+                      className={`w-full px-3 py-1.5 text-sm text-left transition-colors ${
+                        languageFilter === "all"
+                          ? "bg-logo-primary/20 text-logo-primary font-semibold"
+                          : "hover:bg-mid-gray/10"
+                      }`}
+                    >
+                      {t("settings.models.filters.allLanguages")}
+                    </button>
+                    {filteredLanguages.map((lang) => (
                       <button
+                        key={lang.value}
                         type="button"
                         onClick={() => {
-                          setLanguageFilter("all");
+                          setLanguageFilter(lang.value);
                           setLanguageDropdownOpen(false);
                           setLanguageSearch("");
                         }}
                         className={`w-full px-3 py-1.5 text-sm text-left transition-colors ${
-                          languageFilter === "all"
+                          languageFilter === lang.value
                             ? "bg-logo-primary/20 text-logo-primary font-semibold"
                             : "hover:bg-mid-gray/10"
                         }`}
                       >
-                        {t("settings.models.filters.allLanguages")}
+                        {lang.label}
                       </button>
-                      {filteredLanguages.map((lang) => (
-                        <button
-                          key={lang.value}
-                          type="button"
-                          onClick={() => {
-                            setLanguageFilter(lang.value);
-                            setLanguageDropdownOpen(false);
-                            setLanguageSearch("");
-                          }}
-                          className={`w-full px-3 py-1.5 text-sm text-left transition-colors ${
-                            languageFilter === lang.value
-                              ? "bg-logo-primary/20 text-logo-primary font-semibold"
-                              : "hover:bg-mid-gray/10"
-                          }`}
-                        >
-                          {lang.label}
-                        </button>
-                      ))}
-                      {filteredLanguages.length === 0 && (
-                        <div className="px-3 py-2 text-sm text-text/50 text-center">
-                          {t("settings.general.language.noResults")}
-                        </div>
-                      )}
-                    </div>
+                    ))}
+                    {filteredLanguages.length === 0 && (
+                      <div className="px-3 py-2 text-sm text-text/50 text-center">
+                        {t("settings.general.language.noResults")}
+                      </div>
+                    )}
                   </div>
-                )}
-              </div>
+                </div>
+              )}
             </div>
-            {downloadedModels.map((model: ModelInfo) => (
+          </div>
+          {hasElevenLabsApiKey && (
+            <ExternalTranscriptionModelCard
+              profile={elevenLabsProfile}
+              isActive={isElevenLabsSelected}
+              isInstalled={true}
+              savedApiKey={
+                transcriptionApiKeys[ELEVENLABS_TRANSCRIPTION_PROVIDER_ID] || ""
+              }
+              apiKeySaving={elevenLabsApiKeySaving}
+              apiKeyError={elevenLabsApiKeyError}
+              isSwitching={
+                switchingModelId === ELEVENLABS_TRANSCRIPTION_PROVIDER_ID
+              }
+              onSelect={() => {
+                setSwitchingModelId(ELEVENLABS_TRANSCRIPTION_PROVIDER_ID);
+                void handleElevenLabsSelect().finally(() => {
+                  setSwitchingModelId(null);
+                });
+              }}
+              onSaveApiKey={handleElevenLabsApiKeySave}
+              onRemoveApiKey={handleElevenLabsApiKeyRemove}
+            />
+          )}
+          {downloadedModels.map((model: ModelInfo) => (
+            <ModelCard
+              key={model.id}
+              model={model}
+              status={getModelStatus(model.id)}
+              onSelect={handleModelSelect}
+              onDownload={handleModelDownload}
+              onDelete={handleModelDelete}
+              onCancel={handleModelCancel}
+              downloadProgress={getDownloadProgress(model.id)}
+              downloadSpeed={getDownloadSpeed(model.id)}
+              showRecommended={false}
+            />
+          ))}
+        </div>
+
+        {availableModels.length > 0 && (
+          <div className="space-y-3">
+            <h2 className="text-sm font-medium text-text/60">
+              {t("settings.models.availableModels")}
+            </h2>
+            {availableModels.map((model: ModelInfo) => (
               <ModelCard
                 key={model.id}
                 model={model}
@@ -331,35 +481,35 @@ export const ModelsSettings: React.FC = () => {
               />
             ))}
           </div>
+        )}
 
-          {/* Available Models Section */}
-          {availableModels.length > 0 && (
-            <div className="space-y-3">
-              <h2 className="text-sm font-medium text-text/60">
-                {t("settings.models.availableModels")}
-              </h2>
-              {availableModels.map((model: ModelInfo) => (
-                <ModelCard
-                  key={model.id}
-                  model={model}
-                  status={getModelStatus(model.id)}
-                  onSelect={handleModelSelect}
-                  onDownload={handleModelDownload}
-                  onDelete={handleModelDelete}
-                  onCancel={handleModelCancel}
-                  downloadProgress={getDownloadProgress(model.id)}
-                  downloadSpeed={getDownloadSpeed(model.id)}
-                  showRecommended={false}
-                />
-              ))}
-            </div>
-          )}
-        </div>
-      ) : (
-        <div className="text-center py-8 text-text/50">
-          {t("settings.models.noModelsMatch")}
-        </div>
-      )}
+        {!hasElevenLabsApiKey && (
+          <div className="space-y-3">
+            <h2 className="text-sm font-medium text-text/60">
+              {t("settings.models.cloudModels", {
+                defaultValue: "Cloud Models",
+              })}
+            </h2>
+            <ExternalTranscriptionModelCard
+              profile={elevenLabsProfile}
+              isActive={false}
+              isInstalled={false}
+              savedApiKey=""
+              apiKeySaving={elevenLabsApiKeySaving}
+              apiKeyError={elevenLabsApiKeyError}
+              onSelect={handleElevenLabsSelect}
+              onSaveApiKey={handleElevenLabsApiKeySave}
+              onRemoveApiKey={handleElevenLabsApiKeyRemove}
+            />
+          </div>
+        )}
+
+        {languageFilter !== "all" && filteredModels.length === 0 && (
+          <div className="text-center py-2 text-text/50">
+            {t("settings.models.noModelsMatch")}
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -536,7 +536,19 @@
         "translation": "ترجمة",
         "allLanguages": "جميع اللغات"
       },
-      "noModelsMatch": "لا توجد نماذج مطابقة لهذا الفلتر."
+      "noModelsMatch": "لا توجد نماذج مطابقة لهذا الفلتر.",
+      "external": {
+        "apiKey": {
+          "title": "API key",
+          "placeholder": "Enter your ElevenLabs API key",
+          "required": "Enter your ElevenLabs API key.",
+          "verifying": "Verifying...",
+          "saveFailed": "Failed to save API key."
+        },
+        "addApiKey": "Add API key",
+        "cloudStorage": "Cloud"
+      },
+      "cloudModels": "Cloud Models"
     }
   },
   "footer": {
@@ -597,7 +609,9 @@
     "noInputDevice": "لم يتم اكتشاف أي جهاز إدخال صوتي. يرجى توصيل ميكروفون أو سماعة رأس والمحاولة مرة أخرى.",
     "recordingFailed": "فشل في بدء التسجيل: {{error}}",
     "modelLoadFailed": "فشل في تحميل النموذج: {{model}}",
-    "modelLoadFailedUnknown": "نموذج غير معروف"
+    "modelLoadFailedUnknown": "نموذج غير معروف",
+    "transcriptionFailedTitle": "Transcription failed",
+    "transcriptionFailedDefault": "The transcription request did not complete."
   },
   "appLanguage": {
     "title": "لغة التطبيق",

--- a/src/i18n/locales/bg/translation.json
+++ b/src/i18n/locales/bg/translation.json
@@ -213,7 +213,19 @@
         "translation": "Превод",
         "allLanguages": "Всички езици"
       },
-      "noModelsMatch": "Няма модели, отговарящи на този филтър."
+      "noModelsMatch": "Няма модели, отговарящи на този филтър.",
+      "external": {
+        "apiKey": {
+          "title": "API key",
+          "placeholder": "Enter your ElevenLabs API key",
+          "required": "Enter your ElevenLabs API key.",
+          "verifying": "Verifying...",
+          "saveFailed": "Failed to save API key."
+        },
+        "addApiKey": "Add API key",
+        "cloudStorage": "Cloud"
+      },
+      "cloudModels": "Cloud Models"
     },
     "sound": {
       "title": "Звук",
@@ -597,7 +609,9 @@
     "noInputDevice": "Не е открито аудио входно устройство. Свържете микрофон или слушалки и опитайте отново.",
     "recordingFailed": "Стартирането на записа не бе успешно: {{error}}",
     "modelLoadFailed": "Зареждането на модела не бе успешно: {{model}}",
-    "modelLoadFailedUnknown": "неизвестен модел"
+    "modelLoadFailedUnknown": "неизвестен модел",
+    "transcriptionFailedTitle": "Transcription failed",
+    "transcriptionFailedDefault": "The transcription request did not complete."
   },
   "appLanguage": {
     "title": "Език на приложението",

--- a/src/i18n/locales/cs/translation.json
+++ b/src/i18n/locales/cs/translation.json
@@ -171,7 +171,19 @@
       },
       "noModelsMatch": "Tomuto filtru neodpovídají žádné modely.",
       "yourModels": "Stažené modely",
-      "availableModels": "Dostupné ke stažení"
+      "availableModels": "Dostupné ke stažení",
+      "external": {
+        "apiKey": {
+          "title": "API key",
+          "placeholder": "Enter your ElevenLabs API key",
+          "required": "Enter your ElevenLabs API key.",
+          "verifying": "Verifying...",
+          "saveFailed": "Failed to save API key."
+        },
+        "addApiKey": "Add API key",
+        "cloudStorage": "Cloud"
+      },
+      "cloudModels": "Cloud Models"
     },
     "general": {
       "title": "Obecné",
@@ -597,7 +609,9 @@
     "noInputDevice": "Nebylo detekováno žádné zvukové vstupní zařízení. Připojte mikrofon nebo sluchátka a zkuste to znovu.",
     "recordingFailed": "Nepodařilo se spustit nahrávání: {{error}}",
     "modelLoadFailed": "Nepodařilo se načíst model: {{model}}",
-    "modelLoadFailedUnknown": "neznámý model"
+    "modelLoadFailedUnknown": "neznámý model",
+    "transcriptionFailedTitle": "Transcription failed",
+    "transcriptionFailedDefault": "The transcription request did not complete."
   },
   "appLanguage": {
     "title": "Jazyk aplikace",

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -158,7 +158,7 @@
     "models": {
       "title": "Transkriptionsmodelle",
       "description": "Wähle ein Transkriptionsmodell aus oder lade zusätzliche Modelle herunter. Verschiedene Modelle bieten unterschiedliche Genauigkeits- und Geschwindigkeitsstufen.",
-      "downloaded": "Heruntergeladen",
+      "downloaded": "Installiert",
       "available": "Zum Download verfügbar",
       "deleteConfirm": "Bist du sicher, dass du {{modelName}} löschen möchtest? Du musst es erneut herunterladen, um es zu verwenden.",
       "deleteActiveConfirm": "{{modelName}} ist dein aktives Modell. Das Löschen stoppt Transkriptionen, bis du ein neues Modell auswählst. Bist du sicher?",
@@ -170,8 +170,20 @@
         "allLanguages": "Alle Sprachen"
       },
       "noModelsMatch": "Keine Modelle entsprechen diesem Filter.",
-      "yourModels": "Heruntergeladene Modelle",
-      "availableModels": "Zum Download verfügbar"
+      "yourModels": "Installierte Modelle",
+      "availableModels": "Zum Download verfügbar",
+      "external": {
+        "apiKey": {
+          "title": "API-Schlüssel",
+          "placeholder": "Gib deinen ElevenLabs-API-Schlüssel ein",
+          "required": "Gib deinen ElevenLabs-API-Schlüssel ein.",
+          "verifying": "Wird überprüft...",
+          "saveFailed": "API-Schlüssel konnte nicht gespeichert werden."
+        },
+        "addApiKey": "API-Schlüssel hinzufügen",
+        "cloudStorage": "Cloud"
+      },
+      "cloudModels": "Cloud-Modelle"
     },
     "general": {
       "title": "Allgemein",
@@ -597,7 +609,9 @@
     "noInputDevice": "Es wurde kein Audio-Eingabegerät erkannt. Bitte schließen Sie ein Mikrofon oder Headset an und versuchen Sie es erneut.",
     "recordingFailed": "Aufnahme konnte nicht gestartet werden: {{error}}",
     "modelLoadFailed": "Modell konnte nicht geladen werden: {{model}}",
-    "modelLoadFailedUnknown": "unbekanntes Modell"
+    "modelLoadFailedUnknown": "unbekanntes Modell",
+    "transcriptionFailedTitle": "Transkription fehlgeschlagen",
+    "transcriptionFailedDefault": "Die Transkriptionsanfrage wurde nicht abgeschlossen."
   },
   "appLanguage": {
     "title": "Anwendungssprache",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -200,9 +200,10 @@
     "models": {
       "title": "Transcription Models",
       "description": "Select a transcription model or download additional models. Different models offer varying levels of accuracy and speed.",
-      "yourModels": "Downloaded Models",
+      "yourModels": "Installed Models",
       "availableModels": "Available to Download",
-      "downloaded": "Downloaded",
+      "cloudModels": "Cloud Models",
+      "downloaded": "Installed",
       "available": "Available to Download",
       "deleteConfirm": "Are you sure you want to delete {{modelName}}? You will need to download it again to use it.",
       "deleteActiveConfirm": "{{modelName}} is your active model. Deleting it will stop transcriptions until you select a new model. Are you sure?",
@@ -213,7 +214,18 @@
         "translation": "Translation",
         "allLanguages": "All Languages"
       },
-      "noModelsMatch": "No models match this filter."
+      "noModelsMatch": "No models match this filter.",
+      "external": {
+        "addApiKey": "Add API key",
+        "cloudStorage": "Cloud",
+        "apiKey": {
+          "title": "API key",
+          "placeholder": "Enter your ElevenLabs API key",
+          "required": "Enter your ElevenLabs API key.",
+          "verifying": "Verifying...",
+          "saveFailed": "Failed to save API key."
+        }
+      }
     },
     "sound": {
       "title": "Sound",
@@ -596,6 +608,8 @@
     "noInputDeviceTitle": "No Microphone Found",
     "noInputDevice": "No audio input device was detected. Please connect a microphone or headset and try again.",
     "recordingFailed": "Failed to start recording: {{error}}",
+    "transcriptionFailedTitle": "Transcription failed",
+    "transcriptionFailedDefault": "The transcription request did not complete.",
     "modelLoadFailed": "Failed to load model: {{model}}",
     "modelLoadFailedUnknown": "unknown model"
   },

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -171,7 +171,19 @@
       },
       "noModelsMatch": "Ningún modelo coincide con este filtro.",
       "yourModels": "Modelos descargados",
-      "availableModels": "Disponibles para descargar"
+      "availableModels": "Disponibles para descargar",
+      "external": {
+        "apiKey": {
+          "title": "API key",
+          "placeholder": "Enter your ElevenLabs API key",
+          "required": "Enter your ElevenLabs API key.",
+          "verifying": "Verifying...",
+          "saveFailed": "Failed to save API key."
+        },
+        "addApiKey": "Add API key",
+        "cloudStorage": "Cloud"
+      },
+      "cloudModels": "Cloud Models"
     },
     "general": {
       "title": "General",
@@ -597,7 +609,9 @@
     "noInputDevice": "No se detectó ningún dispositivo de entrada de audio. Conecta un micrófono o auriculares e inténtalo de nuevo.",
     "recordingFailed": "Error al iniciar la grabación: {{error}}",
     "modelLoadFailed": "Error al cargar el modelo: {{model}}",
-    "modelLoadFailedUnknown": "modelo desconocido"
+    "modelLoadFailedUnknown": "modelo desconocido",
+    "transcriptionFailedTitle": "Transcription failed",
+    "transcriptionFailedDefault": "The transcription request did not complete."
   },
   "appLanguage": {
     "title": "Idioma de la aplicación",

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -171,7 +171,19 @@
       },
       "noModelsMatch": "Aucun modèle ne correspond à ce filtre.",
       "yourModels": "Modèles téléchargés",
-      "availableModels": "Disponibles au téléchargement"
+      "availableModels": "Disponibles au téléchargement",
+      "external": {
+        "apiKey": {
+          "title": "API key",
+          "placeholder": "Enter your ElevenLabs API key",
+          "required": "Enter your ElevenLabs API key.",
+          "verifying": "Verifying...",
+          "saveFailed": "Failed to save API key."
+        },
+        "addApiKey": "Add API key",
+        "cloudStorage": "Cloud"
+      },
+      "cloudModels": "Cloud Models"
     },
     "general": {
       "title": "Général",
@@ -597,7 +609,9 @@
     "noInputDevice": "Aucun périphérique d'entrée audio n'a été détecté. Veuillez connecter un microphone ou un casque et réessayer.",
     "recordingFailed": "Échec du démarrage de l'enregistrement : {{error}}",
     "modelLoadFailed": "Échec du chargement du modèle : {{model}}",
-    "modelLoadFailedUnknown": "modèle inconnu"
+    "modelLoadFailedUnknown": "modèle inconnu",
+    "transcriptionFailedTitle": "Transcription failed",
+    "transcriptionFailedDefault": "The transcription request did not complete."
   },
   "appLanguage": {
     "title": "Langue de l'application",

--- a/src/i18n/locales/he/translation.json
+++ b/src/i18n/locales/he/translation.json
@@ -213,7 +213,19 @@
         "translation": "תרגום",
         "allLanguages": "כל השפות"
       },
-      "noModelsMatch": "אין מודלים שמתאימים לסינון הזה."
+      "noModelsMatch": "אין מודלים שמתאימים לסינון הזה.",
+      "external": {
+        "apiKey": {
+          "title": "API key",
+          "placeholder": "Enter your ElevenLabs API key",
+          "required": "Enter your ElevenLabs API key.",
+          "verifying": "Verifying...",
+          "saveFailed": "Failed to save API key."
+        },
+        "addApiKey": "Add API key",
+        "cloudStorage": "Cloud"
+      },
+      "cloudModels": "Cloud Models"
     },
     "sound": {
       "title": "שמע",
@@ -597,7 +609,9 @@
     "noInputDevice": "לא זוהה התקן קלט שמע. חבר מיקרופון או אוזנייה ונסה שוב.",
     "recordingFailed": "הפעלת ההקלטה נכשלה: {{error}}",
     "modelLoadFailed": "טעינת המודל נכשלה: {{model}}",
-    "modelLoadFailedUnknown": "מודל לא ידוע"
+    "modelLoadFailedUnknown": "מודל לא ידוע",
+    "transcriptionFailedTitle": "Transcription failed",
+    "transcriptionFailedDefault": "The transcription request did not complete."
   },
   "appLanguage": {
     "title": "שפת האפליקציה",

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -171,7 +171,19 @@
       },
       "noModelsMatch": "Nessun modello corrisponde a questo filtro.",
       "yourModels": "Modelli scaricati",
-      "availableModels": "Disponibili per il Download"
+      "availableModels": "Disponibili per il Download",
+      "external": {
+        "apiKey": {
+          "title": "API key",
+          "placeholder": "Enter your ElevenLabs API key",
+          "required": "Enter your ElevenLabs API key.",
+          "verifying": "Verifying...",
+          "saveFailed": "Failed to save API key."
+        },
+        "addApiKey": "Add API key",
+        "cloudStorage": "Cloud"
+      },
+      "cloudModels": "Cloud Models"
     },
     "general": {
       "title": "Generale",
@@ -597,7 +609,9 @@
     "noInputDevice": "Non è stato rilevato alcun dispositivo di ingresso audio. Collega un microfono o delle cuffie e riprova.",
     "recordingFailed": "Impossibile avviare la registrazione: {{error}}",
     "modelLoadFailed": "Impossibile caricare il modello: {{model}}",
-    "modelLoadFailedUnknown": "modello sconosciuto"
+    "modelLoadFailedUnknown": "modello sconosciuto",
+    "transcriptionFailedTitle": "Transcription failed",
+    "transcriptionFailedDefault": "The transcription request did not complete."
   },
   "appLanguage": {
     "title": "Lingua Applicazione",

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -171,7 +171,19 @@
       },
       "noModelsMatch": "このフィルターに一致するモデルがありません。",
       "yourModels": "ダウンロード済みモデル",
-      "availableModels": "ダウンロード可能"
+      "availableModels": "ダウンロード可能",
+      "external": {
+        "apiKey": {
+          "title": "API key",
+          "placeholder": "Enter your ElevenLabs API key",
+          "required": "Enter your ElevenLabs API key.",
+          "verifying": "Verifying...",
+          "saveFailed": "Failed to save API key."
+        },
+        "addApiKey": "Add API key",
+        "cloudStorage": "Cloud"
+      },
+      "cloudModels": "Cloud Models"
     },
     "general": {
       "title": "一般",
@@ -597,7 +609,9 @@
     "noInputDevice": "オーディオ入力デバイスが検出されませんでした。マイクまたはヘッドセットを接続してから再試行してください。",
     "recordingFailed": "録音の開始に失敗しました: {{error}}",
     "modelLoadFailed": "モデルの読み込みに失敗しました: {{model}}",
-    "modelLoadFailedUnknown": "不明なモデル"
+    "modelLoadFailedUnknown": "不明なモデル",
+    "transcriptionFailedTitle": "Transcription failed",
+    "transcriptionFailedDefault": "The transcription request did not complete."
   },
   "appLanguage": {
     "title": "アプリケーション言語",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -236,7 +236,19 @@
         "translation": "번역",
         "allLanguages": "모든 언어"
       },
-      "noModelsMatch": "이 필터에 맞는 모델이 없습니다."
+      "noModelsMatch": "이 필터에 맞는 모델이 없습니다.",
+      "external": {
+        "apiKey": {
+          "title": "API key",
+          "placeholder": "Enter your ElevenLabs API key",
+          "required": "Enter your ElevenLabs API key.",
+          "verifying": "Verifying...",
+          "saveFailed": "Failed to save API key."
+        },
+        "addApiKey": "Add API key",
+        "cloudStorage": "Cloud"
+      },
+      "cloudModels": "Cloud Models"
     },
     "advanced": {
       "title": "고급",
@@ -597,7 +609,9 @@
     "noInputDevice": "오디오 입력 장치가 감지되지 않았습니다. 마이크 또는 헤드셋을 연결한 후 다시 시도해 주세요.",
     "recordingFailed": "녹음을 시작하지 못했습니다: {{error}}",
     "modelLoadFailed": "모델을 불러오지 못했습니다: {{model}}",
-    "modelLoadFailedUnknown": "알 수 없는 모델"
+    "modelLoadFailedUnknown": "알 수 없는 모델",
+    "transcriptionFailedTitle": "Transcription failed",
+    "transcriptionFailedDefault": "The transcription request did not complete."
   },
   "appLanguage": {
     "title": "애플리케이션 언어",

--- a/src/i18n/locales/pl/translation.json
+++ b/src/i18n/locales/pl/translation.json
@@ -171,7 +171,19 @@
       },
       "noModelsMatch": "Żadne modele nie pasują do tego filtra.",
       "yourModels": "Pobrane modele",
-      "availableModels": "Dostępne do pobrania"
+      "availableModels": "Dostępne do pobrania",
+      "external": {
+        "apiKey": {
+          "title": "API key",
+          "placeholder": "Enter your ElevenLabs API key",
+          "required": "Enter your ElevenLabs API key.",
+          "verifying": "Verifying...",
+          "saveFailed": "Failed to save API key."
+        },
+        "addApiKey": "Add API key",
+        "cloudStorage": "Cloud"
+      },
+      "cloudModels": "Cloud Models"
     },
     "general": {
       "title": "Ogólne",
@@ -597,7 +609,9 @@
     "noInputDevice": "Nie wykryto żadnego urządzenia wejściowego audio. Podłącz mikrofon lub słuchawki i spróbuj ponownie.",
     "recordingFailed": "Nie udało się rozpocząć nagrywania: {{error}}",
     "modelLoadFailed": "Nie udało się załadować modelu: {{model}}",
-    "modelLoadFailedUnknown": "nieznany model"
+    "modelLoadFailedUnknown": "nieznany model",
+    "transcriptionFailedTitle": "Transcription failed",
+    "transcriptionFailedDefault": "The transcription request did not complete."
   },
   "appLanguage": {
     "title": "Język aplikacji",

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -213,7 +213,19 @@
       },
       "noModelsMatch": "Nenhum modelo corresponde a este filtro.",
       "yourModels": "Modelos baixados",
-      "availableModels": "Disponíveis para download"
+      "availableModels": "Disponíveis para download",
+      "external": {
+        "apiKey": {
+          "title": "API key",
+          "placeholder": "Enter your ElevenLabs API key",
+          "required": "Enter your ElevenLabs API key.",
+          "verifying": "Verifying...",
+          "saveFailed": "Failed to save API key."
+        },
+        "addApiKey": "Add API key",
+        "cloudStorage": "Cloud"
+      },
+      "cloudModels": "Cloud Models"
     },
     "sound": {
       "title": "Som",
@@ -597,7 +609,9 @@
     "noInputDevice": "Nenhum dispositivo de entrada de áudio foi detectado. Conecte um microfone ou fone de ouvido e tente novamente.",
     "recordingFailed": "Falha ao iniciar a gravação: {{error}}",
     "modelLoadFailed": "Falha ao carregar o modelo: {{model}}",
-    "modelLoadFailedUnknown": "modelo desconhecido"
+    "modelLoadFailedUnknown": "modelo desconhecido",
+    "transcriptionFailedTitle": "Transcription failed",
+    "transcriptionFailedDefault": "The transcription request did not complete."
   },
   "appLanguage": {
     "title": "Idioma da Aplicação",

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -171,7 +171,19 @@
       },
       "noModelsMatch": "Нет моделей, соответствующих этому фильтру.",
       "yourModels": "Загруженные модели",
-      "availableModels": "Доступны для загрузки"
+      "availableModels": "Доступны для загрузки",
+      "external": {
+        "apiKey": {
+          "title": "API key",
+          "placeholder": "Enter your ElevenLabs API key",
+          "required": "Enter your ElevenLabs API key.",
+          "verifying": "Verifying...",
+          "saveFailed": "Failed to save API key."
+        },
+        "addApiKey": "Add API key",
+        "cloudStorage": "Cloud"
+      },
+      "cloudModels": "Cloud Models"
     },
     "general": {
       "title": "Общие",
@@ -597,7 +609,9 @@
     "noInputDevice": "Аудиоустройство ввода не обнаружено. Подключите микрофон или гарнитуру и попробуйте снова.",
     "recordingFailed": "Не удалось начать запись: {{error}}",
     "modelLoadFailed": "Не удалось загрузить модель: {{model}}",
-    "modelLoadFailedUnknown": "неизвестная модель"
+    "modelLoadFailedUnknown": "неизвестная модель",
+    "transcriptionFailedTitle": "Transcription failed",
+    "transcriptionFailedDefault": "The transcription request did not complete."
   },
   "appLanguage": {
     "title": "Язык приложения",

--- a/src/i18n/locales/sv/translation.json
+++ b/src/i18n/locales/sv/translation.json
@@ -213,7 +213,19 @@
         "translation": "Översättning",
         "allLanguages": "Alla språk"
       },
-      "noModelsMatch": "Inga modeller matchar detta filter."
+      "noModelsMatch": "Inga modeller matchar detta filter.",
+      "external": {
+        "apiKey": {
+          "title": "API key",
+          "placeholder": "Enter your ElevenLabs API key",
+          "required": "Enter your ElevenLabs API key.",
+          "verifying": "Verifying...",
+          "saveFailed": "Failed to save API key."
+        },
+        "addApiKey": "Add API key",
+        "cloudStorage": "Cloud"
+      },
+      "cloudModels": "Cloud Models"
     },
     "sound": {
       "title": "Ljud",
@@ -597,7 +609,9 @@
     "modelLoadFailed": "Misslyckades med att ladda modell: {{model}}",
     "modelLoadFailedUnknown": "okänd modell",
     "noInputDeviceTitle": "Ingen mikrofon hittades",
-    "noInputDevice": "Ingen ljudenhet hittades. Anslut en mikrofon eller ett headset och försök igen."
+    "noInputDevice": "Ingen ljudenhet hittades. Anslut en mikrofon eller ett headset och försök igen.",
+    "transcriptionFailedTitle": "Transcription failed",
+    "transcriptionFailedDefault": "The transcription request did not complete."
   },
   "appLanguage": {
     "title": "Applikationsspråk",

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -171,7 +171,19 @@
       },
       "noModelsMatch": "Bu filtreyle eşleşen model yok.",
       "yourModels": "İndirilen modeller",
-      "availableModels": "İndirilebilir"
+      "availableModels": "İndirilebilir",
+      "external": {
+        "apiKey": {
+          "title": "API key",
+          "placeholder": "Enter your ElevenLabs API key",
+          "required": "Enter your ElevenLabs API key.",
+          "verifying": "Verifying...",
+          "saveFailed": "Failed to save API key."
+        },
+        "addApiKey": "Add API key",
+        "cloudStorage": "Cloud"
+      },
+      "cloudModels": "Cloud Models"
     },
     "general": {
       "title": "Genel",
@@ -597,7 +609,9 @@
     "noInputDevice": "Ses giriş aygıtı algılanamadı. Lütfen bir mikrofon veya kulaklık bağlayın ve tekrar deneyin.",
     "recordingFailed": "Kayıt başlatılamadı: {{error}}",
     "modelLoadFailed": "Model yüklenemedi: {{model}}",
-    "modelLoadFailedUnknown": "bilinmeyen model"
+    "modelLoadFailedUnknown": "bilinmeyen model",
+    "transcriptionFailedTitle": "Transcription failed",
+    "transcriptionFailedDefault": "The transcription request did not complete."
   },
   "appLanguage": {
     "title": "Uygulama Dili",

--- a/src/i18n/locales/uk/translation.json
+++ b/src/i18n/locales/uk/translation.json
@@ -213,7 +213,19 @@
       },
       "noModelsMatch": "Жодна модель не відповідає цьому фільтру.",
       "yourModels": "Завантажені моделі",
-      "availableModels": "Доступні для завантаження"
+      "availableModels": "Доступні для завантаження",
+      "external": {
+        "apiKey": {
+          "title": "API key",
+          "placeholder": "Enter your ElevenLabs API key",
+          "required": "Enter your ElevenLabs API key.",
+          "verifying": "Verifying...",
+          "saveFailed": "Failed to save API key."
+        },
+        "addApiKey": "Add API key",
+        "cloudStorage": "Cloud"
+      },
+      "cloudModels": "Cloud Models"
     },
     "sound": {
       "title": "Звук",
@@ -597,7 +609,9 @@
     "noInputDevice": "Не виявлено жодного пристрою введення звуку. Підключіть мікрофон або гарнітуру та спробуйте знову.",
     "recordingFailed": "Не вдалося розпочати запис: {{error}}",
     "modelLoadFailed": "Не вдалося завантажити модель: {{model}}",
-    "modelLoadFailedUnknown": "невідома модель"
+    "modelLoadFailedUnknown": "невідома модель",
+    "transcriptionFailedTitle": "Transcription failed",
+    "transcriptionFailedDefault": "The transcription request did not complete."
   },
   "appLanguage": {
     "title": "Мова інтерфейсу",

--- a/src/i18n/locales/vi/translation.json
+++ b/src/i18n/locales/vi/translation.json
@@ -171,7 +171,19 @@
       },
       "noModelsMatch": "Không có mô hình nào khớp với bộ lọc này.",
       "yourModels": "Mô hình đã tải",
-      "availableModels": "Có sẵn để tải xuống"
+      "availableModels": "Có sẵn để tải xuống",
+      "external": {
+        "apiKey": {
+          "title": "API key",
+          "placeholder": "Enter your ElevenLabs API key",
+          "required": "Enter your ElevenLabs API key.",
+          "verifying": "Verifying...",
+          "saveFailed": "Failed to save API key."
+        },
+        "addApiKey": "Add API key",
+        "cloudStorage": "Cloud"
+      },
+      "cloudModels": "Cloud Models"
     },
     "general": {
       "title": "Chung",
@@ -597,7 +609,9 @@
     "noInputDevice": "Không phát hiện thiết bị đầu vào âm thanh nào. Vui lòng kết nối micrô hoặc tai nghe và thử lại.",
     "recordingFailed": "Không thể bắt đầu ghi âm: {{error}}",
     "modelLoadFailed": "Không thể tải mô hình: {{model}}",
-    "modelLoadFailedUnknown": "mô hình không xác định"
+    "modelLoadFailedUnknown": "mô hình không xác định",
+    "transcriptionFailedTitle": "Transcription failed",
+    "transcriptionFailedDefault": "The transcription request did not complete."
   },
   "appLanguage": {
     "title": "Ngôn ngữ ứng dụng",

--- a/src/i18n/locales/zh-TW/translation.json
+++ b/src/i18n/locales/zh-TW/translation.json
@@ -213,7 +213,19 @@
         "translation": "翻譯",
         "allLanguages": "所有語言"
       },
-      "noModelsMatch": "沒有符合此篩選條件的模型"
+      "noModelsMatch": "沒有符合此篩選條件的模型",
+      "external": {
+        "apiKey": {
+          "title": "API key",
+          "placeholder": "Enter your ElevenLabs API key",
+          "required": "Enter your ElevenLabs API key.",
+          "verifying": "Verifying...",
+          "saveFailed": "Failed to save API key."
+        },
+        "addApiKey": "Add API key",
+        "cloudStorage": "Cloud"
+      },
+      "cloudModels": "Cloud Models"
     },
     "sound": {
       "title": "聲音",
@@ -597,7 +609,9 @@
     "noInputDevice": "未偵測到音訊輸入裝置。請連接麥克風或耳機後重試。",
     "recordingFailed": "錄音啟動失敗: {{error}}",
     "modelLoadFailed": "載入模型失敗: {{model}}",
-    "modelLoadFailedUnknown": "未知模型"
+    "modelLoadFailedUnknown": "未知模型",
+    "transcriptionFailedTitle": "Transcription failed",
+    "transcriptionFailedDefault": "The transcription request did not complete."
   },
   "appLanguage": {
     "title": "應用程式語言",

--- a/src/i18n/locales/zh/translation.json
+++ b/src/i18n/locales/zh/translation.json
@@ -171,7 +171,19 @@
       },
       "noModelsMatch": "没有符合此筛选条件的模型。",
       "yourModels": "已下载的模型",
-      "availableModels": "可供下载"
+      "availableModels": "可供下载",
+      "external": {
+        "apiKey": {
+          "title": "API key",
+          "placeholder": "Enter your ElevenLabs API key",
+          "required": "Enter your ElevenLabs API key.",
+          "verifying": "Verifying...",
+          "saveFailed": "Failed to save API key."
+        },
+        "addApiKey": "Add API key",
+        "cloudStorage": "Cloud"
+      },
+      "cloudModels": "Cloud Models"
     },
     "general": {
       "title": "通用",
@@ -597,7 +609,9 @@
     "noInputDevice": "未检测到音频输入设备。请连接麦克风或耳机后重试。",
     "recordingFailed": "录音启动失败: {{error}}",
     "modelLoadFailed": "加载模型失败: {{model}}",
-    "modelLoadFailedUnknown": "未知模型"
+    "modelLoadFailedUnknown": "未知模型",
+    "transcriptionFailedTitle": "Transcription failed",
+    "transcriptionFailedDefault": "The transcription request did not complete."
   },
   "appLanguage": {
     "title": "应用语言",

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -9,3 +9,7 @@ export interface RecordingErrorEvent {
   error_type: string;
   detail?: string;
 }
+
+export interface TranscriptionErrorEvent {
+  detail?: string;
+}

--- a/src/lib/utils/externalTranscriptionModel.ts
+++ b/src/lib/utils/externalTranscriptionModel.ts
@@ -1,0 +1,39 @@
+import type { SecretMap } from "@/bindings";
+
+export const ELEVENLABS_TRANSCRIPTION_PROVIDER_ID = "elevenlabs";
+
+export interface ExternalTranscriptionModelProfile {
+  fullLabel: string;
+  description: string;
+  accuracyScore: number;
+  speedScore: number;
+}
+
+const ELEVENLABS_PROFILE: ExternalTranscriptionModelProfile = {
+  fullLabel: "Scribe v2 by ElevenLabs",
+  description:
+    "Highest-accuracy cloud transcription with multilingual support.",
+  accuracyScore: 1,
+  speedScore: 0.58,
+};
+
+export const getElevenLabsModelProfile =
+  (): ExternalTranscriptionModelProfile => ELEVENLABS_PROFILE;
+
+export const hasTranscriptionProviderApiKey = (
+  providerId: string,
+  apiKeys?: SecretMap | null,
+): boolean => {
+  const apiKey = apiKeys?.[providerId];
+  return typeof apiKey === "string" && apiKey.trim().length > 0;
+};
+
+export const getActiveTranscriptionModelDisplayName = (
+  providerId?: string | null,
+): string | null => {
+  if (providerId !== ELEVENLABS_TRANSCRIPTION_PROVIDER_ID) {
+    return null;
+  }
+
+  return ELEVENLABS_PROFILE.fullLabel;
+};

--- a/src/overlay/RecordingOverlay.css
+++ b/src/overlay/RecordingOverlay.css
@@ -1,6 +1,8 @@
 .recording-overlay {
-  height: 36px;
-  width: 172px;
+  height: 100%;
+  width: 100%;
+  min-height: 36px;
+  min-width: 172px;
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
@@ -12,6 +14,11 @@
   box-sizing: border-box;
 }
 
+.recording-overlay.error {
+  min-height: 56px;
+  background: #2b0c16e6;
+}
+
 .overlay-left {
   display: flex;
   align-items: center;
@@ -21,6 +28,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  min-width: 0;
+}
+
+.overlay-middle.error {
+  justify-content: flex-start;
 }
 
 .overlay-right {
@@ -68,6 +80,18 @@
   50% {
     opacity: 1;
   }
+}
+
+.error-text {
+  color: white;
+  font-size: 12px;
+  line-height: 1.3;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 .cancel-button {

--- a/src/overlay/RecordingOverlay.tsx
+++ b/src/overlay/RecordingOverlay.tsx
@@ -12,11 +12,15 @@ import i18n, { syncLanguageFromSettings } from "@/i18n";
 import { getLanguageDirection } from "@/lib/utils/rtl";
 
 type OverlayState = "recording" | "transcribing" | "processing";
+interface OverlayErrorPayload {
+  message: string;
+}
 
 const RecordingOverlay: React.FC = () => {
   const { t } = useTranslation();
   const [isVisible, setIsVisible] = useState(false);
-  const [state, setState] = useState<OverlayState>("recording");
+  const [state, setState] = useState<OverlayState | "error">("recording");
+  const [errorMessage, setErrorMessage] = useState("");
   const [levels, setLevels] = useState<number[]>(Array(16).fill(0));
   const smoothedLevelsRef = useRef<number[]>(Array(16).fill(0));
   const direction = getLanguageDirection(i18n.language);
@@ -29,8 +33,19 @@ const RecordingOverlay: React.FC = () => {
         await syncLanguageFromSettings();
         const overlayState = event.payload as OverlayState;
         setState(overlayState);
+        setErrorMessage("");
         setIsVisible(true);
       });
+
+      const unlistenError = await listen<OverlayErrorPayload>(
+        "show-overlay-error",
+        async (event) => {
+          await syncLanguageFromSettings();
+          setState("error");
+          setErrorMessage(event.payload.message);
+          setIsVisible(true);
+        },
+      );
 
       // Listen for hide-overlay event from Rust
       const unlistenHide = await listen("hide-overlay", () => {
@@ -54,6 +69,7 @@ const RecordingOverlay: React.FC = () => {
       // Cleanup function
       return () => {
         unlistenShow();
+        unlistenError();
         unlistenHide();
         unlistenLevel();
       };
@@ -65,6 +81,8 @@ const RecordingOverlay: React.FC = () => {
   const getIcon = () => {
     if (state === "recording") {
       return <MicrophoneIcon />;
+    } else if (state === "error") {
+      return <CancelIcon />;
     } else {
       return <TranscriptionIcon />;
     }
@@ -73,11 +91,11 @@ const RecordingOverlay: React.FC = () => {
   return (
     <div
       dir={direction}
-      className={`recording-overlay ${isVisible ? "fade-in" : ""}`}
+      className={`recording-overlay ${isVisible ? "fade-in" : ""} ${state === "error" ? "error" : ""}`}
     >
       <div className="overlay-left">{getIcon()}</div>
 
-      <div className="overlay-middle">
+      <div className={`overlay-middle ${state === "error" ? "error" : ""}`}>
         {state === "recording" && (
           <div className="bars-container">
             {levels.map((v, i) => (
@@ -98,6 +116,11 @@ const RecordingOverlay: React.FC = () => {
         )}
         {state === "processing" && (
           <div className="transcribing-text">{t("overlay.processing")}</div>
+        )}
+        {state === "error" && (
+          <div className="error-text" title={errorMessage}>
+            {errorMessage}
+          </div>
         )}
       </div>
 

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -88,6 +88,8 @@ const settingUpdaters: {
     commands.changeAutostartSetting(value as boolean),
   update_checks_enabled: (value) =>
     commands.changeUpdateChecksSetting(value as boolean),
+  transcription_provider_id: (value) =>
+    commands.changeTranscriptionProviderSetting(value as string),
   push_to_talk: (value) => commands.changePttSetting(value as boolean),
   selected_microphone: (value) =>
     commands.setSelectedMicrophone(

--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -15,4 +15,50 @@ test.describe("Handy App", () => {
     expect(html).toContain("<html");
     expect(html).toContain("<body");
   });
+
+  test("external transcription model helper exposes ElevenLabs profile", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const data = await page.evaluate(async () => {
+      const mod = await import("/src/lib/utils/externalTranscriptionModel.ts");
+
+      return {
+        profile: mod.getElevenLabsModelProfile(),
+        activeName: mod.getActiveTranscriptionModelDisplayName("elevenlabs"),
+        hasKey: mod.hasTranscriptionProviderApiKey("elevenlabs", {
+          elevenlabs: "  sk-test  ",
+        }),
+        missingKey: mod.hasTranscriptionProviderApiKey("elevenlabs", {
+          elevenlabs: "   ",
+        }),
+      };
+    });
+
+    expect(data.profile.fullLabel).toBe("Scribe v2 by ElevenLabs");
+    expect(data.profile.description).toContain("Highest-accuracy");
+    expect(data.activeName).toBe("Scribe v2 by ElevenLabs");
+    expect(data.hasKey).toBe(true);
+    expect(data.missingKey).toBe(false);
+  });
+
+  test("english translations include cloud model copy", async ({ page }) => {
+    await page.goto("/");
+
+    const strings = await page.evaluate(async () => {
+      const mod = await import("/src/i18n/locales/en/translation.json");
+      return {
+        yourModels: mod.default.settings.models.yourModels,
+        cloudModels: mod.default.settings.models.cloudModels,
+        addApiKey: mod.default.settings.models.external.addApiKey,
+        transcriptionFailedTitle: mod.default.errors.transcriptionFailedTitle,
+      };
+    });
+
+    expect(strings.yourModels).toBe("Installed Models");
+    expect(strings.cloudModels).toBe("Cloud Models");
+    expect(strings.addApiKey).toBe("Add API key");
+    expect(strings.transcriptionFailedTitle).toBe("Transcription failed");
+  });
 });


### PR DESCRIPTION
## Summary

This PR adds an optional ElevenLabs speech-to-text backend to Handy.

The key design goal is to keep Handy's existing local-first behavior unchanged by default while allowing users to explicitly opt into a hosted provider when they want higher cloud transcription accuracy.

## What Changed

- added an opt-in `ElevenLabs` transcription provider alongside the existing local backend
- added provider-side API key verification before saving the key
- forwarded Handy custom words to ElevenLabs as `keyterms`
- surfaced ElevenLabs as a model-style card in Settings with `Installed Models` / `Cloud Models` grouping
- updated the active model display so `Scribe v2 by ElevenLabs` shows up like the selected local model
- added short overlay failure messages and full main-window error toasts for auth, quota, rate-limit, timeout, downtime, and connectivity failures
- added Rust unit coverage for ElevenLabs error handling and overlay error summarization
- added Playwright coverage for the external-model helper and the new English copy

## Why

Some users want a hosted transcription option for cases where local models are not the right tradeoff for them.

This implementation tries to stay aligned with Handy's current UX by:

- keeping local transcription as the default
- requiring an explicit API key setup before the cloud model is considered installed
- keeping the hosted path visually separate under `Cloud Models` until configured
- not changing the existing local-model flow for users who do not want cloud providers

## Quality Context

The strongest argument for this feature is quality.

For a public quality reference, I compared Scribe v2 against the closest Handy-shipped local model families I could map on [Artificial Analysis' STT leaderboard](https://artificialanalysis.ai/speech-to-text) and their [AA-WER v2 benchmark write-up](https://artificialanalysis.ai/articles/aa-wer-v2). Lower AA-WER is better.

These are benchmark reference points, not measurements from this exact local Handy build on-device.

![Artificial Analysis AA-WER comparison](https://github.com/christophostertag/Handy/blob/c048770094074cc5a84514157d868cf8bd3181cb/docs/aa-wer-comparison.svg?raw=1)

Source data:

- [Artificial Analysis STT leaderboard](https://artificialanalysis.ai/speech-to-text)
- [Artificial Analysis AA-WER v2 benchmark write-up](https://artificialanalysis.ai/articles/aa-wer-v2)

Reference mapping used for the chart:

- `Scribe v2 by ElevenLabs`: `2.3%`
- `Parakeet V3`: `4.2%`
- `Whisper Large`: `4.2%` using the closest `Whisper Large v3` reference point
- `Whisper Turbo`: `4.8%` using the closest `Whisper Large v3 Turbo` reference point

That is the clearest case for this feature in my view: even against strong local/open models that Handy already ships, Scribe v2 benchmarks materially better on a public third-party evaluation.

## Free-Tier Context

The second argument is that trying this quality level does not immediately require another subscription.

I normalized a few official free-tier offers to approximate monthly transcription minutes so the practical cost of trying this feature is easier to scan.

![Hosted STT free-tier comparison](https://github.com/christophostertag/Handy/blob/c048770094074cc5a84514157d868cf8bd3181cb/docs/free-tier-comparison.svg?raw=1)

Source data:

- [ElevenLabs API pricing](https://elevenlabs.io/pricing/api)
- [Wispr Flow plans](https://docs.wisprflow.ai/articles/9559327591-flow-plans-and-what-s-included)
- [Azure AI Speech pricing](https://azure.microsoft.com/en-us/pricing/details/cognitive-services/speech-services/)
- [Google Cloud Speech-to-Text pricing](https://cloud.google.com/speech-to-text/pricing)
- [Amazon Transcribe getting started / free tier](https://aws.amazon.com/transcribe/getting-started/)

Notes on the chart:

- Wispr Flow is converted from `2,000 desktop words / week` to approximate monthly minutes at `~150 words per minute`.
- Amazon Transcribe's `60 min / month` offer is part of the AWS Free Tier for the first `12 months`, so it is not a permanent recurring free plan.
- ElevenLabs' `2h 30m / month` works out to roughly `22,500-27,000 spoken words / month` at `150-180 wpm`.

The point here is not that ElevenLabs has the single biggest free allowance across every speech product. It is that the free tier is still generous enough to make a high-quality hosted option realistically usable before payment becomes necessary.

## Scope / Non-Goals

This PR only adds the standard ElevenLabs speech-to-text API path.

It does **not** add realtime / streaming transcription. That would be future work if this direction makes sense for the project.

## Validation

- `bun run build`
- `bun run lint`
- `bun run format:check`
- `bun run check:translations`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `bun run test:playwright`

## Notes

I understand this may or may not fit Handy's long-term product direction given the project's local/privacy-first positioning.

If the overall direction is not a fit, that's completely fine. I still wanted to share a version that keeps the cloud path explicitly optional and isolated from the existing local default behavior.
