### PR TITLE
fix(wayland): initialise Enigo, and tolerate failure

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,7 @@
         onnxruntime
         libayatana-appindicator
         libevdev
+        libxkbcommon
         libxtst
         gtk-layer-shell
         openssl

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1533,6 +1533,10 @@ dependencies = [
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "tempfile",
+ "wayland-client",
+ "wayland-protocols-misc",
+ "wayland-protocols-wlr",
  "windows 0.61.3",
  "x11rb",
  "xkbcommon",
@@ -7548,6 +7552,19 @@ dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
  "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-misc"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791c58fdeec5406aa37169dd815327d1e47f334219b523444bc26d70ceb4c34e"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -56,7 +56,7 @@ log = "0.4.25"
 env_filter = "0.1.0"
 tokio = "1.43.0"
 vad-rs = { git = "https://github.com/cjpais/vad-rs", default-features = false }
-enigo = "0.6.1"
+enigo = { version = "0.6.1", features = ["wayland"] }
 rodio = { git = "https://github.com/cjpais/rodio.git" }
 reqwest = { version = "0.12", features = ["json", "stream"] }
 futures-util = "0.3"

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -14,7 +14,7 @@ use crate::utils::{is_kde_wayland, is_wayland};
 
 /// Pastes text using the clipboard: saves current content, writes text, sends paste keystroke, restores clipboard.
 fn paste_via_clipboard(
-    enigo: &mut Enigo,
+    enigo: &mut Option<&mut Enigo>,
     text: &str,
     app_handle: &AppHandle,
     paste_method: &PasteMethod,
@@ -53,11 +53,13 @@ fn paste_via_clipboard(
 
     // Fall back to enigo if no native tool handled it
     if !key_combo_sent {
-        match paste_method {
-            PasteMethod::CtrlV => input::send_paste_ctrl_v(enigo)?,
-            PasteMethod::CtrlShiftV => input::send_paste_ctrl_shift_v(enigo)?,
-            PasteMethod::ShiftInsert => input::send_paste_shift_insert(enigo)?,
-            _ => return Err("Invalid paste method for clipboard paste".into()),
+        if let Some(e) = enigo.as_mut() {
+            match paste_method {
+                PasteMethod::CtrlV => input::send_paste_ctrl_v(e)?,
+                PasteMethod::CtrlShiftV => input::send_paste_ctrl_shift_v(e)?,
+                PasteMethod::ShiftInsert => input::send_paste_shift_insert(e)?,
+                _ => return Err("Invalid paste method for clipboard paste".into()),
+            }
         }
     }
 
@@ -526,7 +528,7 @@ fn paste_via_external_script(text: &str, script_path: &str) -> Result<(), String
 
 /// Types text directly by simulating individual key presses.
 fn paste_direct(
-    enigo: &mut Enigo,
+    enigo: &mut Option<&mut Enigo>,
     text: &str,
     #[cfg(target_os = "linux")] typing_tool: TypingTool,
 ) -> Result<(), String> {
@@ -538,46 +540,54 @@ fn paste_direct(
         info!("Falling back to enigo for direct text input");
     }
 
-    input::paste_text_direct(enigo, text)
+    if let Some(e) = enigo.as_mut() {
+        input::paste_text_direct(e, text)?;
+    }
+    Ok(())
 }
 
-fn send_return_key(enigo: &mut Enigo, key_type: AutoSubmitKey) -> Result<(), String> {
-    match key_type {
-        AutoSubmitKey::Enter => {
-            enigo
-                .key(Key::Return, Direction::Press)
-                .map_err(|e| format!("Failed to press Return key: {}", e))?;
-            enigo
-                .key(Key::Return, Direction::Release)
-                .map_err(|e| format!("Failed to release Return key: {}", e))?;
-        }
-        AutoSubmitKey::CtrlEnter => {
-            enigo
-                .key(Key::Control, Direction::Press)
-                .map_err(|e| format!("Failed to press Control key: {}", e))?;
-            enigo
-                .key(Key::Return, Direction::Press)
-                .map_err(|e| format!("Failed to press Return key: {}", e))?;
-            enigo
-                .key(Key::Return, Direction::Release)
-                .map_err(|e| format!("Failed to release Return key: {}", e))?;
-            enigo
-                .key(Key::Control, Direction::Release)
-                .map_err(|e| format!("Failed to release Control key: {}", e))?;
-        }
-        AutoSubmitKey::CmdEnter => {
-            enigo
-                .key(Key::Meta, Direction::Press)
-                .map_err(|e| format!("Failed to press Meta/Cmd key: {}", e))?;
-            enigo
-                .key(Key::Return, Direction::Press)
-                .map_err(|e| format!("Failed to press Return key: {}", e))?;
-            enigo
-                .key(Key::Return, Direction::Release)
-                .map_err(|e| format!("Failed to release Return key: {}", e))?;
-            enigo
-                .key(Key::Meta, Direction::Release)
-                .map_err(|e| format!("Failed to release Meta/Cmd key: {}", e))?;
+fn send_return_key(
+    enigo: &mut Option<&mut Enigo>,
+    key_type: AutoSubmitKey
+) -> Result<(), String> {
+    if let Some(e) = enigo.as_mut() {
+        match key_type {
+            AutoSubmitKey::Enter => {
+                e
+                    .key(Key::Return, Direction::Press)
+                    .map_err(|err| format!("Failed to press Return key: {}", err))?;
+                e
+                    .key(Key::Return, Direction::Release)
+                    .map_err(|err| format!("Failed to release Return key: {}", err))?;
+            }
+            AutoSubmitKey::CtrlEnter => {
+                e
+                    .key(Key::Control, Direction::Press)
+                    .map_err(|err| format!("Failed to press Control key: {}", err))?;
+                e
+                    .key(Key::Return, Direction::Press)
+                    .map_err(|err| format!("Failed to press Return key: {}", err))?;
+                e
+                    .key(Key::Return, Direction::Release)
+                    .map_err(|err| format!("Failed to release Return key: {}", err))?;
+                e
+                    .key(Key::Control, Direction::Release)
+                    .map_err(|err| format!("Failed to release Control key: {}", err))?;
+            }
+            AutoSubmitKey::CmdEnter => {
+                e
+                    .key(Key::Meta, Direction::Press)
+                    .map_err(|err| format!("Failed to press Meta/Cmd key: {}", err))?;
+                e
+                    .key(Key::Return, Direction::Press)
+                    .map_err(|err| format!("Failed to press Return key: {}", err))?;
+                e
+                    .key(Key::Return, Direction::Release)
+                    .map_err(|err| format!("Failed to release Return key: {}", err))?;
+                e
+                    .key(Key::Meta, Direction::Release)
+                    .map_err(|err| format!("Failed to release Meta/Cmd key: {}", err))?;
+            }
         }
     }
 
@@ -605,36 +615,66 @@ pub fn paste(text: String, app_handle: AppHandle) -> Result<(), String> {
         paste_method, paste_delay_ms
     );
 
-    // Get the managed Enigo instance
-    let enigo_state = app_handle
-        .try_state::<EnigoState>()
-        .ok_or("Enigo state not initialized")?;
-    let mut enigo = enigo_state
-        .0
-        .lock()
-        .map_err(|e| format!("Failed to lock Enigo: {}", e))?;
-
     // Perform the paste operation
     match paste_method {
         PasteMethod::None => {
             info!("PasteMethod::None selected - skipping paste action");
         }
         PasteMethod::Direct => {
-            paste_direct(
-                &mut enigo,
-                &text,
-                #[cfg(target_os = "linux")]
-                settings.typing_tool,
-            )?;
+            // Try to get enigo, but proceed with None if not available
+            // Primary methods (wtype, xdotool, etc.) will still work
+            match app_handle.try_state::<EnigoState>() {
+                Some(enigo_state) => {
+                    let mut enigo_guard = enigo_state.0.lock()
+                        .map_err(|e| format!("Failed to lock Enigo mutex: {}", e))?;
+                    let mut enigo_opt: Option<&mut Enigo> = Some(&mut *enigo_guard);
+                    paste_direct(
+                        &mut enigo_opt,
+                        &text,
+                        #[cfg(target_os = "linux")]
+                        settings.typing_tool,
+                    )?;
+                }
+                None => {
+                    log::warn!("Enigo state not initialized, trying primary method only");
+                    let mut enigo_opt: Option<&mut Enigo> = None;
+                    paste_direct(
+                        &mut enigo_opt,
+                        &text,
+                        #[cfg(target_os = "linux")]
+                        settings.typing_tool,
+                    )?;
+                }
+            }
         }
         PasteMethod::CtrlV | PasteMethod::CtrlShiftV | PasteMethod::ShiftInsert => {
-            paste_via_clipboard(
-                &mut enigo,
-                &text,
-                &app_handle,
-                &paste_method,
-                paste_delay_ms,
-            )?
+            // Try to get enigo, but proceed with None if not available
+            // Primary methods (wtype, dotool, etc.) will still work
+            match app_handle.try_state::<EnigoState>() {
+                Some(enigo_state) => {
+                    let mut enigo_guard = enigo_state.0.lock()
+                        .map_err(|e| format!("Failed to lock Enigo mutex: {}", e))?;
+                    let mut enigo_opt: Option<&mut Enigo> = Some(&mut *enigo_guard);
+                    paste_via_clipboard(
+                        &mut enigo_opt,
+                        &text,
+                        &app_handle,
+                        &paste_method,
+                        paste_delay_ms,
+                    )?
+                }
+                None => {
+                    log::warn!("Enigo state not initialized, trying primary method only");
+                    let mut enigo_opt: Option<&mut Enigo> = None;
+                    paste_via_clipboard(
+                        &mut enigo_opt,
+                        &text,
+                        &app_handle,
+                        &paste_method,
+                        paste_delay_ms,
+                    )?
+                }
+            }
         }
         PasteMethod::ExternalScript => {
             let script_path = settings
@@ -648,7 +688,17 @@ pub fn paste(text: String, app_handle: AppHandle) -> Result<(), String> {
 
     if should_send_auto_submit(settings.auto_submit, paste_method) {
         std::thread::sleep(Duration::from_millis(50));
-        send_return_key(&mut enigo, settings.auto_submit_key)?;
+        match app_handle.try_state::<EnigoState>() {
+            Some(enigo_state) => {
+                let mut enigo_guard = enigo_state.0.lock()
+                    .map_err(|e| format!("Failed to lock Enigo mutex: {}", e))?;
+                let mut enigo_opt: Option<&mut Enigo> = Some(&mut *enigo_guard);
+                send_return_key(&mut enigo_opt, settings.auto_submit_key)?;
+            }
+            None => {
+                log::warn!("Enigo state not initialized, cannot send auto-submit key");
+            }
+        }
     }
 
     // After pasting, optionally copy to clipboard based on settings


### PR DESCRIPTION
Enable the `enigo` crate's `wayland` feature. Without it, despite `WAYLAND_DISPLAY` being set, Enigo tries only its `x11rb` backend rather than `wayland`:

```text
[2026-04-27][09:29:56][enigo][DEBUG] using default settings
[2026-04-27][09:29:56][enigo::platform][DEBUG] trying to establish a x11 connection to $DISPLAY
[2026-04-27][09:29:56][enigo::platform::x11][DEBUG] using x11rb
[2026-04-27][09:29:56][enigo::platform::x11][ERROR] DisplayParsingError(DisplayNotSet)
[2026-04-27][09:29:56][enigo::platform][WARN] failed to establish x11 connection: no connection could be established: (failed to establish the connection)
[2026-04-27][09:29:56][enigo::platform][ERROR] no successful connection
```

<details><summary>In this configuration Enigo will try both the `x11rb` and `wayland` backends, but only the `wayland` one will succeed:</summary>

```text
[2026-04-27][09:44:52][enigo][DEBUG] using default settings
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] trying to establish a connection to $WAYLAND_DISPLAY
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: wl_compositor (name: 1, version: 6)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: wl_subcompositor (name: 2, version: 1)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: xdg_wm_base (name: 3, version: 7)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: zxdg_decoration_manager_v1 (name: 4, version: 1)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: org_kde_kwin_server_decoration_manager (name: 5, version: 1)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: zwlr_layer_shell_v1 (name: 6, version: 5)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: ext_session_lock_manager_v1 (name: 7, version: 1)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: wl_shm (name: 8, version: 2)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: zxdg_output_manager_v1 (name: 9, version: 3)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: wp_fractional_scale_manager_v1 (name: 10, version: 1)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: zwp_tablet_manager_v2 (name: 11, version: 1)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: zwp_pointer_gestures_v1 (name: 12, version: 3)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: zwp_relative_pointer_manager_v1 (name: 13, version: 1)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: zwp_pointer_constraints_v1 (name: 14, version: 1)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: ext_idle_notifier_v1 (name: 15, version: 2)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: zwp_idle_inhibit_manager_v1 (name: 16, version: 1)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: wl_data_device_manager (name: 17, version: 3)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: zwlr_data_control_manager_v1 (name: 19, version: 2)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: ext_data_control_manager_v1 (name: 20, version: 1)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: wp_presentation (name: 21, version: 2)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: wp_security_context_manager_v1 (name: 22, version: 1)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: zwp_text_input_manager_v3 (name: 23, version: 1)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: zwp_input_method_manager_v2 (name: 24, version: 1)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: zwp_keyboard_shortcuts_inhibit_manager_v1 (name: 25, version: 1)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: zwp_virtual_keyboard_manager_v1 (name: 26, version: 1)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: zwlr_virtual_pointer_manager_v1 (name: 27, version: 2)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: ext_foreign_toplevel_list_v1 (name: 28, version: 1)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: zwlr_foreign_toplevel_manager_v1 (name: 29, version: 3)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: ext_workspace_manager_v1 (name: 30, version: 1)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: zwlr_output_manager_v1 (name: 31, version: 4)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: zwlr_screencopy_manager_v1 (name: 32, version: 3)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: wp_viewporter (name: 33, version: 1)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: ext_background_effect_manager_v1 (name: 34, version: 1)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: zxdg_exporter_v2 (name: 35, version: 1)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: zxdg_importer_v2 (name: 36, version: 1)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: zwlr_gamma_control_manager_v1 (name: 37, version: 1)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: xdg_activation_v1 (name: 38, version: 1)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: mutter_x11_interop (name: 39, version: 1)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: wl_seat (name: 40, version: 9)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: wp_cursor_shape_manager_v1 (name: 41, version: 2)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: zwp_linux_dmabuf_v1 (name: 42, version: 5)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: wp_drm_lease_device_v1 (name: 43, version: 1)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] Global announced: wl_output (name: 44, version: 4)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] WlSeat received event: Capabilities { capabilities: Value(Capability(Pointer | Keyboard)) }
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] WlOutput received event: Geometry { x: 0, y: 0, physical_width: 290, physical_height: 190, subpixel: Value(Unknown), make: "BOE", model: "NE135A1M-NY1", transform: Value(Normal) }
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] WlOutput received event: Mode { flags: Value(Mode(Current | Preferred)), width: 2880, height: 1920, refresh: 120000 }
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] WlKeyboard received event: wl_keyboard::Event::Keymap { Value(XkbV1), OwnedFd { fd: 54 }, 35356 }
[2026-04-27][09:44:52][enigo::platform::keymap2][DEBUG] creating new xkb:Keymap
[2026-04-27][09:44:52][enigo::platform::keymap2][DEBUG] new(format: 1, size: 35356, ...)
[2026-04-27][09:44:52][enigo::platform::keymap2][DEBUG] removed NULL byte at the end
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] WlKeyboard received irrelevant event: RepeatInfo { rate: 25, delay: 600 }
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] ZwpInputMethodV2 received event: zwp_input_method_v2::Event::Done
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] update_keymap(&mut self)
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] wait for response after keymap call
[2026-04-27][09:44:52][enigo::platform::wayland][DEBUG] protocols available
virtual_keyboard: true
input_method: true
virtual_pointer: true
[2026-04-27][09:44:52][enigo::platform][DEBUG] wayland connection established
[2026-04-27][09:44:52][enigo::platform][DEBUG] trying to establish a x11 connection to $DISPLAY
[2026-04-27][09:44:52][enigo::platform::x11][DEBUG] using x11rb
[2026-04-27][09:44:52][enigo::platform::x11][ERROR] DisplayParsingError(DisplayNotSet)
[2026-04-27][09:44:52][enigo::platform][WARN] failed to establish x11 connection: no connection could be established: (failed to establish the connection)
[2026-04-27][09:44:52][handy_app_lib::commands][INFO] Enigo initialized successfully after permission grant
```

</details>

Enigo is used as a fallback, but prior to this change, if it failed to initialise `paste()` would never invoke the primary paste method. Instead the following logs would be observed:

    [2026-04-26][23:56:08][handy_app_lib::clipboard][INFO] Using paste method: Direct, delay: 60ms
    [2026-04-26][23:56:08][handy_app_lib::clipboard][ERROR] Enigo state not initialized
    [2026-04-26][23:56:08][handy_app_lib::actions][ERROR] Failed to paste transcription: Enigo state not initialized

...since paste()'s call to `AppHandle::try_state()` would return an error which would be propagated up, causing an early exit.

## Before Submitting This PR

<!--
HANDY IS UNDERGOING A FEATURE FREEZE. IF YOU ARE SUBMITTING A PR WHICH IS A NEW FEATURE THAT THE COMMUNITY HAS NOT ASKED FOR: PREPARE TO BE REJECTED. IF THE COMMUNITY HAS ASKED FOR IT, OR YOU HAVE EXPLICITLY GATHERED SUPPORT IT MAY STILL BE CONSIDERED.

BUG FIXES ARE THE TOP PRIORITY. THERE ARE 60+ ISSUES TO FIX.
-->

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

<!-- Describe your changes clearly and concisely

Please write 2-3 sentences in your own words explaining:
- What problem you noticed or idea you had
- Why you think this change matters

This section should be YOUR thinking, not AI-generated text. Even if AI helped write the code, we want to hear from you directly. Your perspective as a human is what makes contributions meaningful. Your PR may be rejected if you do not
include a human-written description.
-->

Enigo is used as a fallback, but prior to this change, if it failed to initialise `paste()` would never invoke the primary paste method. Instead the following logs would be observed:

```text
[2026-04-26][23:56:08][handy_app_lib::clipboard][INFO] Using paste method: Direct, delay: 60ms
[2026-04-26][23:56:08][handy_app_lib::clipboard][ERROR] Enigo state not initialized
[2026-04-26][23:56:08][handy_app_lib::actions][ERROR] Failed to paste transcription: Enigo state not initialized
```

...since `paste()`'s call to `AppHandle::try_state()` would return an error which would be propagated up, causing an early exit.

Happy to switch to doing early returns rather than `if let Some(x)`s if you prefer, as it would reduce the size of the diff, but I thought it made the code easier to read.

## Related Issues/Discussions

<!-- Link to related issues, discussions, or previous PRs -->
<!-- If reopening something previously closed, explain why this should be reconsidered -->

Fixes #
Discussion:

## Community Feedback

<!--
PRs with community support are much more likely to be merged.

For features: Link to a discussion where community members have expressed interest.
For bug fixes: Link to the issue where others have confirmed the bug.

If you haven't gathered feedback yet, consider starting a discussion first:
https://github.com/cjpais/Handy/discussions

It is not explicitly required to gather feedback, but it certainly helps your PR get merged.
-->

## Testing

<!-- Describe how you tested your changes and if you need help getting additional testing -->

## Screenshots/Videos (if applicable)

<!-- Add screenshots or videos demonstrating the change -->

## AI Assistance

<!-- AI-assisted PRs are welcome! Just let us know so we can review appropriately. -->

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Haiku 4.5 via Goose
- How extensively: moderate -- I had sprinked some logging calls around to confirm that the issue was with `paste()` propagating that error, but figuring out the correct fix for the mutex took a bit of back and forth.
