### PR TITLE
refactor(nix): remove phases duplicated from cargo-tauri.hook

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,8 @@
             src = self;
 
             cargoRoot = "src-tauri";
+            buildAndTestSubdir = "src-tauri";
+            tauriBundleType = "deb";
 
             cargoLock = {
               lockFile = ./src-tauri/Cargo.lock;
@@ -103,7 +105,7 @@
             };
 
             postPatch = ''
-              ${pkgs.jq}/bin/jq 'del(.build.beforeBuildCommand) | .bundle.createUpdaterArtifacts = false' \
+              ${pkgs.jq}/bin/jq '.bundle.createUpdaterArtifacts = false' \
                 src-tauri/tauri.conf.json > $TMPDIR/tauri.conf.json
               cp $TMPDIR/tauri.conf.json src-tauri/tauri.conf.json
 
@@ -150,26 +152,9 @@
               shaderc
             ];
 
-            preBuild = ''
-              # bun2nix.hook has already set up node_modules from pre-fetched cache.
-              # Build the frontend with bun (tsc + vite).
-              export HOME=$TMPDIR
-              bun run build
-            '';
-
             # Tests require runtime resources (audio devices, model files, GPU/Vulkan)
             # not available in the Nix build sandbox
             doCheck = false;
-
-            # The tauri hook's installPhase expects target/ in cwd, but our
-            # cargoRoot puts it under src-tauri/. Override to extract the DEB.
-            installPhase = ''
-              runHook preInstall
-              mkdir -p $out
-              cd src-tauri
-              mv target/${pkgs.stdenv.hostPlatform.rust.rustcTarget}/release/bundle/deb/*/data/usr/* $out/
-              runHook postInstall
-            '';
 
             buildInputs = commonNativeDeps pkgs ++ (with pkgs; [
               glib-networking


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched existing issues and pull requests (including closed ones) to ensure this isn't a duplicate
- [x] I have read CONTRIBUTING.md

## Human Written Description

While looking at how another `cargo-tauri.hook`-based flake.nix wires up its build, I noticed the hook already provides exactly the build/install behaviour we were re-implementing by hand. The custom `installPhase` and `preBuild` here were workarounds dating back to the original from-source PR (#778), but the hook's `buildAndTestSubdir` parameter (which makes it `pushd` into the right subdirectory) means we can let it do its standard job. Less code to maintain, and we get the hook's well-tested defaults for free.

## Related Issues/Discussions

Follow-up cleanup after #778 (original `cargo-tauri.hook` migration) and #1255 (bindgenHook cleanup).

## Testing

Built and ran end-to-end on NixOS x86_64-linux:

- `nix build .#handy` — clean from-scratch build (new derivation hash, not cache)
- Wrapper script inspected: all `preFixup` env vars (`WEBKIT_DISABLE_DMABUF_RENDERER`, `ALSA_PLUGIN_DIR`, `LD_LIBRARY_PATH` with vulkan/onnx) plus the hook's defaults (`WEBKIT_GST_ALLOWED_URI_PROTOCOLS=asset`, `__NV_DISABLE_EXPLICIT_SYNC=1`, `GST_PLUGIN_SYSTEM_PATH_1_0` from `tauri-asset-gst-plugin`) are all present
- Launched binary with `--debug`: GigaAM v3 int8 ASR (Russian) transcribed several phrases correctly; Whisper large-v3-turbo loaded onto Vulkan/GTX 1650; microphone capture, paste via dotool, and global shortcuts all worked

I'm on NixOS so can only confirm the Linux side. If anyone is building this on a different distro and willing to spot-check `nix build .#handy`, that would be appreciated.

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Helped read through `cargo-tauri.hook` source to confirm semantics of `buildAndTestSubdir` / `tauriBundleType` / `installScript`, and to compare our flake against another `cargo-tauri.hook`-based flake side-by-side. The change itself is small and was hand-verified.