### PR TITLE
fix(nix): Fix for macOS build for nixpkgs

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -181,6 +181,15 @@ fn build_apple_intelligence_bridge() {
     let status = Command::new("xcrun")
         .args([
             "swiftc",
+            // Without this flag swiftc treats single-file input as script
+            // mode and emits its own `_main` symbol into the .o, which can
+            // win the link against Rust's main under some linkers (e.g.
+            // open-source ld64 used in nixpkgs' Darwin stdenv), producing a
+            // binary whose main() is a 5-instruction no-op that returns 0.
+            // `-parse-as-library` keeps the compilation in library mode so
+            // no `_main` is emitted. See:
+            //   https://forums.swift.org/t/main-in-a-single-swift-file/63079
+            "-parse-as-library",
             "-target",
             "arm64-apple-macosx11.0",
             "-sdk",

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -129,16 +129,20 @@ fn build_apple_intelligence_bridge() {
     let object_path = out_dir.join("apple_intelligence.o");
     let static_lib_path = out_dir.join("libapple_intelligence.a");
 
-    let sdk_path = String::from_utf8(
-        Command::new("xcrun")
-            .args(["--sdk", "macosx", "--show-sdk-path"])
-            .output()
-            .expect("Failed to locate macOS SDK")
-            .stdout,
-    )
-    .expect("SDK path is not valid UTF-8")
-    .trim()
-    .to_string();
+    // SDKROOT/SWIFTC env-var overrides let non-Xcode toolchains (e.g. nixpkgs
+    // with apple-sdk_* + standalone swift) bypass xcrun, which is Xcode-only.
+    let sdk_path = env::var("SDKROOT").unwrap_or_else(|_| {
+        String::from_utf8(
+            Command::new("xcrun")
+                .args(["--sdk", "macosx", "--show-sdk-path"])
+                .output()
+                .expect("Failed to locate macOS SDK")
+                .stdout,
+        )
+        .expect("SDK path is not valid UTF-8")
+        .trim()
+        .to_string()
+    });
 
     // Check if the SDK supports FoundationModels (required for Apple Intelligence)
     let framework_path =
@@ -157,16 +161,19 @@ fn build_apple_intelligence_bridge() {
         panic!("Source file {} is missing!", source_file);
     }
 
-    let swiftc_path = String::from_utf8(
-        Command::new("xcrun")
-            .args(["--find", "swiftc"])
-            .output()
-            .expect("Failed to locate swiftc")
-            .stdout,
-    )
-    .expect("swiftc path is not valid UTF-8")
-    .trim()
-    .to_string();
+    // See SDKROOT note above — same env-override pattern for non-Xcode toolchains.
+    let swiftc_path = env::var("SWIFTC").unwrap_or_else(|_| {
+        String::from_utf8(
+            Command::new("xcrun")
+                .args(["--find", "swiftc"])
+                .output()
+                .expect("Failed to locate swiftc")
+                .stdout,
+        )
+        .expect("swiftc path is not valid UTF-8")
+        .trim()
+        .to_string()
+    });
 
     let toolchain_swift_lib = Path::new(&swiftc_path)
         .parent()
@@ -178,9 +185,8 @@ fn build_apple_intelligence_bridge() {
     // Use macOS 11.0 as deployment target for compatibility
     // The @available(macOS 26.0, *) checks in Swift handle runtime availability
     // Weak linking for FoundationModels is handled via cargo:rustc-link-arg below
-    let status = Command::new("xcrun")
+    let status = Command::new(&swiftc_path)
         .args([
-            "swiftc",
             // Without this flag swiftc treats single-file input as script
             // mode and emits its own `_main` symbol into the .o, which can
             // win the link against Rust's main under some linkers (e.g.


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Human Written Description

While debugging the Handy macOS build for nixpkgs it turned out that `swiftc` in `build.rs`, when invoked without `-parse-as-library`, emits its own `_main` symbol into the Apple Intelligence bridge object file, and the open-source `ld64` used by nixpkgs' Darwin stdenv picks that `_main` over Rust's — so the Rust runtime is never entered and the app silently exits with code 0. Adding the flag keeps `swiftc` in library mode and the binary works. Production releases (Xcode's linker) mask this because Xcode's `ld` prefers Rust's `_main`.

A second related fix: the Apple Intelligence bridge build (`build.rs`) invoked `xcrun` directly to locate the SDK and `swiftc`, which is unavailable in non-Xcode toolchains (nixpkgs uses standalone `apple-sdk_*` + `swift`). The build now honors `SDKROOT` and `SWIFTC` env vars when set, falling back to `xcrun` otherwise — Apple-toolchain behavior is unchanged. Both code paths verified on `macos-26`: https://github.com/xilec/Handy/actions/runs/24940175357

## Related Issues/Discussions

- [NixOS/nixpkgs#507754](https://github.com/NixOS/nixpkgs/pull/507754) — philocalyst reports "the generated binary on Darwin does nothing, has no typical Rust main entrypoint, 50 KiB stub of a stub"
- [Discussion #1242](https://github.com/cjpais/Handy/discussions/1242) — same observation ("it will quit and exit cleanly, without executing anything")
- [philocalyst/nixpkgs#1](https://github.com/philocalyst/nixpkgs/pull/1) — **current Nix packaging PR** (feeds into NixOS/nixpkgs#507754). `src` is pinned to this PR's HEAD, so it's the easiest end-to-end test of the fix on Darwin under Nix. macOS users wanting to validate this PR under Nix should build from there: `nix-build https://github.com/xilec/nixpkgs/archive/handy-cross-platform-deps.tar.gz -A handy` works as-is on `aarch64-darwin`.

## Community Feedback

Bug reported by philocalyst (nixpkgs maintainer working on the Handy package) in NixOS/nixpkgs#507754 and in discussion #1242.

## Testing

Reproduced and fixed in a Nix flake that mirrors the Darwin build used by nixpkgs. Matrix CI on `macos-latest` (aarch64-darwin) across four variants — full run: https://github.com/xilec/Handy/actions/runs/24674832551

| Variant | `_main` address | Behaviour on launch | Job |
|---|---|---|---|
| baseline (current `main`) | `0x100031180` | 5-insn stub, exits in ~50 ms | [job 72155708502](https://github.com/xilec/Handy/actions/runs/24674832551/job/72155708502) |
| minimal swift stub (no `import Foundation`, no typealias) | `0x100031340` | still stub — script mode emits `_main` regardless of file content | [job 72155708494](https://github.com/xilec/Handy/actions/runs/24674832551/job/72155708494) |
| + `apple-sdk_26` (real `apple_intelligence.swift` with FoundationModels) | `0x100031200` | still stub | [job 72155708487](https://github.com/xilec/Handy/actions/runs/24674832551/job/72155708487) |
| **`-parse-as-library`** (this PR) | **`0x100007b10`** | **real Rust main**, GUI event loop runs until killed by 5 s timeout | [job 72155708525](https://github.com/xilec/Handy/actions/runs/24674832551/job/72155708525) |

In each job the collapsed **"Diagnose binary (stub check)"** step contains the `::group::_main disassembly`, `::group::_main symbol`, and `::group::Try to run (…)` sections with raw `otool -tV` output and wall-clock timings. The **"Compare pre-bundle vs bundled binary"** step confirms that the stub `_main` is already present in `src-tauri/target/<arch>/release/handy` before `cargo tauri bundle` runs — i.e., the bug is at Rust/link time, not in bundling.

Baseline `_main` (5-inst no-op `return 0`):

```
_main:
    stp x29, x30, [sp, #-0x10]!
    mov x29, sp
    mov w0, #0x0               ; return 0
    ldp x29, x30, [sp], #0x10
    ret
```

After the fix (`_main` saves callee-saved registers and calls into rustc's `lang_start_internal` via `blr x8` — real Rust entry):

```
_main:
    stp x22, x21, [sp, #0x90]
    stp x20, x19, [sp, #0xa0]
    stp x29, x30, [sp, #0xb0]
    add x29, sp, #0xb0
    adrp x0, ...
    ldr x8, [x0]
    blr x8                      ; call lang_start
    cbnz x8, ...
    ...
```

Production macOS CI (`macos-26` runner, Xcode's linker) is unaffected — Xcode's `ld` was already ignoring Swift's `_main`, the flag just stops emitting that unused symbol.

References on swiftc's script-mode `_main` emission:
- [Swift forums: main in a single Swift file](https://forums.swift.org/t/main-in-a-single-swift-file/63079) (Evan Wilde on `SourceFileKind`)
- [apple/swift#60277](https://github.com/apple/swift/issues/60277) — build systems should pass `-parse-as-library`

Debug branch used for reproduction: https://github.com/xilec/Handy/tree/debug/darwin-flake

## Screenshots/Videos (if applicable)

N/A — one-line build-config change, no UI impact.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (claude.ai/code)
- How extensively: used for researching swiftc script-mode behaviour and ld64 differences (Swift forums, GitHub issues, blog posts), drafting the build.rs comment, and running/analyzing the matrix-CI reproduction. The fix itself is one flag; the investigation was AI-assisted but validated against Swift compiler docs and primary sources cited above.

