### PR TITLE
fix(macos): add menu bar mode for window managers

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -84,8 +84,57 @@ fn build_console_filter() -> env_filter::Filter {
     builder.build()
 }
 
+// Window/tray launch policy lives here because it combines persisted settings,
+// runtime CLI overrides, and macOS activation policy.
+fn is_tray_disabled_by_cli(app: &AppHandle) -> bool {
+    app.try_state::<CliArgs>()
+        .map(|args| args.no_tray)
+        .unwrap_or(false)
+}
+
+fn is_tray_enabled(app: &AppHandle, settings: &settings::AppSettings) -> bool {
+    (settings.menu_bar_mode || settings.show_tray_icon) && !is_tray_disabled_by_cli(app)
+}
+
+fn should_start_with_main_window_hidden(
+    settings: &settings::AppSettings,
+    cli_args: &CliArgs,
+) -> bool {
+    settings.menu_bar_mode || settings.start_hidden || cli_args.start_hidden
+}
+
+#[cfg(target_os = "macos")]
+fn should_use_accessory_activation_policy_on_start(
+    app: &AppHandle,
+    settings: &settings::AppSettings,
+) -> bool {
+    should_start_with_main_window_hidden(settings, &app.state::<CliArgs>())
+        && is_tray_enabled(app, settings)
+}
+
+#[cfg(target_os = "macos")]
+fn should_show_settings_as_accessory(app: &AppHandle, settings: &settings::AppSettings) -> bool {
+    settings.menu_bar_mode && is_tray_enabled(app, settings)
+}
+
+#[cfg(target_os = "macos")]
+fn apply_activation_policy_for_settings_window(app: &AppHandle, settings: &settings::AppSettings) {
+    if should_show_settings_as_accessory(app, settings) {
+        return;
+    }
+
+    if let Err(e) = app.set_activation_policy(tauri::ActivationPolicy::Regular) {
+        log::error!("Failed to set activation policy to Regular: {}", e);
+    }
+}
+
 fn show_main_window(app: &AppHandle) {
     if let Some(main_window) = app.get_webview_window("main") {
+        #[cfg(target_os = "macos")]
+        {
+            let settings = settings::get_settings(app);
+            apply_activation_policy_for_settings_window(app, &settings);
+        }
         if let Err(e) = main_window.unminimize() {
             log::error!("Failed to unminimize webview window: {}", e);
         }
@@ -94,12 +143,6 @@ fn show_main_window(app: &AppHandle) {
         }
         if let Err(e) = main_window.set_focus() {
             log::error!("Failed to focus webview window: {}", e);
-        }
-        #[cfg(target_os = "macos")]
-        {
-            if let Err(e) = app.set_activation_policy(tauri::ActivationPolicy::Regular) {
-                log::error!("Failed to set activation policy to Regular: {}", e);
-            }
         }
         return;
     }
@@ -181,7 +224,7 @@ fn initialize_core_logic(app_handle: &AppHandle) {
     #[cfg(target_os = "macos")]
     {
         let settings = settings::get_settings(app_handle);
-        if settings.start_hidden && settings.show_tray_icon {
+        if should_use_accessory_activation_policy_on_start(app_handle, &settings) {
             let _ = app_handle.set_activation_policy(tauri::ActivationPolicy::Accessory);
         }
     }
@@ -268,7 +311,7 @@ fn initialize_core_logic(app_handle: &AppHandle) {
 
     // Apply show_tray_icon setting
     let settings = settings::get_settings(app_handle);
-    if !settings.show_tray_icon {
+    if !is_tray_enabled(app_handle, &settings) {
         tray::set_tray_visibility(app_handle, false);
     }
 
@@ -331,6 +374,7 @@ pub fn run(cli_args: CliArgs) {
             shortcut::change_audio_feedback_volume_setting,
             shortcut::change_sound_theme_setting,
             shortcut::change_start_hidden_setting,
+            shortcut::change_menu_bar_mode_setting,
             shortcut::change_autostart_setting,
             shortcut::change_translate_to_english_setting,
             shortcut::change_selected_language_setting,
@@ -561,12 +605,12 @@ pub fn run(cli_args: CliArgs) {
             // Show main window only if not starting hidden.
             // CLI --start-hidden flag overrides the setting.
             // But if permission onboarding is required, always show the window.
-            let should_hide = settings.start_hidden || cli_args.start_hidden;
+            let should_hide = should_start_with_main_window_hidden(&settings, &cli_args);
             let should_force_show = should_force_show_permissions_window(&app_handle);
 
             // If start_hidden but tray is disabled, we must show the window
             // anyway. Without a tray icon, the dock is the only way back in.
-            let tray_available = settings.show_tray_icon && !cli_args.no_tray;
+            let tray_available = is_tray_enabled(&app_handle, &settings);
             if should_force_show || !should_hide || !tray_available {
                 show_main_window(&app_handle);
             }
@@ -581,9 +625,7 @@ pub fn run(cli_args: CliArgs) {
                 #[cfg(target_os = "macos")]
                 {
                     let settings = get_settings(&window.app_handle());
-                    let tray_visible =
-                        settings.show_tray_icon && !window.app_handle().state::<CliArgs>().no_tray;
-                    if tray_visible {
+                    if is_tray_enabled(&window.app_handle(), &settings) {
                         // Tray is available: hide the dock icon, app lives in the tray
                         let res = window
                             .app_handle()

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -345,6 +345,8 @@ pub struct AppSettings {
     pub sound_theme: SoundTheme,
     #[serde(default = "default_start_hidden")]
     pub start_hidden: bool,
+    #[serde(default = "default_menu_bar_mode")]
+    pub menu_bar_mode: bool,
     #[serde(default = "default_autostart_enabled")]
     pub autostart_enabled: bool,
     #[serde(default = "default_update_checks_enabled")]
@@ -445,6 +447,10 @@ fn default_translate_to_english() -> bool {
 }
 
 fn default_start_hidden() -> bool {
+    false
+}
+
+fn default_menu_bar_mode() -> bool {
     false
 }
 
@@ -771,6 +777,7 @@ pub fn get_default_settings() -> AppSettings {
         audio_feedback_volume: default_audio_feedback_volume(),
         sound_theme: default_sound_theme(),
         start_hidden: default_start_hidden(),
+        menu_bar_mode: default_menu_bar_mode(),
         autostart_enabled: default_autostart_enabled(),
         update_checks_enabled: default_update_checks_enabled(),
         selected_model: "".to_string(),

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -596,6 +596,24 @@ pub fn change_start_hidden_setting(app: AppHandle, enabled: bool) -> Result<(), 
 
 #[tauri::command]
 #[specta::specta]
+pub fn change_menu_bar_mode_setting(app: AppHandle, enabled: bool) -> Result<(), String> {
+    let mut settings = settings::get_settings(&app);
+    settings.menu_bar_mode = enabled;
+    settings::write_settings(&app, settings);
+
+    let _ = app.emit(
+        "settings-changed",
+        serde_json::json!({
+            "setting": "menu_bar_mode",
+            "value": enabled
+        }),
+    );
+
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
 pub fn change_autostart_setting(app: AppHandle, enabled: bool) -> Result<(), String> {
     let mut settings = settings::get_settings(&app);
     settings.autostart_enabled = enabled;

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -61,6 +61,14 @@ async changeStartHiddenSetting(enabled: boolean) : Promise<Result<null, string>>
     else return { status: "error", error: e  as any };
 }
 },
+async changeMenuBarModeSetting(enabled: boolean) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("change_menu_bar_mode_setting", { enabled }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async changeAutostartSetting(enabled: boolean) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("change_autostart_setting", { enabled }) };
@@ -832,7 +840,7 @@ historyUpdatePayload: "history-update-payload"
 
 /** user-defined types **/
 
-export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk: boolean; audio_feedback: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; selected_model?: string; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: SecretMap; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; experimental_enabled?: boolean; lazy_stream_close?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool; external_script_path: string | null; custom_filler_words?: string[] | null; whisper_accelerator?: WhisperAcceleratorSetting; ort_accelerator?: OrtAcceleratorSetting; whisper_gpu_device?: number; extra_recording_buffer_ms?: number }
+export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk: boolean; audio_feedback: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; menu_bar_mode?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; selected_model?: string; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: SecretMap; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; experimental_enabled?: boolean; lazy_stream_close?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool; external_script_path: string | null; custom_filler_words?: string[] | null; whisper_accelerator?: WhisperAcceleratorSetting; ort_accelerator?: OrtAcceleratorSetting; whisper_gpu_device?: number; extra_recording_buffer_ms?: number }
 export type AudioDevice = { index: string; name: string; is_default: boolean }
 export type AutoSubmitKey = "enter" | "ctrl_enter" | "cmd_enter"
 export type AvailableAccelerators = { whisper: string[]; ort: string[]; gpu_devices: GpuDeviceOption[] }

--- a/src/components/settings/MenuBarMode.tsx
+++ b/src/components/settings/MenuBarMode.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { ToggleSwitch } from "../ui/ToggleSwitch";
+import { useSettings } from "../../hooks/useSettings";
+
+interface MenuBarModeProps {
+  descriptionMode?: "inline" | "tooltip";
+  grouped?: boolean;
+}
+
+export const MenuBarMode: React.FC<MenuBarModeProps> = React.memo(
+  ({ descriptionMode = "tooltip", grouped = false }) => {
+    const { t } = useTranslation();
+    const { getSetting, updateSetting, isUpdating } = useSettings();
+
+    const menuBarMode = getSetting("menu_bar_mode") ?? false;
+
+    return (
+      <ToggleSwitch
+        checked={menuBarMode}
+        onChange={(enabled) => updateSetting("menu_bar_mode", enabled)}
+        isUpdating={isUpdating("menu_bar_mode")}
+        label={t("settings.advanced.menuBarMode.label")}
+        description={t("settings.advanced.menuBarMode.description")}
+        descriptionMode={descriptionMode}
+        grouped={grouped}
+        tooltipPosition="bottom"
+      />
+    );
+  },
+);

--- a/src/components/settings/advanced/AdvancedSettings.tsx
+++ b/src/components/settings/advanced/AdvancedSettings.tsx
@@ -5,6 +5,7 @@ import { ModelUnloadTimeoutSetting } from "../ModelUnloadTimeout";
 import { CustomWords } from "../CustomWords";
 import { SettingsGroup } from "../../ui/SettingsGroup";
 import { StartHidden } from "../StartHidden";
+import { MenuBarMode } from "../MenuBarMode";
 import { AutostartToggle } from "../AutostartToggle";
 import { ShowTrayIcon } from "../ShowTrayIcon";
 import { PasteMethodSetting } from "../PasteMethod";
@@ -20,16 +21,21 @@ import { useSettings } from "../../../hooks/useSettings";
 import { KeyboardImplementationSelector } from "../debug/KeyboardImplementationSelector";
 import { AccelerationSelector } from "../AccelerationSelector";
 import { LazyStreamClose } from "../LazyStreamClose";
+import { useOsType } from "../../../hooks/useOsType";
 
 export const AdvancedSettings: React.FC = () => {
   const { t } = useTranslation();
   const { getSetting } = useSettings();
+  const osType = useOsType();
   const experimentalEnabled = getSetting("experimental_enabled") || false;
 
   return (
     <div className="max-w-3xl w-full mx-auto space-y-6">
       <SettingsGroup title={t("settings.advanced.groups.app")}>
         <StartHidden descriptionMode="tooltip" grouped={true} />
+        {osType === "macos" && (
+          <MenuBarMode descriptionMode="tooltip" grouped={true} />
+        )}
         <AutostartToggle descriptionMode="tooltip" grouped={true} />
         <ShowTrayIcon descriptionMode="tooltip" grouped={true} />
         <ShowOverlay descriptionMode="tooltip" grouped={true} />

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -253,8 +253,8 @@
         "description": ".التشغيل في صينية النظام دون فتح النافذة"
       },
       "menuBarMode": {
-        "label": "Keep in Menu Bar",
-        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+        "label": "الإبقاء في شريط القوائم",
+        "description": ".أبقِ Handy في شريط القوائم وخارج Dock ومبدّل التطبيقات حتى لا تسحب الاختصارات العامة التركيز. يسري ذلك بعد إعادة تشغيل Handy"
       },
       "autostart": {
         "label": "التشغيل عند بدء التشغيل",

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -252,6 +252,10 @@
         "label": "بدء مخفي",
         "description": ".التشغيل في صينية النظام دون فتح النافذة"
       },
+      "menuBarMode": {
+        "label": "Keep in Menu Bar",
+        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+      },
       "autostart": {
         "label": "التشغيل عند بدء التشغيل",
         "description": ".بدء تشغيل Handy تلقائياً عند تسجيل الدخول إلى جهاز الكمبيوتر الخاص بك"

--- a/src/i18n/locales/bg/translation.json
+++ b/src/i18n/locales/bg/translation.json
@@ -274,6 +274,10 @@
         "label": "Стартиране скрито",
         "description": "Стартиране в системната област без отваряне на прозореца."
       },
+      "menuBarMode": {
+        "label": "Keep in Menu Bar",
+        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+      },
       "autostart": {
         "label": "Стартиране със системата",
         "description": "Автоматично стартиране на Handy при влизане в профила ви."

--- a/src/i18n/locales/bg/translation.json
+++ b/src/i18n/locales/bg/translation.json
@@ -275,8 +275,8 @@
         "description": "Стартиране в системната област без отваряне на прозореца."
       },
       "menuBarMode": {
-        "label": "Keep in Menu Bar",
-        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+        "label": "Оставане в лентата с менюта",
+        "description": "Дръжте Handy в лентата с менюта и извън Dock и превключвателя на приложения, за да не отнемат глобалните клавишни комбинации фокуса. Влиза в сила след рестартиране на Handy."
       },
       "autostart": {
         "label": "Стартиране със системата",

--- a/src/i18n/locales/cs/translation.json
+++ b/src/i18n/locales/cs/translation.json
@@ -275,8 +275,8 @@
         "description": "Spustit do systémové lišty bez otevření okna."
       },
       "menuBarMode": {
-        "label": "Keep in Menu Bar",
-        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+        "label": "Ponechat v řádku nabídek",
+        "description": "Ponechá Handy v řádku nabídek a mimo Dock i přepínač aplikací, aby globální zkratky nepřenášely fokus na Handy. Projeví se po restartování Handy."
       },
       "autostart": {
         "label": "Spouštět při startu",

--- a/src/i18n/locales/cs/translation.json
+++ b/src/i18n/locales/cs/translation.json
@@ -274,6 +274,10 @@
         "label": "Spouštět skrytě",
         "description": "Spustit do systémové lišty bez otevření okna."
       },
+      "menuBarMode": {
+        "label": "Keep in Menu Bar",
+        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+      },
       "autostart": {
         "label": "Spouštět při startu",
         "description": "Automaticky spustit Handy po přihlášení do počítače."

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -275,8 +275,8 @@
         "description": "In den Systembereich starten, ohne das Fenster zu öffnen."
       },
       "menuBarMode": {
-        "label": "Keep in Menu Bar",
-        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+        "label": "In der Menüleiste behalten",
+        "description": "Handy in der Menüleiste behalten und aus Dock und App-Umschalter ausblenden, damit globale Tastenkürzel den Fokus nicht auf Handy ziehen. Wird nach einem Neustart von Handy wirksam."
       },
       "autostart": {
         "label": "Beim Start ausführen",

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -274,6 +274,10 @@
         "label": "Versteckt starten",
         "description": "In den Systembereich starten, ohne das Fenster zu öffnen."
       },
+      "menuBarMode": {
+        "label": "Keep in Menu Bar",
+        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+      },
       "autostart": {
         "label": "Beim Start ausführen",
         "description": "Handy automatisch beim Anmelden starten."

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -274,6 +274,10 @@
         "label": "Start Hidden",
         "description": "Launch to system tray without opening the window."
       },
+      "menuBarMode": {
+        "label": "Keep in Menu Bar",
+        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+      },
       "autostart": {
         "label": "Launch on Startup",
         "description": "Automatically start Handy when you log in to your computer."

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -274,6 +274,10 @@
         "label": "Iniciar Oculto",
         "description": "Lanzar en la bandeja del sistema sin abrir la ventana."
       },
+      "menuBarMode": {
+        "label": "Keep in Menu Bar",
+        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+      },
       "autostart": {
         "label": "Iniciar al Arranque",
         "description": "Iniciar Handy automáticamente cuando inicies sesión en tu computadora."

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -275,8 +275,8 @@
         "description": "Lanzar en la bandeja del sistema sin abrir la ventana."
       },
       "menuBarMode": {
-        "label": "Keep in Menu Bar",
-        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+        "label": "Mantener en la Barra de Menús",
+        "description": "Mantiene Handy en la barra de menús y fuera del Dock y del selector de aplicaciones para que los atajos globales no roben el foco. Surte efecto después de reiniciar Handy."
       },
       "autostart": {
         "label": "Iniciar al Arranque",

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -274,6 +274,10 @@
         "label": "Démarrer masqué",
         "description": "Lancer dans la barre système sans ouvrir la fenêtre."
       },
+      "menuBarMode": {
+        "label": "Keep in Menu Bar",
+        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+      },
       "autostart": {
         "label": "Lancer au démarrage",
         "description": "Démarrer automatiquement Handy lorsque vous vous connectez à votre ordinateur."

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -275,8 +275,8 @@
         "description": "Lancer dans la barre système sans ouvrir la fenêtre."
       },
       "menuBarMode": {
-        "label": "Keep in Menu Bar",
-        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+        "label": "Garder dans la barre des menus",
+        "description": "Garde Handy dans la barre des menus et hors du Dock et du sélecteur d'applications afin que les raccourcis globaux ne ramènent pas le focus sur Handy. Prend effet après le redémarrage de Handy."
       },
       "autostart": {
         "label": "Lancer au démarrage",

--- a/src/i18n/locales/he/translation.json
+++ b/src/i18n/locales/he/translation.json
@@ -274,6 +274,10 @@
         "label": "התחל מוסתר",
         "description": "הפעל לתוך מגש המערכת בלי לפתוח את החלון."
       },
+      "menuBarMode": {
+        "label": "Keep in Menu Bar",
+        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+      },
       "autostart": {
         "label": "הפעל עם עליית המערכת",
         "description": "הפעל את Handy אוטומטית כשאתה מתחבר למחשב."

--- a/src/i18n/locales/he/translation.json
+++ b/src/i18n/locales/he/translation.json
@@ -275,8 +275,8 @@
         "description": "הפעל לתוך מגש המערכת בלי לפתוח את החלון."
       },
       "menuBarMode": {
-        "label": "Keep in Menu Bar",
-        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+        "label": "השאר בשורת התפריטים",
+        "description": "השאר את Handy בשורת התפריטים ומחוץ ל-Dock ולמחליף היישומים, כדי שקיצורי דרך גלובליים לא יעבירו אליו את המיקוד. נכנס לתוקף לאחר הפעלה מחדש של Handy."
       },
       "autostart": {
         "label": "הפעל עם עליית המערכת",

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -275,8 +275,8 @@
         "description": "Avvia l'applicazione in background senza aprire la finestra."
       },
       "menuBarMode": {
-        "label": "Keep in Menu Bar",
-        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+        "label": "Mantieni nella barra dei menu",
+        "description": "Mantiene Handy nella barra dei menu e fuori dal Dock e dal selettore applicazioni, così le scorciatoie globali non spostano il focus su Handy. Ha effetto dopo il riavvio di Handy."
       },
       "autostart": {
         "label": "Avvia all'Accensione",

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -274,6 +274,10 @@
         "label": "Avvia in Background",
         "description": "Avvia l'applicazione in background senza aprire la finestra."
       },
+      "menuBarMode": {
+        "label": "Keep in Menu Bar",
+        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+      },
       "autostart": {
         "label": "Avvia all'Accensione",
         "description": "Avvia Handy automaticamente quando accedi al computer."

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -274,6 +274,10 @@
         "label": "非表示で起動",
         "description": "ウィンドウを開かずにシステムトレイに起動。"
       },
+      "menuBarMode": {
+        "label": "Keep in Menu Bar",
+        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+      },
       "autostart": {
         "label": "起動時に実行",
         "description": "コンピューターにログインしたときにHandyを自動的に起動。"

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -275,8 +275,8 @@
         "description": "ウィンドウを開かずにシステムトレイに起動。"
       },
       "menuBarMode": {
-        "label": "Keep in Menu Bar",
-        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+        "label": "メニューバーに常駐",
+        "description": "Handyをメニューバーに表示し、Dockとアプリ切り替えから外して、グローバルショートカットでフォーカスがHandyに戻らないようにします。Handyの再起動後に有効になります。"
       },
       "autostart": {
         "label": "起動時に実行",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -275,8 +275,8 @@
         "description": "창을 열지 않고 시스템 트레이에서 실행합니다."
       },
       "menuBarMode": {
-        "label": "Keep in Menu Bar",
-        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+        "label": "메뉴 막대에 유지",
+        "description": "Handy를 메뉴 막대에 유지하고 Dock과 앱 전환기에서 제외하여 전역 단축키가 포커스를 가져오지 않게 합니다. Handy를 다시 시작한 후 적용됩니다."
       },
       "autostart": {
         "label": "시작 시 실행",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -274,6 +274,10 @@
         "label": "숨김으로 시작",
         "description": "창을 열지 않고 시스템 트레이에서 실행합니다."
       },
+      "menuBarMode": {
+        "label": "Keep in Menu Bar",
+        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+      },
       "autostart": {
         "label": "시작 시 실행",
         "description": "컴퓨터 로그인 시 Handy를 자동으로 시작합니다."

--- a/src/i18n/locales/pl/translation.json
+++ b/src/i18n/locales/pl/translation.json
@@ -275,8 +275,8 @@
         "description": "Uruchom w zasobniku systemowym bez otwierania okna."
       },
       "menuBarMode": {
-        "label": "Keep in Menu Bar",
-        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+        "label": "Pozostaw w pasku menu",
+        "description": "Pozostawia Handy na pasku menu, poza Dockiem i przełącznikiem aplikacji, aby globalne skróty nie przenosiły fokusu na Handy. Zacznie działać po ponownym uruchomieniu Handy."
       },
       "autostart": {
         "label": "Uruchamiaj przy starcie",

--- a/src/i18n/locales/pl/translation.json
+++ b/src/i18n/locales/pl/translation.json
@@ -274,6 +274,10 @@
         "label": "Uruchom ukryty",
         "description": "Uruchom w zasobniku systemowym bez otwierania okna."
       },
+      "menuBarMode": {
+        "label": "Keep in Menu Bar",
+        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+      },
       "autostart": {
         "label": "Uruchamiaj przy starcie",
         "description": "Automatycznie uruchamiaj Handy po zalogowaniu."

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -275,8 +275,8 @@
         "description": "Iniciar na bandeja do sistema sem abrir a janela."
       },
       "menuBarMode": {
-        "label": "Keep in Menu Bar",
-        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+        "label": "Manter na Barra de Menus",
+        "description": "Mantém o Handy na barra de menus e fora do Dock e do alternador de apps para que atalhos globais não roubem o foco. Entra em vigor depois que o Handy for reiniciado."
       },
       "autostart": {
         "label": "Iniciar na Inicialização",

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -274,6 +274,10 @@
         "label": "Iniciar Oculto",
         "description": "Iniciar na bandeja do sistema sem abrir a janela."
       },
+      "menuBarMode": {
+        "label": "Keep in Menu Bar",
+        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+      },
       "autostart": {
         "label": "Iniciar na Inicialização",
         "description": "Iniciar automaticamente o Handy quando você fizer login no seu computador."

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -275,8 +275,8 @@
         "description": "Запускать в системный трей, не открывая окно."
       },
       "menuBarMode": {
-        "label": "Keep in Menu Bar",
-        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+        "label": "Оставить в строке меню",
+        "description": "Оставляет Handy в строке меню и убирает из Dock и переключателя приложений, чтобы глобальные сочетания клавиш не переводили фокус на Handy. Вступает в силу после перезапуска Handy."
       },
       "autostart": {
         "label": "Запускать при старте",

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -274,6 +274,10 @@
         "label": "Скрыть при запуске",
         "description": "Запускать в системный трей, не открывая окно."
       },
+      "menuBarMode": {
+        "label": "Keep in Menu Bar",
+        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+      },
       "autostart": {
         "label": "Запускать при старте",
         "description": "Автоматически запускать Handy при входе в систему."

--- a/src/i18n/locales/sv/translation.json
+++ b/src/i18n/locales/sv/translation.json
@@ -274,6 +274,10 @@
         "label": "Starta dold",
         "description": "Starta i systemfältet utan att öppna fönstret."
       },
+      "menuBarMode": {
+        "label": "Keep in Menu Bar",
+        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+      },
       "autostart": {
         "label": "Starta vid uppstart",
         "description": "Starta Handy automatiskt när du loggar in på din dator."

--- a/src/i18n/locales/sv/translation.json
+++ b/src/i18n/locales/sv/translation.json
@@ -275,8 +275,8 @@
         "description": "Starta i systemfältet utan att öppna fönstret."
       },
       "menuBarMode": {
-        "label": "Keep in Menu Bar",
-        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+        "label": "Behåll i menyraden",
+        "description": "Behåller Handy i menyraden och utanför Dock och appväxlaren så att globala genvägar inte flyttar fokus till Handy. Börjar gälla efter att Handy har startats om."
       },
       "autostart": {
         "label": "Starta vid uppstart",

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -274,6 +274,10 @@
         "label": "Gizli Başlat",
         "description": "Pencereyi açmadan sistem tepsisinde başlatır."
       },
+      "menuBarMode": {
+        "label": "Keep in Menu Bar",
+        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+      },
       "autostart": {
         "label": "Başlangıçta Çalıştır",
         "description": "Bilgisayara giriş yaptığınızda Handy otomatik olarak başlatılır."

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -275,8 +275,8 @@
         "description": "Pencereyi açmadan sistem tepsisinde başlatır."
       },
       "menuBarMode": {
-        "label": "Keep in Menu Bar",
-        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+        "label": "Menü Çubuğunda Tut",
+        "description": "Handy'yi menü çubuğunda tutar; Dock ve uygulama değiştiricinin dışında bırakarak global kısayolların odağı Handy'ye çekmesini önler. Handy yeniden başlatıldıktan sonra etkili olur."
       },
       "autostart": {
         "label": "Başlangıçta Çalıştır",

--- a/src/i18n/locales/uk/translation.json
+++ b/src/i18n/locales/uk/translation.json
@@ -274,6 +274,10 @@
         "label": "Запуск у фоні",
         "description": "Запускати в системному треї без відкриття вікна"
       },
+      "menuBarMode": {
+        "label": "Keep in Menu Bar",
+        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+      },
       "autostart": {
         "label": "Запуск при старті системи",
         "description": "Автоматично запускати Handy при вході в систему"

--- a/src/i18n/locales/uk/translation.json
+++ b/src/i18n/locales/uk/translation.json
@@ -275,8 +275,8 @@
         "description": "Запускати в системному треї без відкриття вікна"
       },
       "menuBarMode": {
-        "label": "Keep in Menu Bar",
-        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+        "label": "Залишати в рядку меню",
+        "description": "Залишає Handy в рядку меню та поза Dock і перемикачем додатків, щоб глобальні комбінації клавіш не переводили фокус на Handy. Набуде чинності після перезапуску Handy."
       },
       "autostart": {
         "label": "Запуск при старті системи",

--- a/src/i18n/locales/vi/translation.json
+++ b/src/i18n/locales/vi/translation.json
@@ -275,8 +275,8 @@
         "description": "Khởi động vào khay hệ thống mà không mở cửa sổ."
       },
       "menuBarMode": {
-        "label": "Keep in Menu Bar",
-        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+        "label": "Giữ trong thanh menu",
+        "description": "Giữ Handy trong thanh menu và ngoài Dock cũng như trình chuyển đổi ứng dụng để phím tắt toàn cục không kéo tiêu điểm về Handy. Có hiệu lực sau khi khởi động lại Handy."
       },
       "autostart": {
         "label": "Khởi động cùng hệ thống",

--- a/src/i18n/locales/vi/translation.json
+++ b/src/i18n/locales/vi/translation.json
@@ -274,6 +274,10 @@
         "label": "Khởi động ẩn",
         "description": "Khởi động vào khay hệ thống mà không mở cửa sổ."
       },
+      "menuBarMode": {
+        "label": "Keep in Menu Bar",
+        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+      },
       "autostart": {
         "label": "Khởi động cùng hệ thống",
         "description": "Tự động khởi động Handy khi bạn đăng nhập vào máy tính."

--- a/src/i18n/locales/zh-TW/translation.json
+++ b/src/i18n/locales/zh-TW/translation.json
@@ -274,6 +274,10 @@
         "label": "隱藏啟動",
         "description": "啟動至系統匣而不開啟視窗"
       },
+      "menuBarMode": {
+        "label": "Keep in Menu Bar",
+        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+      },
       "autostart": {
         "label": "開機啟動",
         "description": "登入電腦時自動啟動 Handy"

--- a/src/i18n/locales/zh-TW/translation.json
+++ b/src/i18n/locales/zh-TW/translation.json
@@ -275,8 +275,8 @@
         "description": "啟動至系統匣而不開啟視窗"
       },
       "menuBarMode": {
-        "label": "Keep in Menu Bar",
-        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+        "label": "保留在選單列",
+        "description": "將 Handy 保留在選單列，並從 Dock 和 App 切換器中隱藏，避免全域快捷鍵將焦點拉回 Handy。重新啟動 Handy 後生效。"
       },
       "autostart": {
         "label": "開機啟動",

--- a/src/i18n/locales/zh/translation.json
+++ b/src/i18n/locales/zh/translation.json
@@ -274,6 +274,10 @@
         "label": "隐藏启动",
         "description": "启动到系统托盘而不打开窗口。"
       },
+      "menuBarMode": {
+        "label": "Keep in Menu Bar",
+        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+      },
       "autostart": {
         "label": "开机启动",
         "description": "登录计算机时自动启动 Handy。"

--- a/src/i18n/locales/zh/translation.json
+++ b/src/i18n/locales/zh/translation.json
@@ -275,8 +275,8 @@
         "description": "启动到系统托盘而不打开窗口。"
       },
       "menuBarMode": {
-        "label": "Keep in Menu Bar",
-        "description": "Keep Handy in the menu bar and out of the Dock and app switcher so global shortcuts do not pull focus. Takes effect after Handy restarts."
+        "label": "保留在菜单栏",
+        "description": "将 Handy 保留在菜单栏，并从 Dock 和应用切换器中隐藏，避免全局快捷键将焦点拉回 Handy。重启 Handy 后生效。"
       },
       "autostart": {
         "label": "开机启动",

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -84,6 +84,7 @@ const settingUpdaters: {
     commands.changeAudioFeedbackVolumeSetting(value as number),
   sound_theme: (value) => commands.changeSoundThemeSetting(value as string),
   start_hidden: (value) => commands.changeStartHiddenSetting(value as boolean),
+  menu_bar_mode: (value) => commands.changeMenuBarModeSetting(value as boolean),
   autostart_enabled: (value) =>
     commands.changeAutostartSetting(value as boolean),
   update_checks_enabled: (value) =>


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Human Written Description

Handy currently does not work cleanly with one of/the most popular MacOS windowing manager systems, AeroSpace.

When triggering dictation, "focus" switches to the Handy app, and whatever workspace it was first launched in becomes focused.
The current behavior/bug makes it impoosible to use Handy alongside Aerospace.

This PR adds an option to run Handy in macOS menu bar mode, which fixes the observed behavior.

(This brings Handy up to parity with WhisperFlow, which already implements this behavior and works alongside AeroSpace and other window managers)

## Related Issues/Discussions

Related but not duplicate:
- #105 added Start Hidden, but does not provide a dedicated macOS menu bar mode for window-manager workflows.
- #903 fixed an unreachable macOS state involving Start Hidden and Show Tray Icon, but does not address AeroSpace focus/workspace disruption.
- #361 fixed macOS overlay visibility across fullscreen apps and Spaces, which is separate from Dock/app-switcher activation behavior.
- #87, #147, and #792 cover Linux window-manager/CLI/paste workflows, not macOS AeroSpace.

## Community Feedback

N/A. This is a bug fix for macOS window-manager compatibility rather than a new feature.

## Testing

- Tested thoroughly with and without this new option
- Reliably reproduced the issue before this fix
- Reliably works after this fix

Note: `bun run format:check` currently fails on existing `AGENTS.md` formatting.

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex, GPT-5.5 xhigh
- How extensively: I asked Codex to implement a first PoC, to check if it was possible to keep using Handy. After that, I went through the changes by hand and rewrote them to read well and conform to the repo style and conventions.
- I asked Codex to create best-effort translations of the new copy. The translation pass was specifically instructed to conform to the current translation styles, terminology, capitalization, and punctuation patterns in each locale file.
