### PR TITLE
fix: prevent abort on quit by handling poisoned mutexes in Drop impls

### DIFF
--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -56,7 +56,12 @@ pub struct LoadingGuard {
 
 impl Drop for LoadingGuard {
     fn drop(&mut self) {
-        let mut is_loading = self.is_loading.lock().unwrap();
+        // Recover from a poisoned mutex instead of panicking —
+        // a panic inside Drop calls abort().
+        let mut is_loading = match self.is_loading.lock() {
+            Ok(g) => g,
+            Err(e) => e.into_inner(),
+        };
         *is_loading = false;
         self.loading_condvar.notify_all();
     }
@@ -842,8 +847,14 @@ impl Drop for TranscriptionManager {
         // Signal the watcher thread to shutdown
         self.shutdown_signal.store(true, Ordering::Relaxed);
 
-        // Wait for the thread to finish gracefully
-        if let Some(handle) = self.watcher_handle.lock().unwrap().take() {
+        // Wait for the thread to finish gracefully.
+        // Use match instead of unwrap to avoid panicking if the mutex is
+        // poisoned — a panic inside Drop calls abort().
+        let mut guard = match self.watcher_handle.lock() {
+            Ok(g) => g,
+            Err(e) => e.into_inner(),
+        };
+        if let Some(handle) = guard.take() {
             if let Err(e) = handle.join() {
                 warn!("Failed to join idle watcher thread: {:?}", e);
             } else {


### PR DESCRIPTION
## Summary

- Replace `.lock().unwrap()` with `match` + `into_inner()` in `TranscriptionManager::drop()` and `LoadingGuard::drop()` to prevent `abort()` on app quit

## Problem

When macOS sends a quit event (Cmd+Q, system shutdown, etc.), the app terminates via `[NSApplication terminate:]` → `exit()` → `__cxa_finalize_ranges`, which runs Rust Drop handlers. If a mutex was poisoned by a prior panic anywhere in the transcription pipeline, calling `.lock().unwrap()` inside a Drop impl triggers a second panic. Rust treats panic-during-Drop as unrecoverable and calls `abort()`, producing a `SIGABRT` crash instead of a clean exit.

The two affected locations:
- **`TranscriptionManager::drop()`** (`transcription.rs:846`) — `.lock().unwrap()` on `watcher_handle`
- **`LoadingGuard::drop()`** (`transcription.rs:59`) — `.lock().unwrap()` on `is_loading`

Note: `HandyKeysState::drop()` already uses `if let Ok(...)` which correctly handles poisoned locks.

## Fix

Use `PoisonError::into_inner()` to recover the underlying `MutexGuard` even when the mutex is poisoned. This is the standard Rust pattern for "I need this data during cleanup regardless of prior panics."

## Test plan

- [ ] `cargo check` / `cargo clippy` pass
- [ ] App starts and records normally
- [ ] Cmd+Q exits cleanly without crash
- [ ] Force-quit and re-launch works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)