### PR TITLE
refactor(nix): replace manual bindgen env with rustPlatform.bindgenHook

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,8 +60,6 @@
 
       # Shared environment variables for Rust/native builds
       commonEnv = pkgs: let lib = pkgs.lib; in {
-        LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
-        BINDGEN_EXTRA_CLANG_ARGS = "-isystem ${pkgs.llvmPackages.libclang.lib}/lib/clang/${lib.getVersion pkgs.llvmPackages.libclang}/include -isystem ${pkgs.glibc.dev}/include";
         ORT_LIB_LOCATION = "${pkgs.onnxruntime}/lib";
         ORT_PREFER_DYNAMIC_LINK = "1";
         GST_PLUGIN_SYSTEM_PATH_1_0 = "${lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" (gstPlugins pkgs)}";
@@ -148,7 +146,7 @@
               pkgs.bun2nix.hook # Sets up node_modules from pre-fetched bun cache
               jq
               cmake
-              llvmPackages.libclang
+              rustPlatform.bindgenHook
               shaderc
             ];
 
@@ -246,13 +244,11 @@
               # Build tools
               cargo-tauri
               pkg-config
-              llvmPackages.libclang
+              rustPlatform.bindgenHook
               cmake
             ]);
 
             inherit (commonEnv pkgs)
-              LIBCLANG_PATH
-              BINDGEN_EXTRA_CLANG_ARGS
               ORT_LIB_LOCATION
               ORT_PREFER_DYNAMIC_LINK
               GST_PLUGIN_SYSTEM_PATH_1_0;


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched existing issues and pull requests (including closed ones) to ensure this isn't a duplicate
- [x] I have read CONTRIBUTING.md

## Human Written Description

While reviewing the nixpkgs upstream PR (NixOS/nixpkgs#507754), I discovered that manually setting `BINDGEN_EXTRA_CLANG_ARGS` with `${stdenv.cc.libc}/include` instead of `${stdenv.cc.libc.dev}/include` silently breaks Vulkan bindgen — `bindgenHook` avoids this class of bugs entirely.

- Replaced hand-crafted `LIBCLANG_PATH` and `BINDGEN_EXTRA_CLANG_ARGS` with `rustPlatform.bindgenHook`
- Removed `llvmPackages.libclang` from both package and devShell inputs

`bindgenHook` is a standard nixpkgs setup hook that reads include paths (including `libc.dev`) from the cc-wrapper automatically. It's simpler, less error-prone, and consistent with how other Rust+bindgen packages in nixpkgs handle it (e.g. `atuin-desktop`).

## Related Issues/Discussions

Related to NixOS/nixpkgs#507754

## Testing

- [x] `nix build .#handy` succeeds
- [x] Application launches, hotkeys and transcription work correctly
- [x] Vulkan GPU acceleration works (Whisper Turbo model tested)

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: AI helped research bindgenHook usage patterns in nixpkgs