### PR TITLE
feat(linux): add xdg-desktop-portal GlobalShortcuts backend for Wayland

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -190,6 +190,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "ashpd"
+version = "0.13.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13bdf0fd848239dcd5e64eeeee35dbc00378ebcc6f3aa4ead0a305eec83d0cfb"
+dependencies = [
+ "enumflags2",
+ "futures-util",
+ "getrandom 0.4.1",
+ "serde",
+ "tokio",
+ "zbus",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2416,6 +2430,7 @@ name = "handy"
 version = "0.8.2"
 dependencies = [
  "anyhow",
+ "ashpd",
  "chrono",
  "clap",
  "cpal",
@@ -6769,8 +6784,10 @@ dependencies = [
  "libc",
  "mio 1.1.1",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -8625,6 +8642,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_repr",
+ "tokio",
  "tracing",
  "uds_windows",
  "uuid",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -106,6 +106,7 @@ transcribe-rs = { version = "0.3.3", features = ["whisper-metal"] }
 gtk-layer-shell = { version = "0.8", features = ["v0_6"] }
 gtk = "0.18"
 transcribe-rs = { version = "0.3.3", features = ["whisper-vulkan"] }
+ashpd = { version = "0.13", features = ["global_shortcuts"] }
 
 [patch.crates-io]
 tauri-runtime = { git = "https://github.com/cjpais/tauri.git", branch = "handy-2.10.2" }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -168,6 +168,7 @@ pub enum RecordingRetentionPeriod {
 pub enum KeyboardImplementation {
     Tauri,
     HandyKeys,
+    Portal,
 }
 
 impl Default for KeyboardImplementation {

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -11,6 +11,8 @@
 
 mod handler;
 pub mod handy_keys;
+#[cfg(target_os = "linux")]
+pub mod portal_impl;
 mod tauri_impl;
 
 use log::{error, info, warn};
@@ -53,6 +55,26 @@ pub fn init_shortcuts(app: &AppHandle) {
                 tauri_impl::init_shortcuts(app);
             }
         }
+        KeyboardImplementation::Portal => {
+            #[cfg(target_os = "linux")]
+            {
+                if let Err(e) = portal_impl::init_shortcuts(app) {
+                    error!("Failed to initialize portal shortcuts: {}", e);
+                    warn!("Falling back to Tauri global shortcut implementation");
+
+                    let mut settings = settings::get_settings(app);
+                    settings.keyboard_implementation = KeyboardImplementation::Tauri;
+                    settings::write_settings(app, settings);
+
+                    tauri_impl::init_shortcuts(app);
+                }
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                warn!("Portal shortcuts are only available on Linux, falling back to Tauri");
+                tauri_impl::init_shortcuts(app);
+            }
+        }
     }
 }
 
@@ -62,6 +84,10 @@ pub fn register_cancel_shortcut(app: &AppHandle) {
     match settings.keyboard_implementation {
         KeyboardImplementation::Tauri => tauri_impl::register_cancel_shortcut(app),
         KeyboardImplementation::HandyKeys => handy_keys::register_cancel_shortcut(app),
+        #[cfg(target_os = "linux")]
+        KeyboardImplementation::Portal => portal_impl::register_cancel_shortcut(app),
+        #[cfg(not(target_os = "linux"))]
+        KeyboardImplementation::Portal => {}
     }
 }
 
@@ -71,6 +97,10 @@ pub fn unregister_cancel_shortcut(app: &AppHandle) {
     match settings.keyboard_implementation {
         KeyboardImplementation::Tauri => tauri_impl::unregister_cancel_shortcut(app),
         KeyboardImplementation::HandyKeys => handy_keys::unregister_cancel_shortcut(app),
+        #[cfg(target_os = "linux")]
+        KeyboardImplementation::Portal => portal_impl::unregister_cancel_shortcut(app),
+        #[cfg(not(target_os = "linux"))]
+        KeyboardImplementation::Portal => {}
     }
 }
 
@@ -80,6 +110,10 @@ pub fn register_shortcut(app: &AppHandle, binding: ShortcutBinding) -> Result<()
     match settings.keyboard_implementation {
         KeyboardImplementation::Tauri => tauri_impl::register_shortcut(app, binding),
         KeyboardImplementation::HandyKeys => handy_keys::register_shortcut(app, binding),
+        #[cfg(target_os = "linux")]
+        KeyboardImplementation::Portal => portal_impl::register_shortcut(app, binding),
+        #[cfg(not(target_os = "linux"))]
+        KeyboardImplementation::Portal => Err("Portal only available on Linux".into()),
     }
 }
 
@@ -89,6 +123,10 @@ pub fn unregister_shortcut(app: &AppHandle, binding: ShortcutBinding) -> Result<
     match settings.keyboard_implementation {
         KeyboardImplementation::Tauri => tauri_impl::unregister_shortcut(app, binding),
         KeyboardImplementation::HandyKeys => handy_keys::unregister_shortcut(app, binding),
+        #[cfg(target_os = "linux")]
+        KeyboardImplementation::Portal => portal_impl::unregister_shortcut(app, binding),
+        #[cfg(not(target_os = "linux"))]
+        KeyboardImplementation::Portal => Ok(()),
     }
 }
 
@@ -282,10 +320,20 @@ pub fn change_keyboard_implementation_setting(
     settings.keyboard_implementation = new_impl;
     settings::write_settings(&app, settings);
 
-    // Initialize new implementation if needed (HandyKeys needs state)
+    // Initialize new implementation if needed (HandyKeys and Portal need state)
     if new_impl == KeyboardImplementation::HandyKeys {
         if initialize_handy_keys_with_rollback(&app)? {
             // Shortcuts already registered during init
+            return Ok(ImplementationChangeResult {
+                success: true,
+                reset_bindings: vec![],
+            });
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    if new_impl == KeyboardImplementation::Portal {
+        if initialize_portal_with_rollback(&app)? {
             return Ok(ImplementationChangeResult {
                 success: true,
                 reset_bindings: vec![],
@@ -322,6 +370,7 @@ pub fn get_keyboard_implementation(app: AppHandle) -> String {
     match settings.keyboard_implementation {
         KeyboardImplementation::Tauri => "tauri".to_string(),
         KeyboardImplementation::HandyKeys => "handy_keys".to_string(),
+        KeyboardImplementation::Portal => "portal".to_string(),
     }
 }
 
@@ -337,6 +386,10 @@ fn validate_shortcut_for_implementation(
     match implementation {
         KeyboardImplementation::Tauri => tauri_impl::validate_shortcut(raw),
         KeyboardImplementation::HandyKeys => handy_keys::validate_shortcut(raw),
+        #[cfg(target_os = "linux")]
+        KeyboardImplementation::Portal => portal_impl::validate_shortcut(raw),
+        #[cfg(not(target_os = "linux"))]
+        KeyboardImplementation::Portal => Err("Portal only available on Linux".into()),
     }
 }
 
@@ -345,6 +398,7 @@ fn parse_keyboard_implementation(s: &str) -> KeyboardImplementation {
     match s {
         "tauri" => KeyboardImplementation::Tauri,
         "handy_keys" => KeyboardImplementation::HandyKeys,
+        "portal" => KeyboardImplementation::Portal,
         other => {
             warn!(
                 "Invalid keyboard implementation '{}', defaulting to tauri",
@@ -368,6 +422,10 @@ fn unregister_all_shortcuts(app: &AppHandle, implementation: KeyboardImplementat
         let result = match implementation {
             KeyboardImplementation::Tauri => tauri_impl::unregister_shortcut(app, binding),
             KeyboardImplementation::HandyKeys => handy_keys::unregister_shortcut(app, binding),
+            #[cfg(target_os = "linux")]
+            KeyboardImplementation::Portal => portal_impl::unregister_shortcut(app, binding),
+            #[cfg(not(target_os = "linux"))]
+            KeyboardImplementation::Portal => Ok(()),
         };
 
         if let Err(e) = result {
@@ -426,6 +484,10 @@ fn register_all_shortcuts_for_implementation(
         let result = match implementation {
             KeyboardImplementation::Tauri => tauri_impl::register_shortcut(app, binding),
             KeyboardImplementation::HandyKeys => handy_keys::register_shortcut(app, binding),
+            #[cfg(target_os = "linux")]
+            KeyboardImplementation::Portal => portal_impl::register_shortcut(app, binding),
+            #[cfg(not(target_os = "linux"))]
+            KeyboardImplementation::Portal => Err("Portal only available on Linux".into()),
         };
 
         if let Err(e) = result {
@@ -464,6 +526,31 @@ fn initialize_handy_keys_with_rollback(app: &AppHandle) -> Result<bool, String> 
     }
 
     // init_shortcuts already registered shortcuts
+    Ok(true)
+}
+
+/// Initialize Portal if not already initialized, with rollback on failure
+#[cfg(target_os = "linux")]
+fn initialize_portal_with_rollback(app: &AppHandle) -> Result<bool, String> {
+    if app
+        .try_state::<portal_impl::PortalState>()
+        .is_some()
+    {
+        return Ok(false);
+    }
+
+    if let Err(e) = portal_impl::init_shortcuts(app) {
+        error!("Failed to initialize Portal: {}", e);
+        let mut settings = settings::get_settings(app);
+        settings.keyboard_implementation = KeyboardImplementation::Tauri;
+        settings::write_settings(app, settings);
+        tauri_impl::init_shortcuts(app);
+        return Err(format!(
+            "Failed to initialize Portal: {}. Reverted to Tauri.",
+            e
+        ));
+    }
+
     Ok(true)
 }
 

--- a/src-tauri/src/shortcut/portal_impl.rs
+++ b/src-tauri/src/shortcut/portal_impl.rs
@@ -1,0 +1,387 @@
+//! xdg-desktop-portal GlobalShortcuts implementation
+//!
+//! This module provides shortcut functionality using the freedesktop
+//! GlobalShortcuts portal interface, which works natively on Wayland
+//! compositors that implement it (GNOME 45+, KDE Plasma 6+, etc.).
+//!
+//! ## Architecture
+//!
+//! The portal API is async (D-Bus via zbus), while Handy's shortcut
+//! interface is synchronous. A background tokio task owns the portal
+//! session and processes commands sent over an mpsc channel:
+//!
+//! ```text
+//! ┌──────────────────┐   PortalCommand    ┌────────────────────────┐
+//! │   Main Thread    │ ─────────────────▶ │   Portal Task (async)  │
+//! │                  │   (tokio mpsc)     │                        │
+//! │ - register()     │                    │ - owns Session         │
+//! │ - unregister()   │ ◀───────────────── │ - calls bind_shortcuts │
+//! │                  │   (std mpsc resp)  │ - listens for signals  │
+//! └──────────────────┘                    └────────────────────────┘
+//! ```
+//!
+//! The portal's `bind_shortcuts` is declarative: it replaces the full
+//! set of shortcuts on each call. The task maintains the complete
+//! shortcut map and rebinds everything whenever a binding changes.
+
+use ashpd::desktop::global_shortcuts::{
+    Activated, Deactivated, GlobalShortcuts, NewShortcut,
+};
+use futures_util::StreamExt;
+use log::{debug, error, info, warn};
+use std::collections::HashMap;
+use std::sync::mpsc as std_mpsc;
+use tauri::{AppHandle, Manager};
+use tokio::sync::mpsc;
+
+use crate::settings::{self, ShortcutBinding};
+
+use super::handler::handle_shortcut_event;
+
+/// Commands sent from the synchronous API to the portal background task.
+enum PortalCommand {
+    Register {
+        binding: ShortcutBinding,
+        response: std_mpsc::Sender<Result<(), String>>,
+    },
+    RegisterBatch {
+        bindings: Vec<ShortcutBinding>,
+        response: std_mpsc::Sender<Result<(), String>>,
+    },
+    Unregister {
+        binding_id: String,
+        response: std_mpsc::Sender<Result<(), String>>,
+    },
+    Shutdown,
+}
+
+/// Tauri-managed state for the portal shortcut backend.
+pub struct PortalState {
+    command_tx: mpsc::UnboundedSender<PortalCommand>,
+}
+
+impl PortalState {
+    fn register_batch(&self, bindings: Vec<ShortcutBinding>) -> Result<(), String> {
+        let (tx, rx) = std_mpsc::channel();
+        self.command_tx
+            .send(PortalCommand::RegisterBatch {
+                bindings,
+                response: tx,
+            })
+            .map_err(|_| "Portal task is not running".to_string())?;
+        rx.recv()
+            .map_err(|_| "Failed to receive portal response".to_string())?
+    }
+
+    fn register(&self, binding: &ShortcutBinding) -> Result<(), String> {
+        let (tx, rx) = std_mpsc::channel();
+        self.command_tx
+            .send(PortalCommand::Register {
+                binding: binding.clone(),
+                response: tx,
+            })
+            .map_err(|_| "Portal task is not running".to_string())?;
+        rx.recv()
+            .map_err(|_| "Failed to receive portal response".to_string())?
+    }
+
+    fn unregister(&self, binding_id: &str) -> Result<(), String> {
+        let (tx, rx) = std_mpsc::channel();
+        self.command_tx
+            .send(PortalCommand::Unregister {
+                binding_id: binding_id.to_string(),
+                response: tx,
+            })
+            .map_err(|_| "Portal task is not running".to_string())?;
+        rx.recv()
+            .map_err(|_| "Failed to receive portal response".to_string())?
+    }
+}
+
+impl Drop for PortalState {
+    fn drop(&mut self) {
+        let _ = self.command_tx.send(PortalCommand::Shutdown);
+    }
+}
+
+/// Background task that owns the portal session and processes shortcut
+/// commands. Runs on the tokio runtime for the lifetime of the app.
+async fn portal_task(mut cmd_rx: mpsc::UnboundedReceiver<PortalCommand>, app: AppHandle) {
+    let proxy = match GlobalShortcuts::new().await {
+        Ok(p) => p,
+        Err(e) => {
+            error!("Failed to connect to GlobalShortcuts portal: {}", e);
+            // Drain any pending commands so callers don't hang
+            while let Some(cmd) = cmd_rx.recv().await {
+                match cmd {
+                    PortalCommand::Register { response, .. }
+                    | PortalCommand::RegisterBatch { response, .. }
+                    | PortalCommand::Unregister { response, .. } => {
+                        let _ = response.send(Err(format!("Portal unavailable: {}", e)));
+                    }
+                    PortalCommand::Shutdown => break,
+                }
+            }
+            return;
+        }
+    };
+
+    let session = match proxy.create_session(Default::default()).await {
+        Ok(s) => s,
+        Err(e) => {
+            error!("Failed to create GlobalShortcuts session: {}", e);
+            while let Some(cmd) = cmd_rx.recv().await {
+                match cmd {
+                    PortalCommand::Register { response, .. }
+                    | PortalCommand::RegisterBatch { response, .. }
+                    | PortalCommand::Unregister { response, .. } => {
+                        let _ = response.send(Err(format!("Session creation failed: {}", e)));
+                    }
+                    PortalCommand::Shutdown => break,
+                }
+            }
+            return;
+        }
+    };
+
+    info!("GlobalShortcuts portal session created");
+
+    let mut activated = match proxy.receive_activated().await {
+        Ok(s) => s,
+        Err(e) => {
+            error!("Failed to subscribe to Activated signal: {}", e);
+            return;
+        }
+    };
+
+    let mut deactivated = match proxy.receive_deactivated().await {
+        Ok(s) => s,
+        Err(e) => {
+            error!("Failed to subscribe to Deactivated signal: {}", e);
+            return;
+        }
+    };
+
+    // The full set of currently registered shortcuts, keyed by binding id.
+    let mut shortcuts: HashMap<String, ShortcutBinding> = HashMap::new();
+
+    loop {
+        tokio::select! {
+            Some(cmd) = cmd_rx.recv() => {
+                match cmd {
+                    PortalCommand::Register { binding, response } => {
+                        debug!("Portal: registering shortcut '{}'", binding.id);
+                        shortcuts.insert(binding.id.clone(), binding);
+                        let result = rebind_all(&proxy, &session, &shortcuts).await;
+                        let _ = response.send(result);
+                    }
+                    PortalCommand::RegisterBatch { bindings, response } => {
+                        debug!("Portal: registering {} shortcuts at once", bindings.len());
+                        for binding in bindings {
+                            shortcuts.insert(binding.id.clone(), binding);
+                        }
+                        let result = rebind_all(&proxy, &session, &shortcuts).await;
+                        let _ = response.send(result);
+                    }
+                    PortalCommand::Unregister { binding_id, response } => {
+                        debug!("Portal: unregistering shortcut '{}'", binding_id);
+                        shortcuts.remove(&binding_id);
+                        let result = rebind_all(&proxy, &session, &shortcuts).await;
+                        let _ = response.send(result);
+                    }
+                    PortalCommand::Shutdown => {
+                        info!("Portal shortcut task shutting down");
+                        break;
+                    }
+                }
+            }
+            Some(signal) = activated.next() => {
+                let signal: Activated = signal;
+                let id = signal.shortcut_id();
+                if let Some(binding) = shortcuts.get(id) {
+                    debug!("Portal shortcut activated: {}", id);
+                    handle_shortcut_event(&app, &binding.id, &binding.current_binding, true);
+                } else {
+                    warn!("Activated signal for unknown shortcut '{}'", id);
+                }
+            }
+            Some(signal) = deactivated.next() => {
+                let signal: Deactivated = signal;
+                let id = signal.shortcut_id();
+                if let Some(binding) = shortcuts.get(id) {
+                    debug!("Portal shortcut deactivated: {}", id);
+                    handle_shortcut_event(&app, &binding.id, &binding.current_binding, false);
+                }
+            }
+            else => {
+                warn!("Portal event streams closed unexpectedly");
+                break;
+            }
+        }
+    }
+
+    debug!("Portal shortcut task stopped");
+}
+
+/// Rebind the full set of shortcuts via the portal. The portal API is
+/// declarative: each `bind_shortcuts` call replaces the previous set.
+async fn rebind_all(
+    proxy: &GlobalShortcuts,
+    session: &ashpd::desktop::Session<GlobalShortcuts>,
+    shortcuts: &HashMap<String, ShortcutBinding>,
+) -> Result<(), String> {
+    let portal_shortcuts: Vec<NewShortcut> = shortcuts
+        .values()
+        .map(|b| {
+            let trigger = to_portal_trigger(&b.current_binding);
+            NewShortcut::new(&b.id, &b.id).preferred_trigger(Some(trigger.as_str()))
+        })
+        .collect();
+
+    if portal_shortcuts.is_empty() {
+        debug!("No shortcuts to bind");
+        return Ok(());
+    }
+
+    let request = proxy
+        .bind_shortcuts(session, &portal_shortcuts, None, Default::default())
+        .await
+        .map_err(|e| format!("bind_shortcuts failed: {}", e))?;
+
+    match request.response() {
+        Ok(bound) => {
+            debug!(
+                "Portal bound {} shortcut(s): {:?}",
+                bound.shortcuts().len(),
+                bound
+                    .shortcuts()
+                    .iter()
+                    .map(|s| s.id().to_string())
+                    .collect::<Vec<_>>()
+            );
+        }
+        Err(e) => {
+            return Err(format!("bind_shortcuts response: {}", e));
+        }
+    }
+
+    Ok(())
+}
+
+/// Convert Handy's shortcut format to the portal trigger format.
+///
+/// Handy uses lowercase "ctrl+space", "alt+shift+a", etc. KDE's portal
+/// expects capitalised modifier names (Ctrl, Shift, Alt, Meta) and a
+/// capitalised key name. Passing lowercase "ctrl" causes KDE to log
+/// "Unknown modifier" and silently ignore the preferred trigger.
+fn to_portal_trigger(handy_format: &str) -> String {
+    handy_format
+        .split('+')
+        .map(|part| match part.trim().to_lowercase().as_str() {
+            "ctrl" | "control" => "Ctrl".to_string(),
+            "shift" => "Shift".to_string(),
+            "alt" | "option" => "Alt".to_string(),
+            "super" | "meta" | "command" | "cmd" => "Meta".to_string(),
+            other => {
+                // Capitalise the first letter of key names (space -> Space, etc.)
+                let mut chars = other.chars();
+                match chars.next() {
+                    Some(c) => c.to_uppercase().to_string() + chars.as_str(),
+                    None => String::new(),
+                }
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("+")
+}
+
+// ============================================================================
+// Public API (matches the interface expected by shortcut/mod.rs)
+// ============================================================================
+
+/// Initialize shortcuts using the GlobalShortcuts portal.
+pub fn init_shortcuts(app: &AppHandle) -> Result<(), String> {
+    let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
+    let state = PortalState { command_tx: cmd_tx };
+
+    // Spawn the background task that manages the portal session
+    let app_clone = app.clone();
+    tauri::async_runtime::spawn(async move {
+        portal_task(cmd_rx, app_clone).await;
+    });
+
+    // Give the async task a moment to establish the D-Bus connection.
+    // Without this the first register call can race ahead of session
+    // creation. 200ms is more than enough for local D-Bus.
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    let default_bindings = settings::get_default_settings().bindings;
+    let user_settings = settings::load_or_create_app_settings(app);
+
+    // Collect all bindings and register them in a single bind_shortcuts
+    // call. The portal API is declarative -- each call replaces the full
+    // set, so individual registration would cause earlier shortcuts to be
+    // overwritten. KDE shows one confirmation dialog for all new shortcuts
+    // on first launch, then remembers them for subsequent launches (as
+    // long as the app_id is stable).
+    let mut initial_bindings = Vec::new();
+    for (id, default_binding) in default_bindings {
+        if id == "transcribe_with_post_process" && !user_settings.post_process_enabled {
+            continue;
+        }
+
+        let binding = user_settings
+            .bindings
+            .get(&id)
+            .cloned()
+            .unwrap_or(default_binding);
+
+        initial_bindings.push(binding);
+    }
+
+    if let Err(e) = state.register_batch(initial_bindings) {
+        error!("Failed to register portal shortcuts during init: {}", e);
+    }
+
+    app.manage(state);
+    info!("Portal shortcuts initialized");
+    Ok(())
+}
+
+/// Register a shortcut via the portal.
+pub fn register_shortcut(app: &AppHandle, binding: ShortcutBinding) -> Result<(), String> {
+    let state = app
+        .try_state::<PortalState>()
+        .ok_or("PortalState not initialized")?;
+    state.register(&binding)
+}
+
+/// Unregister a shortcut from the portal.
+pub fn unregister_shortcut(app: &AppHandle, binding: ShortcutBinding) -> Result<(), String> {
+    let state = app
+        .try_state::<PortalState>()
+        .ok_or("PortalState not initialized")?;
+    state.unregister(&binding.id)
+}
+
+/// Register the cancel shortcut (no-op for portal).
+///
+/// The portal backend registers cancel at init along with all other
+/// shortcuts. Dynamic registration is avoided because each
+/// bind_shortcuts call triggers a compositor confirmation dialog.
+pub fn register_cancel_shortcut(_app: &AppHandle) {}
+
+/// Unregister the cancel shortcut (no-op for portal).
+pub fn unregister_cancel_shortcut(_app: &AppHandle) {}
+
+/// Validate a shortcut string for the portal backend.
+///
+/// The portal is lenient: the trigger string is treated as a preferred
+/// hint and the compositor decides what to actually assign. We just
+/// reject obviously empty input.
+pub fn validate_shortcut(raw: &str) -> Result<(), String> {
+    if raw.trim().is_empty() {
+        return Err("Shortcut cannot be empty".into());
+    }
+    Ok(())
+}

--- a/src/components/settings/debug/KeyboardImplementationSelector.tsx
+++ b/src/components/settings/debug/KeyboardImplementationSelector.tsx
@@ -9,6 +9,7 @@ import { toast } from "sonner";
 const KEYBOARD_IMPLEMENTATION_OPTIONS: DropdownOption[] = [
   { value: "tauri", label: "Tauri Global Shortcut" },
   { value: "handy_keys", label: "Handy Keys" },
+  { value: "portal", label: "XDG Desktop Portal" },
 ];
 
 interface KeyboardImplementationSelectorProps {


### PR DESCRIPTION
Adds xdg-desktop-portal GlobalShortcuts as a third keyboard implementation option for Linux. This gives Wayland users proper global shortcut support with full press/release events, so push-to-talk actually works.

The existing Tauri and HandyKeys backends both depend on X11 APIs that don't work on Wayland (XGrab and rdev respectively), which has been an open issue for a while (#949, #1236, #1239). PR #572 took a workaround approach using gsettings + SIGUSR2 signals, but that only supports toggle mode and is GNOME-specific. The portal approach is the standard freedesktop mechanism and works at the compositor level.

The backend creates a D-Bus session with the GlobalShortcuts portal and registers all shortcuts in a single `bind_shortcuts` call. The compositor (KDE, etc.) shows a one-time confirmation dialog, then sends Activated/Deactivated signals whenever the user presses/releases the shortcut. These map directly to the existing `handle_shortcut_event` handler, so push-to-talk works out of the box.

Cancel is registered at init alongside the other shortcuts rather than dynamically, because each `bind_shortcuts` call can trigger a compositor dialog. The dynamic register/unregister calls from `mod.rs` are no-ops for this backend. If the portal isn't available (X11 session, unsupported compositor, etc.), it falls back to Tauri automatically and saves the setting.

Tested on KDE Plasma 6 Wayland -- shortcuts register, push-to-talk works with press/release, permissions persist across restarts when launched from the app menu.

GNOME 49's portal (v1) rejects `bind_shortcuts` for non-Flatpak apps. The backend detects this and falls back to Tauri, so there's no user-facing breakage. GNOME 50 doesn't fix this either -- seems to be a design limitation of their portal implementation.

The app needs to be launched from the desktop menu (not a terminal) for KDE to assign the correct `app_id` and persist shortcut permissions. When launched from a terminal, KDE inherits the terminal's app_id instead.

The recording overlay can steal focus on KDE Wayland since gtk-layer-shell isn't supported there. Setting overlay position to "None" works around it. This is pre-existing and now configurable via `HANDY_NO_GTK_LAYER_SHELL=1`.
