### PR TITLE
fix: don't auto-delete recordings when changing history settings (#1262)

### DIFF
--- a/src-tauri/src/commands/history.rs
+++ b/src-tauri/src/commands/history.rs
@@ -108,19 +108,10 @@ pub async fn retry_history_entry_transcription(
 
 #[tauri::command]
 #[specta::specta]
-pub async fn update_history_limit(
-    app: AppHandle,
-    history_manager: State<'_, Arc<HistoryManager>>,
-    limit: usize,
-) -> Result<(), String> {
+pub async fn update_history_limit(app: AppHandle, limit: usize) -> Result<(), String> {
     let mut settings = crate::settings::get_settings(&app);
     settings.history_limit = limit;
     crate::settings::write_settings(&app, settings);
-
-    history_manager
-        .cleanup_old_entries()
-        .map_err(|e| e.to_string())?;
-
     Ok(())
 }
 
@@ -128,7 +119,6 @@ pub async fn update_history_limit(
 #[specta::specta]
 pub async fn update_recording_retention_period(
     app: AppHandle,
-    history_manager: State<'_, Arc<HistoryManager>>,
     period: String,
 ) -> Result<(), String> {
     use crate::settings::RecordingRetentionPeriod;
@@ -145,10 +135,5 @@ pub async fn update_recording_retention_period(
     let mut settings = crate::settings::get_settings(&app);
     settings.recording_retention_period = retention_period;
     crate::settings::write_settings(&app, settings);
-
-    history_manager
-        .cleanup_old_entries()
-        .map_err(|e| e.to_string())?;
-
     Ok(())
 }

--- a/src/components/settings/HistoryLimit.tsx
+++ b/src/components/settings/HistoryLimit.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { useSettings } from "../../hooks/useSettings";
 import { Input } from "../ui/Input";
 import { SettingContainer } from "../ui/SettingContainer";
@@ -21,6 +22,11 @@ export const HistoryLimit: React.FC<HistoryLimitProps> = ({
   const handleChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = parseInt(event.target.value, 10);
     if (!isNaN(value) && value >= 0) {
+      if (value < historyLimit) {
+        toast.warning(t("settings.debug.historyLimit.warningTitle"), {
+          description: t("settings.debug.historyLimit.warningDescription"),
+        });
+      }
       updateSetting("history_limit", value);
     }
   };

--- a/src/components/settings/RecordingRetentionPeriod.tsx
+++ b/src/components/settings/RecordingRetentionPeriod.tsx
@@ -21,18 +21,12 @@ export const RecordingRetentionPeriodSelector: React.FC<RecordingRetentionPeriod
     const historyLimit = getSetting("history_limit") || 5;
 
     const handleRetentionPeriodSelect = async (period: string) => {
-      if (
-        selectedRetentionPeriod === "never" &&
-        period !== "never"
-      ) {
-        toast.warning(
-          t("settings.debug.recordingRetention.warningTitle"),
-          {
-            description: t(
-              "settings.debug.recordingRetention.warningDescription",
-            ),
-          },
-        );
+      if (selectedRetentionPeriod === "never" && period !== "never") {
+        toast.warning(t("settings.debug.recordingRetention.warningTitle"), {
+          description: t(
+            "settings.debug.recordingRetention.warningDescription",
+          ),
+        });
       }
       await updateSetting(
         "recording_retention_period",

--- a/src/components/settings/RecordingRetentionPeriod.tsx
+++ b/src/components/settings/RecordingRetentionPeriod.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { Dropdown } from "../ui/Dropdown";
 import { SettingContainer } from "../ui/SettingContainer";
 import { useSettings } from "../../hooks/useSettings";
@@ -20,6 +21,19 @@ export const RecordingRetentionPeriodSelector: React.FC<RecordingRetentionPeriod
     const historyLimit = getSetting("history_limit") || 5;
 
     const handleRetentionPeriodSelect = async (period: string) => {
+      if (
+        selectedRetentionPeriod === "never" &&
+        period !== "never"
+      ) {
+        toast.warning(
+          t("settings.debug.recordingRetention.warningTitle"),
+          {
+            description: t(
+              "settings.debug.recordingRetention.warningDescription",
+            ),
+          },
+        );
+      }
       await updateSetting(
         "recording_retention_period",
         period as RecordingRetentionPeriod,

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -437,8 +437,8 @@
         "title": "حد السجل",
         "description": "الحد الأقصى لعدد إدخالات السجل المراد الاحتفاظ بها",
         "entries": "إدخالات",
-        "warningTitle": "Recordings may be removed",
-        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
+        "warningTitle": "قد يتم حذف التسجيلات",
+        "warningDescription": "سيتم حذف الإدخالات التي تتجاوز الحد الجديد عند التسجيل التالي."
       },
       "recordingRetention": {
         "title": "حذف التسجيلات تلقائياً",
@@ -449,8 +449,8 @@
         "weeks2": "بعد أسبوعين",
         "months3": "بعد 3 أشهر",
         "placeholder": "اختر فترة الاحتفاظ...",
-        "warningTitle": "Auto-delete enabled",
-        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
+        "warningTitle": "تم تفعيل الحذف التلقائي",
+        "warningDescription": "سيتم حذف التسجيلات الأقدم من فترة الاحتفاظ عند التسجيل التالي."
       },
       "alwaysOnMicrophone": {
         "label": "ميكروفون يعمل دائماً",

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -436,7 +436,9 @@
       "historyLimit": {
         "title": "حد السجل",
         "description": "الحد الأقصى لعدد إدخالات السجل المراد الاحتفاظ بها",
-        "entries": "إدخالات"
+        "entries": "إدخالات",
+        "warningTitle": "Recordings may be removed",
+        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
       },
       "recordingRetention": {
         "title": "حذف التسجيلات تلقائياً",
@@ -446,7 +448,9 @@
         "days3": "بعد 3 أيام",
         "weeks2": "بعد أسبوعين",
         "months3": "بعد 3 أشهر",
-        "placeholder": "اختر فترة الاحتفاظ..."
+        "placeholder": "اختر فترة الاحتفاظ...",
+        "warningTitle": "Auto-delete enabled",
+        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
       },
       "alwaysOnMicrophone": {
         "label": "ميكروفون يعمل دائماً",

--- a/src/i18n/locales/bg/translation.json
+++ b/src/i18n/locales/bg/translation.json
@@ -458,7 +458,9 @@
       "historyLimit": {
         "title": "Лимит на историята",
         "description": "Максимален брой записи в историята за пазене",
-        "entries": "записа"
+        "entries": "записа",
+        "warningTitle": "Recordings may be removed",
+        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
       },
       "recordingRetention": {
         "title": "Автоматично изтриване на записи",
@@ -468,7 +470,9 @@
         "days3": "След 3 дни",
         "weeks2": "След 2 седмици",
         "months3": "След 3 месеца",
-        "placeholder": "Изберете период на съхранение..."
+        "placeholder": "Изберете период на съхранение...",
+        "warningTitle": "Auto-delete enabled",
+        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
       },
       "alwaysOnMicrophone": {
         "label": "Постоянно активен микрофон",

--- a/src/i18n/locales/bg/translation.json
+++ b/src/i18n/locales/bg/translation.json
@@ -459,8 +459,8 @@
         "title": "Лимит на историята",
         "description": "Максимален брой записи в историята за пазене",
         "entries": "записа",
-        "warningTitle": "Recordings may be removed",
-        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
+        "warningTitle": "Записите може да бъдат премахнати",
+        "warningDescription": "Записите над новия лимит ще бъдат изтрити при следващия запис."
       },
       "recordingRetention": {
         "title": "Автоматично изтриване на записи",
@@ -471,8 +471,8 @@
         "weeks2": "След 2 седмици",
         "months3": "След 3 месеца",
         "placeholder": "Изберете период на съхранение...",
-        "warningTitle": "Auto-delete enabled",
-        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
+        "warningTitle": "Автоматичното изтриване е включено",
+        "warningDescription": "Записите, по-стари от периода на съхранение, ще бъдат изтрити при следващия запис."
       },
       "alwaysOnMicrophone": {
         "label": "Постоянно активен микрофон",

--- a/src/i18n/locales/cs/translation.json
+++ b/src/i18n/locales/cs/translation.json
@@ -458,7 +458,9 @@
       "historyLimit": {
         "title": "Limit historie",
         "description": "Maximální počet záznamů historie k uchování",
-        "entries": "záznamů"
+        "entries": "záznamů",
+        "warningTitle": "Recordings may be removed",
+        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
       },
       "recordingRetention": {
         "title": "Automatické mazání nahrávek",
@@ -468,7 +470,9 @@
         "days3": "Po 3 dnech",
         "weeks2": "Po 2 týdnech",
         "months3": "Po 3 měsících",
-        "placeholder": "Vyberte dobu uchování..."
+        "placeholder": "Vyberte dobu uchování...",
+        "warningTitle": "Auto-delete enabled",
+        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
       },
       "alwaysOnMicrophone": {
         "label": "Vždy zapnutý mikrofon",

--- a/src/i18n/locales/cs/translation.json
+++ b/src/i18n/locales/cs/translation.json
@@ -459,8 +459,8 @@
         "title": "Limit historie",
         "description": "Maximální počet záznamů historie k uchování",
         "entries": "záznamů",
-        "warningTitle": "Recordings may be removed",
-        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
+        "warningTitle": "Nahrávky mohou být odstraněny",
+        "warningDescription": "Záznamy překračující nový limit budou smazány při dalším nahrávání."
       },
       "recordingRetention": {
         "title": "Automatické mazání nahrávek",
@@ -471,8 +471,8 @@
         "weeks2": "Po 2 týdnech",
         "months3": "Po 3 měsících",
         "placeholder": "Vyberte dobu uchování...",
-        "warningTitle": "Auto-delete enabled",
-        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
+        "warningTitle": "Automatické mazání zapnuto",
+        "warningDescription": "Nahrávky starší než doba uchovávání budou smazány při dalším nahrávání."
       },
       "alwaysOnMicrophone": {
         "label": "Vždy zapnutý mikrofon",

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -458,7 +458,9 @@
       "historyLimit": {
         "title": "Verlaufslimit",
         "description": "Maximale Anzahl der Verlaufseinträge",
-        "entries": "Einträge"
+        "entries": "Einträge",
+        "warningTitle": "Recordings may be removed",
+        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
       },
       "recordingRetention": {
         "title": "Aufnahmen automatisch löschen",
@@ -468,7 +470,9 @@
         "days3": "Nach 3 Tagen",
         "weeks2": "Nach 2 Wochen",
         "months3": "Nach 3 Monaten",
-        "placeholder": "Aufbewahrungszeitraum auswählen..."
+        "placeholder": "Aufbewahrungszeitraum auswählen...",
+        "warningTitle": "Auto-delete enabled",
+        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
       },
       "alwaysOnMicrophone": {
         "label": "Mikrofon immer aktiv",

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -459,8 +459,8 @@
         "title": "Verlaufslimit",
         "description": "Maximale Anzahl der Verlaufseinträge",
         "entries": "Einträge",
-        "warningTitle": "Recordings may be removed",
-        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
+        "warningTitle": "Aufnahmen werden möglicherweise entfernt",
+        "warningDescription": "Einträge über dem neuen Limit werden bei der nächsten Aufnahme gelöscht."
       },
       "recordingRetention": {
         "title": "Aufnahmen automatisch löschen",
@@ -471,8 +471,8 @@
         "weeks2": "Nach 2 Wochen",
         "months3": "Nach 3 Monaten",
         "placeholder": "Aufbewahrungszeitraum auswählen...",
-        "warningTitle": "Auto-delete enabled",
-        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
+        "warningTitle": "Automatisches Löschen aktiviert",
+        "warningDescription": "Aufnahmen, die älter als der Aufbewahrungszeitraum sind, werden bei der nächsten Aufnahme gelöscht."
       },
       "alwaysOnMicrophone": {
         "label": "Mikrofon immer aktiv",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -458,7 +458,9 @@
       "historyLimit": {
         "title": "History Limit",
         "description": "Maximum number of history entries to keep",
-        "entries": "entries"
+        "entries": "entries",
+        "warningTitle": "Recordings may be removed",
+        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
       },
       "recordingRetention": {
         "title": "Auto-Delete Recordings",
@@ -468,7 +470,9 @@
         "days3": "After 3 days",
         "weeks2": "After 2 weeks",
         "months3": "After 3 months",
-        "placeholder": "Select retention period..."
+        "placeholder": "Select retention period...",
+        "warningTitle": "Auto-delete enabled",
+        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
       },
       "alwaysOnMicrophone": {
         "label": "Always-On Microphone",

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -459,8 +459,8 @@
         "title": "Límite de Historial",
         "description": "Número máximo de entradas de historial a conservar",
         "entries": "entradas",
-        "warningTitle": "Recordings may be removed",
-        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
+        "warningTitle": "Las grabaciones podrían eliminarse",
+        "warningDescription": "Las entradas que superen el nuevo límite se eliminarán en la próxima grabación."
       },
       "recordingRetention": {
         "title": "Eliminación automática de grabaciones",
@@ -471,8 +471,8 @@
         "weeks2": "Después de 2 semanas",
         "months3": "Después de 3 meses",
         "placeholder": "Seleccionar período de retención...",
-        "warningTitle": "Auto-delete enabled",
-        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
+        "warningTitle": "Eliminación automática activada",
+        "warningDescription": "Las grabaciones anteriores al periodo de retención se eliminarán en la próxima grabación."
       },
       "alwaysOnMicrophone": {
         "label": "Micrófono Siempre Activo",

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -458,7 +458,9 @@
       "historyLimit": {
         "title": "Límite de Historial",
         "description": "Número máximo de entradas de historial a conservar",
-        "entries": "entradas"
+        "entries": "entradas",
+        "warningTitle": "Recordings may be removed",
+        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
       },
       "recordingRetention": {
         "title": "Eliminación automática de grabaciones",
@@ -468,7 +470,9 @@
         "days3": "Después de 3 días",
         "weeks2": "Después de 2 semanas",
         "months3": "Después de 3 meses",
-        "placeholder": "Seleccionar período de retención..."
+        "placeholder": "Seleccionar período de retención...",
+        "warningTitle": "Auto-delete enabled",
+        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
       },
       "alwaysOnMicrophone": {
         "label": "Micrófono Siempre Activo",

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -458,7 +458,9 @@
       "historyLimit": {
         "title": "Limite d'historique",
         "description": "Nombre maximum d'entrées d'historique à conserver",
-        "entries": "entrées"
+        "entries": "entrées",
+        "warningTitle": "Recordings may be removed",
+        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
       },
       "recordingRetention": {
         "title": "Suppression automatique des enregistrements",
@@ -468,7 +470,9 @@
         "days3": "Après 3 jours",
         "weeks2": "Après 2 semaines",
         "months3": "Après 3 mois",
-        "placeholder": "Sélectionner la période de conservation..."
+        "placeholder": "Sélectionner la période de conservation...",
+        "warningTitle": "Auto-delete enabled",
+        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
       },
       "alwaysOnMicrophone": {
         "label": "Microphone toujours actif",

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -459,8 +459,8 @@
         "title": "Limite d'historique",
         "description": "Nombre maximum d'entrées d'historique à conserver",
         "entries": "entrées",
-        "warningTitle": "Recordings may be removed",
-        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
+        "warningTitle": "Des enregistrements pourraient être supprimés",
+        "warningDescription": "Les entrées dépassant la nouvelle limite seront supprimées lors du prochain enregistrement."
       },
       "recordingRetention": {
         "title": "Suppression automatique des enregistrements",
@@ -471,8 +471,8 @@
         "weeks2": "Après 2 semaines",
         "months3": "Après 3 mois",
         "placeholder": "Sélectionner la période de conservation...",
-        "warningTitle": "Auto-delete enabled",
-        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
+        "warningTitle": "Suppression automatique activée",
+        "warningDescription": "Les enregistrements plus anciens que la période de rétention seront supprimés lors du prochain enregistrement."
       },
       "alwaysOnMicrophone": {
         "label": "Microphone toujours actif",

--- a/src/i18n/locales/he/translation.json
+++ b/src/i18n/locales/he/translation.json
@@ -459,8 +459,8 @@
         "title": "מגבלת היסטוריה",
         "description": "המספר המרבי של רשומות היסטוריה לשמירה",
         "entries": "רשומות",
-        "warningTitle": "Recordings may be removed",
-        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
+        "warningTitle": "הקלטות עשויות להימחק",
+        "warningDescription": "רשומות מעבר למגבלה החדשה יימחקו בהקלטה הבאה."
       },
       "recordingRetention": {
         "title": "מחיקה אוטומטית של הקלטות",
@@ -471,8 +471,8 @@
         "weeks2": "אחרי שבועיים",
         "months3": "אחרי 3 חודשים",
         "placeholder": "בחר משך שמירה...",
-        "warningTitle": "Auto-delete enabled",
-        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
+        "warningTitle": "מחיקה אוטומטית הופעלה",
+        "warningDescription": "הקלטות ישנות מתקופת השמירה יימחקו בהקלטה הבאה."
       },
       "alwaysOnMicrophone": {
         "label": "מיקרופון תמיד פעיל",

--- a/src/i18n/locales/he/translation.json
+++ b/src/i18n/locales/he/translation.json
@@ -458,7 +458,9 @@
       "historyLimit": {
         "title": "מגבלת היסטוריה",
         "description": "המספר המרבי של רשומות היסטוריה לשמירה",
-        "entries": "רשומות"
+        "entries": "רשומות",
+        "warningTitle": "Recordings may be removed",
+        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
       },
       "recordingRetention": {
         "title": "מחיקה אוטומטית של הקלטות",
@@ -468,7 +470,9 @@
         "days3": "אחרי 3 ימים",
         "weeks2": "אחרי שבועיים",
         "months3": "אחרי 3 חודשים",
-        "placeholder": "בחר משך שמירה..."
+        "placeholder": "בחר משך שמירה...",
+        "warningTitle": "Auto-delete enabled",
+        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
       },
       "alwaysOnMicrophone": {
         "label": "מיקרופון תמיד פעיל",

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -458,7 +458,9 @@
       "historyLimit": {
         "title": "Limite della Cronologia",
         "description": "Massimo numero di elementi da conservare nella cronologia",
-        "entries": "elementi"
+        "entries": "elementi",
+        "warningTitle": "Recordings may be removed",
+        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
       },
       "recordingRetention": {
         "title": "Eliminazione Automatica Registrazioni",
@@ -468,7 +470,9 @@
         "days3": "Dopo 3 giorni",
         "weeks2": "Dopo 2 settimane",
         "months3": "Dopo 3 mesi",
-        "placeholder": "Seleziona periodo di conservazione..."
+        "placeholder": "Seleziona periodo di conservazione...",
+        "warningTitle": "Auto-delete enabled",
+        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
       },
       "alwaysOnMicrophone": {
         "label": "Microfono Sempre Attivo",

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -459,8 +459,8 @@
         "title": "Limite della Cronologia",
         "description": "Massimo numero di elementi da conservare nella cronologia",
         "entries": "elementi",
-        "warningTitle": "Recordings may be removed",
-        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
+        "warningTitle": "Le registrazioni potrebbero essere rimosse",
+        "warningDescription": "Le voci oltre il nuovo limite verranno eliminate alla prossima registrazione."
       },
       "recordingRetention": {
         "title": "Eliminazione Automatica Registrazioni",
@@ -471,8 +471,8 @@
         "weeks2": "Dopo 2 settimane",
         "months3": "Dopo 3 mesi",
         "placeholder": "Seleziona periodo di conservazione...",
-        "warningTitle": "Auto-delete enabled",
-        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
+        "warningTitle": "Eliminazione automatica attivata",
+        "warningDescription": "Le registrazioni più vecchie del periodo di conservazione verranno eliminate alla prossima registrazione."
       },
       "alwaysOnMicrophone": {
         "label": "Microfono Sempre Attivo",

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -458,7 +458,9 @@
       "historyLimit": {
         "title": "履歴上限",
         "description": "保持する履歴エントリーの最大数",
-        "entries": "件"
+        "entries": "件",
+        "warningTitle": "Recordings may be removed",
+        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
       },
       "recordingRetention": {
         "title": "録音の自動削除",
@@ -468,7 +470,9 @@
         "days3": "3日後",
         "weeks2": "2週間後",
         "months3": "3ヶ月後",
-        "placeholder": "保持期間を選択..."
+        "placeholder": "保持期間を選択...",
+        "warningTitle": "Auto-delete enabled",
+        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
       },
       "alwaysOnMicrophone": {
         "label": "マイク常時オン",

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -459,8 +459,8 @@
         "title": "履歴上限",
         "description": "保持する履歴エントリーの最大数",
         "entries": "件",
-        "warningTitle": "Recordings may be removed",
-        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
+        "warningTitle": "録音が削除される可能性があります",
+        "warningDescription": "新しい上限を超えるエントリは、次の録音時に削除されます。"
       },
       "recordingRetention": {
         "title": "録音の自動削除",
@@ -471,8 +471,8 @@
         "weeks2": "2週間後",
         "months3": "3ヶ月後",
         "placeholder": "保持期間を選択...",
-        "warningTitle": "Auto-delete enabled",
-        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
+        "warningTitle": "自動削除が有効になりました",
+        "warningDescription": "保持期間より古い録音は、次の録音時に削除されます。"
       },
       "alwaysOnMicrophone": {
         "label": "マイク常時オン",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -459,8 +459,8 @@
         "title": "히스토리 제한",
         "description": "보관할 최대 히스토리 항목 수",
         "entries": "항목",
-        "warningTitle": "Recordings may be removed",
-        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
+        "warningTitle": "녕음이 삭제될 수 있습니다",
+        "warningDescription": "새 제한을 초과하는 항목은 다음 녕음 시 삭제됩니다."
       },
       "recordingRetention": {
         "title": "녹음 자동 삭제",
@@ -471,8 +471,8 @@
         "weeks2": "2주 후",
         "months3": "3개월 후",
         "placeholder": "보관 기간 선택...",
-        "warningTitle": "Auto-delete enabled",
-        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
+        "warningTitle": "자동 삭제가 활성화됨",
+        "warningDescription": "보관 기간보다 오래된 녕음은 다음 녕음 시 삭제됩니다."
       },
       "alwaysOnMicrophone": {
         "label": "항상 켜진 마이크",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -458,7 +458,9 @@
       "historyLimit": {
         "title": "히스토리 제한",
         "description": "보관할 최대 히스토리 항목 수",
-        "entries": "항목"
+        "entries": "항목",
+        "warningTitle": "Recordings may be removed",
+        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
       },
       "recordingRetention": {
         "title": "녹음 자동 삭제",
@@ -468,7 +470,9 @@
         "days3": "3일 후",
         "weeks2": "2주 후",
         "months3": "3개월 후",
-        "placeholder": "보관 기간 선택..."
+        "placeholder": "보관 기간 선택...",
+        "warningTitle": "Auto-delete enabled",
+        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
       },
       "alwaysOnMicrophone": {
         "label": "항상 켜진 마이크",

--- a/src/i18n/locales/pl/translation.json
+++ b/src/i18n/locales/pl/translation.json
@@ -459,8 +459,8 @@
         "title": "Limit historii",
         "description": "Maksymalna liczba wpisów w historii",
         "entries": "wpisy",
-        "warningTitle": "Recordings may be removed",
-        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
+        "warningTitle": "Nagrania mogą zostać usunięte",
+        "warningDescription": "Wpisy przekraczające nowy limit zostaną usunięte przy następnym nagraniu."
       },
       "recordingRetention": {
         "title": "Automatyczne usuwanie nagrań",
@@ -471,8 +471,8 @@
         "weeks2": "Po 2 tygodniach",
         "months3": "Po 3 miesiącach",
         "placeholder": "Wybierz okres retencji...",
-        "warningTitle": "Auto-delete enabled",
-        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
+        "warningTitle": "Automatyczne usuwanie włączone",
+        "warningDescription": "Nagrania starsze niż okres przechowywania zostaną usunięte przy następnym nagraniu."
       },
       "alwaysOnMicrophone": {
         "label": "Mikrofon zawsze aktywny",

--- a/src/i18n/locales/pl/translation.json
+++ b/src/i18n/locales/pl/translation.json
@@ -458,7 +458,9 @@
       "historyLimit": {
         "title": "Limit historii",
         "description": "Maksymalna liczba wpisów w historii",
-        "entries": "wpisy"
+        "entries": "wpisy",
+        "warningTitle": "Recordings may be removed",
+        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
       },
       "recordingRetention": {
         "title": "Automatyczne usuwanie nagrań",
@@ -468,7 +470,9 @@
         "days3": "Po 3 dniach",
         "weeks2": "Po 2 tygodniach",
         "months3": "Po 3 miesiącach",
-        "placeholder": "Wybierz okres retencji..."
+        "placeholder": "Wybierz okres retencji...",
+        "warningTitle": "Auto-delete enabled",
+        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
       },
       "alwaysOnMicrophone": {
         "label": "Mikrofon zawsze aktywny",

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -458,7 +458,9 @@
       "historyLimit": {
         "title": "Limite de Histórico",
         "description": "Número máximo de entradas de histórico a manter",
-        "entries": "entradas"
+        "entries": "entradas",
+        "warningTitle": "Recordings may be removed",
+        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
       },
       "recordingRetention": {
         "title": "Excluir Gravações Automaticamente",
@@ -468,7 +470,9 @@
         "days3": "Após 3 dias",
         "weeks2": "Após 2 semanas",
         "months3": "Após 3 meses",
-        "placeholder": "Selecionar período de retenção..."
+        "placeholder": "Selecionar período de retenção...",
+        "warningTitle": "Auto-delete enabled",
+        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
       },
       "alwaysOnMicrophone": {
         "label": "Microfone Sempre Ativo",

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -459,8 +459,8 @@
         "title": "Limite de Histórico",
         "description": "Número máximo de entradas de histórico a manter",
         "entries": "entradas",
-        "warningTitle": "Recordings may be removed",
-        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
+        "warningTitle": "Gravações poderão ser removidas",
+        "warningDescription": "Entradas acima do novo limite serão excluídas na próxima gravação."
       },
       "recordingRetention": {
         "title": "Excluir Gravações Automaticamente",
@@ -471,8 +471,8 @@
         "weeks2": "Após 2 semanas",
         "months3": "Após 3 meses",
         "placeholder": "Selecionar período de retenção...",
-        "warningTitle": "Auto-delete enabled",
-        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
+        "warningTitle": "Exclusão automática ativada",
+        "warningDescription": "Gravações mais antigas que o período de retenção serão excluídas na próxima gravação."
       },
       "alwaysOnMicrophone": {
         "label": "Microfone Sempre Ativo",

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -459,8 +459,8 @@
         "title": "Размер истории",
         "description": "Максимальное количество записей истории, которые можно сохранить",
         "entries": "записи",
-        "warningTitle": "Recordings may be removed",
-        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
+        "warningTitle": "Записи могут быть удалены",
+        "warningDescription": "Записи сверх нового лимита будут удалены при следующей записи."
       },
       "recordingRetention": {
         "title": "Автоматическое удаление записей",
@@ -471,8 +471,8 @@
         "weeks2": "Через 2 недели",
         "months3": "Через 3 месяца",
         "placeholder": "Выберите срок хранения...",
-        "warningTitle": "Auto-delete enabled",
-        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
+        "warningTitle": "Автоматическое удаление включено",
+        "warningDescription": "Записи старше периода хранения будут удалены при следующей записи."
       },
       "alwaysOnMicrophone": {
         "label": "Всегда включенный микрофон",

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -458,7 +458,9 @@
       "historyLimit": {
         "title": "Размер истории",
         "description": "Максимальное количество записей истории, которые можно сохранить",
-        "entries": "записи"
+        "entries": "записи",
+        "warningTitle": "Recordings may be removed",
+        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
       },
       "recordingRetention": {
         "title": "Автоматическое удаление записей",
@@ -468,7 +470,9 @@
         "days3": "Через 3 дня",
         "weeks2": "Через 2 недели",
         "months3": "Через 3 месяца",
-        "placeholder": "Выберите срок хранения..."
+        "placeholder": "Выберите срок хранения...",
+        "warningTitle": "Auto-delete enabled",
+        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
       },
       "alwaysOnMicrophone": {
         "label": "Всегда включенный микрофон",

--- a/src/i18n/locales/sv/translation.json
+++ b/src/i18n/locales/sv/translation.json
@@ -459,8 +459,8 @@
         "title": "Historikgräns",
         "description": "Maximalt antal historikposter som ska sparas",
         "entries": "poster",
-        "warningTitle": "Recordings may be removed",
-        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
+        "warningTitle": "Inspelningar kan tas bort",
+        "warningDescription": "Poster som överskrider den nya gränsen raderas vid nästa inspelning."
       },
       "recordingRetention": {
         "title": "Radera inspelningar automatiskt",
@@ -471,8 +471,8 @@
         "weeks2": "Efter 2 veckor",
         "months3": "Efter 3 månader",
         "placeholder": "Välj lagringsperiod...",
-        "warningTitle": "Auto-delete enabled",
-        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
+        "warningTitle": "Automatisk radering aktiverad",
+        "warningDescription": "Inspelningar äldre än lagringsperioden raderas vid nästa inspelning."
       },
       "alwaysOnMicrophone": {
         "label": "Alltid påslagen mikrofon",

--- a/src/i18n/locales/sv/translation.json
+++ b/src/i18n/locales/sv/translation.json
@@ -458,7 +458,9 @@
       "historyLimit": {
         "title": "Historikgräns",
         "description": "Maximalt antal historikposter som ska sparas",
-        "entries": "poster"
+        "entries": "poster",
+        "warningTitle": "Recordings may be removed",
+        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
       },
       "recordingRetention": {
         "title": "Radera inspelningar automatiskt",
@@ -468,7 +470,9 @@
         "days3": "Efter 3 dagar",
         "weeks2": "Efter 2 veckor",
         "months3": "Efter 3 månader",
-        "placeholder": "Välj lagringsperiod..."
+        "placeholder": "Välj lagringsperiod...",
+        "warningTitle": "Auto-delete enabled",
+        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
       },
       "alwaysOnMicrophone": {
         "label": "Alltid påslagen mikrofon",

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -459,8 +459,8 @@
         "title": "Geçmiş Limiti",
         "description": "Saklanacak maksimum geçmiş kaydı sayısı",
         "entries": "kayıt",
-        "warningTitle": "Recordings may be removed",
-        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
+        "warningTitle": "Kayıtlar silinebilir",
+        "warningDescription": "Yeni sınırı aşan girişler bir sonraki kayıtta silinecektir."
       },
       "recordingRetention": {
         "title": "Kayıtları Otomatik Sil",
@@ -471,8 +471,8 @@
         "weeks2": "2 hafta sonra",
         "months3": "3 ay sonra",
         "placeholder": "Saklama süresi seçin...",
-        "warningTitle": "Auto-delete enabled",
-        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
+        "warningTitle": "Otomatik silme etkinleştirildi",
+        "warningDescription": "Saklama süresinden eski kayıtlar bir sonraki kayıtta silinecektir."
       },
       "alwaysOnMicrophone": {
         "label": "Mikrofon Her Zaman Açık",

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -458,7 +458,9 @@
       "historyLimit": {
         "title": "Geçmiş Limiti",
         "description": "Saklanacak maksimum geçmiş kaydı sayısı",
-        "entries": "kayıt"
+        "entries": "kayıt",
+        "warningTitle": "Recordings may be removed",
+        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
       },
       "recordingRetention": {
         "title": "Kayıtları Otomatik Sil",
@@ -468,7 +470,9 @@
         "days3": "3 gün sonra",
         "weeks2": "2 hafta sonra",
         "months3": "3 ay sonra",
-        "placeholder": "Saklama süresi seçin..."
+        "placeholder": "Saklama süresi seçin...",
+        "warningTitle": "Auto-delete enabled",
+        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
       },
       "alwaysOnMicrophone": {
         "label": "Mikrofon Her Zaman Açık",

--- a/src/i18n/locales/uk/translation.json
+++ b/src/i18n/locales/uk/translation.json
@@ -458,7 +458,9 @@
       "historyLimit": {
         "title": "Ліміт історії",
         "description": "Максимальна кількість записів в історії",
-        "entries": "записів"
+        "entries": "записів",
+        "warningTitle": "Recordings may be removed",
+        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
       },
       "recordingRetention": {
         "title": "Автовидалення записів",
@@ -468,7 +470,9 @@
         "days3": "Через 3 дні",
         "weeks2": "Через 2 тижні",
         "months3": "Через 3 місяці",
-        "placeholder": "Оберіть період зберігання..."
+        "placeholder": "Оберіть період зберігання...",
+        "warningTitle": "Auto-delete enabled",
+        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
       },
       "alwaysOnMicrophone": {
         "label": "Постійно активний мікрофон",

--- a/src/i18n/locales/uk/translation.json
+++ b/src/i18n/locales/uk/translation.json
@@ -459,8 +459,8 @@
         "title": "Ліміт історії",
         "description": "Максимальна кількість записів в історії",
         "entries": "записів",
-        "warningTitle": "Recordings may be removed",
-        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
+        "warningTitle": "Записи можуть бути видалені",
+        "warningDescription": "Записи понад новий ліміт буде видалено під час наступного запису."
       },
       "recordingRetention": {
         "title": "Автовидалення записів",
@@ -471,8 +471,8 @@
         "weeks2": "Через 2 тижні",
         "months3": "Через 3 місяці",
         "placeholder": "Оберіть період зберігання...",
-        "warningTitle": "Auto-delete enabled",
-        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
+        "warningTitle": "Автоматичне видалення увімкнено",
+        "warningDescription": "Записи, старші за період зберігання, буде видалено під час наступного запису."
       },
       "alwaysOnMicrophone": {
         "label": "Постійно активний мікрофон",

--- a/src/i18n/locales/vi/translation.json
+++ b/src/i18n/locales/vi/translation.json
@@ -459,8 +459,8 @@
         "title": "Giới hạn lịch sử",
         "description": "Số lượng mục lịch sử tối đa cần giữ",
         "entries": "mục",
-        "warningTitle": "Recordings may be removed",
-        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
+        "warningTitle": "Bản ghi có thể bị xóa",
+        "warningDescription": "Các mục vượt quá giới hạn mới sẽ bị xóa khi ghi âm tiếp theo."
       },
       "recordingRetention": {
         "title": "Tự động xóa ghi âm",
@@ -471,8 +471,8 @@
         "weeks2": "Sau 2 tuần",
         "months3": "Sau 3 tháng",
         "placeholder": "Chọn thời gian lưu giữ...",
-        "warningTitle": "Auto-delete enabled",
-        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
+        "warningTitle": "Đã bật tự động xóa",
+        "warningDescription": "Các bản ghi cũ hơn thời gian lưu giữ sẽ bị xóa khi ghi âm tiếp theo."
       },
       "alwaysOnMicrophone": {
         "label": "Micrô luôn bật",

--- a/src/i18n/locales/vi/translation.json
+++ b/src/i18n/locales/vi/translation.json
@@ -458,7 +458,9 @@
       "historyLimit": {
         "title": "Giới hạn lịch sử",
         "description": "Số lượng mục lịch sử tối đa cần giữ",
-        "entries": "mục"
+        "entries": "mục",
+        "warningTitle": "Recordings may be removed",
+        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
       },
       "recordingRetention": {
         "title": "Tự động xóa ghi âm",
@@ -468,7 +470,9 @@
         "days3": "Sau 3 ngày",
         "weeks2": "Sau 2 tuần",
         "months3": "Sau 3 tháng",
-        "placeholder": "Chọn thời gian lưu giữ..."
+        "placeholder": "Chọn thời gian lưu giữ...",
+        "warningTitle": "Auto-delete enabled",
+        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
       },
       "alwaysOnMicrophone": {
         "label": "Micrô luôn bật",

--- a/src/i18n/locales/zh-TW/translation.json
+++ b/src/i18n/locales/zh-TW/translation.json
@@ -458,7 +458,9 @@
       "historyLimit": {
         "title": "歷史紀錄上限",
         "description": "歷史紀錄的最大保留筆數",
-        "entries": "筆"
+        "entries": "筆",
+        "warningTitle": "Recordings may be removed",
+        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
       },
       "recordingRetention": {
         "title": "自動刪除錄音",
@@ -468,7 +470,9 @@
         "days3": "3 天後",
         "weeks2": "2 週後",
         "months3": "3 個月後",
-        "placeholder": "選擇保留期限..."
+        "placeholder": "選擇保留期限...",
+        "warningTitle": "Auto-delete enabled",
+        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
       },
       "alwaysOnMicrophone": {
         "label": "麥克風常開",

--- a/src/i18n/locales/zh-TW/translation.json
+++ b/src/i18n/locales/zh-TW/translation.json
@@ -459,8 +459,8 @@
         "title": "歷史紀錄上限",
         "description": "歷史紀錄的最大保留筆數",
         "entries": "筆",
-        "warningTitle": "Recordings may be removed",
-        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
+        "warningTitle": "錄音可能會被刪除",
+        "warningDescription": "超出新限制的項目將在下次錄音時刪除。"
       },
       "recordingRetention": {
         "title": "自動刪除錄音",
@@ -471,8 +471,8 @@
         "weeks2": "2 週後",
         "months3": "3 個月後",
         "placeholder": "選擇保留期限...",
-        "warningTitle": "Auto-delete enabled",
-        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
+        "warningTitle": "已啟用自動刪除",
+        "warningDescription": "超過保留期限的錄音將在下次錄音時刪除。"
       },
       "alwaysOnMicrophone": {
         "label": "麥克風常開",

--- a/src/i18n/locales/zh/translation.json
+++ b/src/i18n/locales/zh/translation.json
@@ -458,7 +458,9 @@
       "historyLimit": {
         "title": "历史记录上限",
         "description": "保留的最大历史条目数",
-        "entries": "条"
+        "entries": "条",
+        "warningTitle": "Recordings may be removed",
+        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
       },
       "recordingRetention": {
         "title": "自动删除录音",
@@ -468,7 +470,9 @@
         "days3": "3 天后",
         "weeks2": "2 周后",
         "months3": "3 个月后",
-        "placeholder": "选择保留期限..."
+        "placeholder": "选择保留期限...",
+        "warningTitle": "Auto-delete enabled",
+        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
       },
       "alwaysOnMicrophone": {
         "label": "麦克风常开",

--- a/src/i18n/locales/zh/translation.json
+++ b/src/i18n/locales/zh/translation.json
@@ -459,8 +459,8 @@
         "title": "历史记录上限",
         "description": "保留的最大历史条目数",
         "entries": "条",
-        "warningTitle": "Recordings may be removed",
-        "warningDescription": "Entries beyond the new limit will be deleted on your next recording."
+        "warningTitle": "录音可能会被删除",
+        "warningDescription": "超出新限制的条目将在下次录音时删除。"
       },
       "recordingRetention": {
         "title": "自动删除录音",
@@ -471,8 +471,8 @@
         "weeks2": "2 周后",
         "months3": "3 个月后",
         "placeholder": "选择保留期限...",
-        "warningTitle": "Auto-delete enabled",
-        "warningDescription": "Recordings older than the retention period will be deleted on your next recording."
+        "warningTitle": "已启用自动删除",
+        "warningDescription": "超过保留期限的录音将在下次录音时删除。"
       },
       "alwaysOnMicrophone": {
         "label": "麦克风常开",


### PR DESCRIPTION
## Summary

- Removes immediate `cleanup_old_entries()` calls from `update_history_limit()` and `update_recording_retention_period()`
- Changing history settings no longer triggers synchronous deletion of recordings
- Cleanup still happens naturally via `save_entry()` on the next recording

Fixes #1262

## Details

When a user changed "History Limit" or "Auto-Delete Recordings", the backend immediately ran cleanup with the new value. If the user was changing **both** settings (e.g., increasing the limit AND switching to "Never"), the first change triggered cleanup before the second was applied, causing unexpected data loss.

The fix removes the immediate cleanup trigger. Entries exceeding the new limit are cleaned up gradually as new recordings are made -- `cleanup_old_entries()` is already called inside `save_entry()` (`managers/history.rs:268`), so no entries accumulate indefinitely.

## Test plan

- [ ] Change History Limit from 5 to 10000 -- existing recordings should NOT be deleted
- [ ] Change Auto-Delete to "Never" -- existing recordings should NOT be deleted
- [ ] Change History Limit from 10000 to 3 -- existing recordings stay until next recording is made
- [ ] Make a new recording after lowering the limit -- old entries beyond the limit are cleaned up
- [ ] Verify normal recording/cleanup cycle still works