### PR TITLE
feat: add microphone switching via tray submenu and keyboard shortcut

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -1,6 +1,7 @@
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 use crate::apple_intelligence;
 use crate::audio_feedback::{play_feedback_sound, play_feedback_sound_blocking, SoundType};
+use crate::audio_toolkit::audio::list_input_devices;
 use crate::audio_toolkit::{is_microphone_access_denied, is_no_input_device_error};
 use crate::managers::audio::AudioRecordingManager;
 use crate::managers::history::HistoryManager;
@@ -696,6 +697,61 @@ impl ShortcutAction for TestAction {
     }
 }
 
+// Switch Microphone Action
+struct SwitchMicrophoneAction;
+
+impl ShortcutAction for SwitchMicrophoneAction {
+    fn start(&self, app: &AppHandle, _binding_id: &str, _shortcut_str: &str) {
+        let devices = match list_input_devices() {
+            Ok(d) => d,
+            Err(e) => {
+                error!("Failed to list input devices: {}", e);
+                return;
+            }
+        };
+
+        let settings = get_settings(app);
+        let current = settings
+            .selected_microphone
+            .as_deref()
+            .unwrap_or("default");
+
+        // Build ordered list: "default" followed by device names
+        let mut names: Vec<String> = vec!["default".to_string()];
+        names.extend(devices.iter().map(|d| d.name.clone()));
+
+        let current_idx = names.iter().position(|n| n == current).unwrap_or(0);
+        let next_idx = (current_idx + 1) % names.len();
+        let next_name = &names[next_idx];
+
+        let mut new_settings = settings.clone();
+        new_settings.selected_microphone = if next_name == "default" {
+            None
+        } else {
+            Some(next_name.clone())
+        };
+        crate::settings::write_settings(app, new_settings);
+
+        let rm = app.state::<Arc<AudioRecordingManager>>();
+        if let Err(e) = rm.update_selected_device() {
+            error!("Failed to switch microphone: {}", e);
+        }
+
+        let display_name = if next_name == "default" {
+            "Default".to_string()
+        } else {
+            next_name.clone()
+        };
+        debug!("Switched microphone to: {}", display_name);
+        let _ = app.emit("microphone-switched", display_name);
+
+        // Refresh tray menu to update the checkmark
+        crate::tray::update_tray_menu(app, &TrayIconState::Idle, None);
+    }
+
+    fn stop(&self, _app: &AppHandle, _binding_id: &str, _shortcut_str: &str) {}
+}
+
 // Static Action Map
 pub static ACTION_MAP: Lazy<HashMap<String, Arc<dyn ShortcutAction>>> = Lazy::new(|| {
     let mut map = HashMap::new();
@@ -716,6 +772,10 @@ pub static ACTION_MAP: Lazy<HashMap<String, Arc<dyn ShortcutAction>>> = Lazy::ne
     map.insert(
         "test".to_string(),
         Arc::new(TestAction) as Arc<dyn ShortcutAction>,
+    );
+    map.insert(
+        "switch_microphone".to_string(),
+        Arc::new(SwitchMicrophoneAction) as Arc<dyn ShortcutAction>,
     );
     map
 });

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -213,6 +213,9 @@ pub fn set_selected_microphone(app: AppHandle, device_name: String) -> Result<()
     rm.update_selected_device()
         .map_err(|e| format!("Failed to update selected device: {}", e))?;
 
+    // Refresh tray menu to update the microphone checkmark
+    crate::tray::update_tray_menu(&app, &crate::tray::TrayIconState::Idle, None);
+
     Ok(())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -238,6 +238,27 @@ fn initialize_core_logic(app_handle: &AppHandle) {
             "quit" => {
                 app.exit(0);
             }
+            id if id.starts_with("mic_select:") => {
+                let device_name = id.strip_prefix("mic_select:").unwrap().to_string();
+                let mut s = settings::get_settings(app);
+                let current = s.selected_microphone.as_deref().unwrap_or("default");
+                if device_name == current {
+                    return;
+                }
+                s.selected_microphone = if device_name == "default" {
+                    None
+                } else {
+                    Some(device_name.clone())
+                };
+                settings::write_settings(app, s);
+                let rm = app.state::<Arc<AudioRecordingManager>>();
+                if let Err(e) = rm.update_selected_device() {
+                    log::error!("Failed to switch mic via tray: {}", e);
+                }
+                let display = if device_name == "default" { "Default".to_string() } else { device_name };
+                let _ = app.emit("microphone-switched", display);
+                tray::update_tray_menu(app, &tray::TrayIconState::Idle, None);
+            }
             id if id.starts_with("model_select:") => {
                 let model_id = id.strip_prefix("model_select:").unwrap().to_string();
                 let current_model = settings::get_settings(app).selected_model;

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -763,6 +763,16 @@ pub fn get_default_settings() -> AppSettings {
             current_binding: "escape".to_string(),
         },
     );
+    bindings.insert(
+        "switch_microphone".to_string(),
+        ShortcutBinding {
+            id: "switch_microphone".to_string(),
+            name: "Switch Microphone".to_string(),
+            description: "Cycles to the next available microphone input.".to_string(),
+            default_binding: "".to_string(),
+            current_binding: "".to_string(),
+        },
+    );
 
     AppSettings {
         bindings,

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,3 +1,4 @@
+use crate::audio_toolkit::audio::list_input_devices;
 use crate::managers::history::{HistoryEntry, HistoryManager};
 use crate::managers::model::ModelManager;
 use crate::managers::transcription::TranscriptionManager;
@@ -177,6 +178,47 @@ pub fn update_tray_menu(app: &AppHandle, state: &TrayIconState, locale: Option<&
     )
     .expect("failed to create unload model item");
 
+    // Build microphone submenu
+    let current_mic = settings
+        .selected_microphone
+        .as_deref()
+        .unwrap_or("default");
+
+    let mic_submenu = {
+        let submenu = Submenu::with_id(app, "mic_submenu", &strings.microphone, true)
+            .expect("failed to create mic submenu");
+
+        let default_item = CheckMenuItem::with_id(
+            app,
+            "mic_select:default",
+            "Default",
+            true,
+            current_mic == "default",
+            None::<&str>,
+        )
+        .expect("failed to create default mic item");
+        let _ = submenu.append(&default_item);
+
+        if let Ok(devices) = list_input_devices() {
+            for device in &devices {
+                let item_id = format!("mic_select:{}", device.name);
+                let is_active = current_mic == device.name;
+                let item = CheckMenuItem::with_id(
+                    app,
+                    &item_id,
+                    &device.name,
+                    true,
+                    is_active,
+                    None::<&str>,
+                )
+                .expect("failed to create mic item");
+                let _ = submenu.append(&item);
+            }
+        }
+
+        submenu
+    };
+
     let menu = match state {
         TrayIconState::Recording | TrayIconState::Transcribing => {
             let cancel_i = MenuItem::with_id(app, "cancel", &strings.cancel, true, None::<&str>)
@@ -207,6 +249,8 @@ pub fn update_tray_menu(app: &AppHandle, state: &TrayIconState, locale: Option<&
                 &separator(),
                 &model_submenu,
                 &unload_model_i,
+                &separator(),
+                &mic_submenu,
                 &separator(),
                 &settings_i,
                 &check_updates_i,

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -5,6 +5,7 @@
     "copyLastTranscript": "Copy Last Transcript",
     "unloadModel": "Unload Model",
     "model": "Model",
+    "microphone": "Microphone",
     "quit": "Quit",
     "cancel": "Cancel"
   },

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -591,6 +591,11 @@ export const useSettingsStore = create<SettingsStore>()(
       listen("model-state-changed", () => {
         get().refreshSettings();
       });
+
+      // Re-fetch settings when microphone is switched via tray or shortcut.
+      listen("microphone-switched", () => {
+        get().refreshSettings();
+      });
     },
   })),
 );


### PR DESCRIPTION
## Summary

Adds two new ways to switch microphones without opening Settings:

- **System tray submenu** — a "Microphone" submenu (mirroring the existing Model submenu) shows all available input devices with a checkmark on the active one. Clicking a device switches immediately.
- **Keyboard shortcut** — a new configurable "Switch Microphone" binding (no default key — user sets their own in Settings > Shortcuts) cycles through available mics on each press.

Both methods hot-swap the audio stream via the existing `update_selected_device()` infrastructure and keep the tray menu and Settings UI in sync bidirectionally (tray → settings and settings → tray).

Here's a demo of the menu icon microphone switching behavior: https://screen.studio/share/XMCNih0d

## Changes

| File | Change |
|------|--------|
| `src-tauri/src/tray.rs` | Microphone submenu in `update_tray_menu()` |
| `src-tauri/src/lib.rs` | `mic_select:` event handler + emit `microphone-switched` |
| `src-tauri/src/actions.rs` | `SwitchMicrophoneAction` + `ACTION_MAP` registration |
| `src-tauri/src/settings.rs` | `switch_microphone` shortcut binding |
| `src-tauri/src/commands/audio.rs` | Tray menu refresh after `set_selected_microphone` |
| `src/stores/settingsStore.ts` | Listen for `microphone-switched` event to sync UI |
| `src/i18n/locales/en/translation.json` | `"microphone"` tray translation key |

## Test plan

- [x] `cargo check` compiles cleanly
- [x] All 65 existing tests pass
- [x] Tray submenu shows all available mics with correct checkmark
- [x] Clicking a tray mic item switches the active mic and updates the Settings dropdown
- [x] Changing mic in Settings updates the tray submenu checkmark
- [x] "Switch Microphone" shortcut binding appears in Settings > Shortcuts