### PR TITLE
fix(overlay): parse HANDY_NO_GTK_LAYER_SHELL as boolean

### DIFF
--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -66,13 +66,27 @@ fn update_gtk_layer_shell_anchors(overlay_window: &tauri::webview::WebviewWindow
     });
 }
 
+/// Returns true when the environment variable is set to a truthy value
+/// (e.g. "1", "true", "yes", "on").
+/// "0", "false", "no", "off" and empty string are treated as falsy (case-insensitive).
+/// Returns false when the variable is not set.
+#[cfg(target_os = "linux")]
+fn env_flag_enabled(name: &str) -> bool {
+    match env::var(name) {
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "" | "0" | "false" | "no" | "off"
+        ),
+        Err(_) => false,
+    }
+}
+
 /// Initializes GTK layer shell for Linux overlay window
 /// Returns true if layer shell was successfully initialized, false otherwise
 #[cfg(target_os = "linux")]
 fn init_gtk_layer_shell(overlay_window: &tauri::webview::WebviewWindow) -> bool {
-
-    if env::var("HANDY_NO_GTK_LAYER_SHELL").is_ok() {
-        debug!("Skipping GTK layer shell init (HANDY_NO_GTK_LAYER_SHELL is set)");
+    if env_flag_enabled("HANDY_NO_GTK_LAYER_SHELL") {
+        debug!("Skipping GTK layer shell init (HANDY_NO_GTK_LAYER_SHELL is enabled)");
         return false;
     }
 


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Human Written Description

Follow-up to #1121. Currently `HANDY_NO_GTK_LAYER_SHELL` is checked with `env::var().is_ok()`, which means setting it to `0`, `false`, or `no` still disables the layer shell — counterintuitive for users. This adds a small helper that properly parses boolean-like values, as I proposed in this [comment](https://github.com/cjpais/Handy/pull/1121#issuecomment-4189498498).

## Related Issues/Discussions

Follow-up to #1121

## Testing

Tested on NixOS with KDE Plasma / Wayland. Verified that `HANDY_NO_GTK_LAYER_SHELL=0` no longer disables the layer shell, while `HANDY_NO_GTK_LAYER_SHELL=1` still does.

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: implementation of the `env_flag_enabled` helper