### PR TITLE
fix: initialize model language filter from user preference (#1265)

### DIFF
--- a/src/components/settings/models/ModelsSettings.tsx
+++ b/src/components/settings/models/ModelsSettings.tsx
@@ -6,6 +6,7 @@ import type { ModelCardStatus } from "@/components/onboarding";
 import { ModelCard } from "@/components/onboarding";
 import { useModelStore } from "@/stores/modelStore";
 import { LANGUAGES } from "@/lib/constants/languages.ts";
+import { useSettings } from "@/hooks/useSettings";
 import type { ModelInfo } from "@/bindings";
 
 // check if model supports a language based on its supported_languages list
@@ -15,8 +16,12 @@ const modelSupportsLanguage = (model: ModelInfo, langCode: string): boolean => {
 
 export const ModelsSettings: React.FC = () => {
   const { t } = useTranslation();
+  const { getSetting } = useSettings();
   const [switchingModelId, setSwitchingModelId] = useState<string | null>(null);
-  const [languageFilter, setLanguageFilter] = useState("all");
+  const savedLanguage = getSetting("selected_language");
+  const initialFilter =
+    savedLanguage && savedLanguage !== "auto" ? savedLanguage : "all";
+  const [languageFilter, setLanguageFilter] = useState(initialFilter);
   const [languageDropdownOpen, setLanguageDropdownOpen] = useState(false);
   const [languageSearch, setLanguageSearch] = useState("");
   const languageDropdownRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
## Summary

- The Models settings page always showed all models regardless of the user's selected transcription language
- Now initializes the language filter dropdown from the user's `selected_language` setting
- When `selected_language` is "auto" or unset, defaults to "All Languages" (preserves current behavior)

Closes #1265

## Details

The `ModelsSettings` component had a local `languageFilter` state hardcoded to `"all"`. This meant every time a user opened Settings > Models, they'd see all models in all languages -- even if they'd configured English-only transcription.

The fix reads `selected_language` from `AppSettings` via the existing `useSettings` hook (same pattern as `LanguageSelector.tsx`) and uses it as the initial filter value. The dropdown still allows browsing models in other languages by manually changing the filter.

Mapping: `"auto"` / `undefined` -> `"all"` (show everything); `"en"`, `"de"`, etc. -> filter directly.

## Test plan

- [ ] Set language to "English" in Settings > General, then open Settings > Models -- should show only English-capable models
- [ ] Set language to "Auto Detect" -- Models page should show all models (no filter)
- [ ] With language set to "German": Models page pre-filters to German, but dropdown can be changed to "All Languages" to browse everything
- [ ] Fresh install (no language set): Models page shows all models