### PR TITLE
docs(audio): clarify what the mic-init timing log actually measures

### DIFF
--- a/src-tauri/src/managers/audio.rs
+++ b/src-tauri/src/managers/audio.rs
@@ -321,6 +321,11 @@ impl AudioRecordingManager {
         }
 
         *open_flag = true;
+        // This timing covers through cpal's stream.play() returning — i.e. the
+        // point cpal surfaces as "stream running." It does NOT guarantee the
+        // host audio device is producing samples yet; the first input callback
+        // fires asynchronously one buffer period later (hardware dependent,
+        // typically ~10–200ms on macOS, longer on Bluetooth/USB).
         info!(
             "Microphone stream initialized in {:?}",
             start_time.elapsed()


### PR DESCRIPTION
## Summary

Adds a 5-line code comment above the existing `"Microphone stream initialized in {:?}"` log in `managers/audio.rs::start_microphone_stream`. No behaviour change, no log text change, no CSV/grep impact for downstream log consumers. Just a note where future readers of the code will see it.

## Why

The elapsed time that log reports covers through cpal's `stream.play()` returning, which is the point cpal surfaces as "stream running." On macOS this bottoms out in `AudioOutputUnitStart` (see [`coreaudio-rs::AudioUnit::start`](https://github.com/RustAudio/coreaudio-rs/blob/master/src/audio_unit/mod.rs#L253) → `AudioOutputUnitStart` invoked via `cpal::Stream::play` → `StreamInner::play` → `audio_unit.start` in [`cpal::host::coreaudio::macos::mod`](https://github.com/RustAudio/cpal/blob/master/src/host/coreaudio/macos/mod.rs)). That call returns synchronously as soon as the audio unit is scheduled — it does not wait for the first input buffer to be captured. The first input callback fires asynchronously one buffer period later, typically ~10–200ms on macOS and longer on Bluetooth / USB class devices.

Which means the log is accurate about what cpal exposes, but slightly easy to misread as "mic is ready to capture speech" when it isn't quite — a subtlety that showed up in the release bisection in #1283. The comment just spells out the scope of the measurement so the next person diffing this log across versions doesn't have to re-derive it.

## Not doing

* No rename of the log line — preserves existing log parsing / grep patterns anyone has built around the current string.
* No change to the timing measurement itself — reporting first-sample-ready would be a behaviour change that belongs in its own PR (and would mean threading an init signal through `build_stream`'s input callback).

Happy to tweak the comment wording if anything feels off.