### PR TITLE
docs: add gaze detection and transcription cleanup research specs

### DIFF
--- a/docs/projects/gaze-detection.md
+++ b/docs/projects/gaze-detection.md
@@ -1,0 +1,501 @@
+# Gaze Detection & Eye Tracking for Handy
+
+## Overview
+
+Add eye-tracking capabilities to Handy so users can control the mouse cursor, switch windows across multiple monitors, and trigger transcription — all through gaze. This extends Handy's existing voice-first model with a second input modality (eyes), enabling powerful voice + gaze fusion commands.
+
+**Primary use case:** Navigate between multiple monitors and windows quickly with eye gaze, without touching the keyboard or mouse.
+
+---
+
+## Architecture
+
+Eye tracking adds two new capabilities to Handy:
+1. **Gaze-triggered transcription** — start/stop transcription by looking at a virtual trigger zone (alternative to keyboard shortcuts)
+2. **Gaze-driven cursor + window switching** — move cursor and switch windows with eye gaze
+
+Both share the same underlying gaze detection pipeline.
+
+### Module Structure
+
+New Rust module in `src-tauri/src/eyetracking/`:
+
+```
+src-tauri/src/eyetracking/
+├── mod.rs              # EyeTrackingManager, public API
+├── gaze.rs             # GazePoint struct, calibration data
+├── providers/
+│   ├── mod.rs          # EyeTrackingProvider trait
+│   ├── webcam.rs       # GazeTracking (Python subprocess) provider
+│   └── pupil.rs        # Pupil Labs API provider (future)
+└── calibration.rs      # Calibration state & routines
+```
+
+### Provider Trait
+
+Follows the established manager/provider pattern used throughout the codebase (AudioManager, ModelManager, etc.):
+
+```rust
+pub trait EyeTrackingProvider: Send + Sync {
+    fn init(&mut self) -> Result<()>;
+    fn start(&mut self) -> Result<()>;
+    fn stop(&mut self);
+    fn poll_gaze(&self) -> Option<GazePoint>;  // Returns screen (x, y) + confidence
+    fn calibrate(&mut self, points: Vec<CalibrationPoint>) -> Result<()>;
+}
+```
+
+### GazePoint Struct
+
+```rust
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct GazePoint {
+    pub x: f64,              // Normalized 0.0-1.0 or screen pixel coords
+    pub y: f64,
+    pub confidence: f32,     // 0.0-1.0 from the provider
+    pub timestamp: u64,      // Millisecond timestamp
+    pub screen_id: Option<u32>, // Which monitor the gaze landed on
+}
+```
+
+---
+
+## Phase 1: Gaze Detection Backend
+
+### Webcam Provider (MVP)
+
+Launch a Python subprocess using the `GazeTracking` library ([Nicmcd-GazeTracking, 2.6k stars](https://github.com/StephanL/Nicmcd-GazeTracking)), communicating via stdin/stdout JSON.
+
+**Why a subprocess?** Avoids adding Rust OpenCV/DLib dependencies. The Python library is mature, webcam-only, and requires no special hardware.
+
+**Python subprocess script** (bundled in `src-tauri/bin/gaze_server.py`):
+
+```python
+#!/usr/bin/env python3
+"""Gaze tracking server - communicates with Handy via JSON over stdin/stdout."""
+import json
+import sys
+from gaze_tracking import GazeTracking
+
+gaze = GazeTracking()
+gaze.calibration_profile_id = "handy_user"  # Persist calibration
+
+while True:
+    command = sys.stdin.readline().strip()
+    if command == "start":
+        gaze.start()
+        print(json.dumps({"status": "started"}))
+    elif command == "stop":
+        gaze.stop()
+        print(json.dumps({"status": "stopped"}))
+    elif command == "poll":
+        frame, gaze_points = gaze.update()
+        if gaze_points:
+            gp = gaze_points[0]  # Left eye
+            print(json.dumps({
+                "x": gp.gaze_x,
+                "y": gp.gaze_y,
+                "confidence": 1.0,  # GazeTracking doesn't expose confidence
+            }))
+        else:
+            print(json.dumps({"x": None, "y": None}))
+    elif command == "calibrate":
+        # Handle calibration points
+        pass
+    sys.stdout.flush()
+```
+
+**Rust subprocess management** in `webcam.rs`:
+- Spawn Python process on `start()`
+- Send `"poll"` commands each frame (e.g., 30Hz loop)
+- Parse JSON responses into `GazePoint`
+- Kill process on `stop()` or shutdown
+- Auto-install `gaze-tracking` pip package on first run if missing
+
+### Alternative: Pupil Labs Provider (Future)
+
+For higher accuracy, integrate with [Pupil Labs](https://github.com/PupilLabs/pupil) hardware (USB camera glasses). Their API exposes gaze data over a network socket. Same provider trait, different implementation.
+
+---
+
+## Phase 2: Settings & Configuration
+
+### New Settings in `AppSettings`
+
+Extend the existing settings system in `src-tauri/src/settings.rs` (follows the pattern of adding fields to `AppSettings`, implementing `#[tauri::command]` getters/setters, and registering commands in `lib.rs`):
+
+```rust
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct EyeTrackingSettings {
+    pub enabled: bool,
+    pub provider: String,              // "webcam" | "pupil"
+    pub sensitivity: f32,              // Gaze-to-cursor scaling (0.5 - 2.0), default 1.0
+    pub dwell_time_ms: u32,           // Time to hold gaze for "click" (500-2000ms), default 1000
+    pub trigger_zone: TriggerZone,    // Where gaze triggers transcription
+    pub calibration_points: u32,      // 5 or 9 point calibration
+    pub smoothing_enabled: bool,      // Temporal gaze smoothing, default true
+    pub smoothing_window: u32,        // Number of frames to average, default 5
+    pub window_switch_mode: bool,     // Enable gaze window switching, default false
+    pub cursor_visibility: String,    // "hide" | "show" | "gaze_only", default "show"
+    pub blink_to_click: bool,         // Use blink detection as click trigger, default false
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct TriggerZone {
+    pub x: f64,    // Normalized 0.0-1.0
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}
+```
+
+### Commands to Add
+
+Follow existing pattern — each setting gets a getter and setter:
+
+```rust
+#[tauri::command]
+async fn get_eye_tracking_settings(state: State<AppState>) -> Result<EyeTrackingSettings, String> {
+    let settings = state.settings.lock().await;
+    Ok(settings.eye_tracking.clone())
+}
+
+#[tauri::command]
+async fn set_eye_tracking_enabled(state: State<AppState>, enabled: bool) -> Result<(), String> {
+    let mut settings = state.settings.lock().await;
+    settings.eye_tracking.enabled = enabled;
+    settings.save().await?;
+
+    // Start/stop the eye tracking manager
+    let manager = state.eye_tracking.lock().await;
+    if enabled {
+        manager.start()?;
+    } else {
+        manager.stop()?;
+    }
+    Ok(())
+}
+
+// ... repeat for each setting field
+```
+
+Register all commands in `src-tauri/src/lib.rs` setup function.
+
+---
+
+## Phase 3: Gaze-to-Cursor + Dwell Click
+
+### Extend Input Module
+
+`src-tauri/src/input.rs` already has cursor control via Enigo. Add:
+
+```rust
+// Add to existing input.rs pub fn list:
+pub fn move_cursor(x: i32, y: i32) -> Result<(), String> {
+    let mut enigo = Enigo::new(&Direction::Inherit)?;
+    enigo.mouse_move_to(Absolute::from(x, y))?;
+    Ok(())
+}
+
+pub fn click_mouse() -> Result<(), String> {
+    let mut enigo = Enigo::new(&Direction::Inherit)?;
+    enigo.mouse_click(Button::Left)?;
+    Ok(())
+}
+
+pub fn mouse_down() -> Result<(), String> {
+    let mut enigo = Enigo::new(&Direction::Inherit)?;
+    enigo.mouse_button_click(Button::Left, 1)?;
+    Ok(())
+}
+```
+
+### Gaze Processing Loop
+
+In `EyeTrackingManager`, run a background task (Tokio task, similar to how `TranscriptionCoordinator` works):
+
+1. Poll gaze coordinates from provider at ~30Hz
+2. Apply calibration offset + smoothing (exponential moving average)
+3. Map normalized gaze (0-1) to screen pixel coordinates
+4. Handle multi-monitor: determine which display the gaze maps to, convert to that display's coordinate space
+5. Move virtual cursor via `move_cursor()`
+6. Track dwell time — if gaze stays within a threshold radius (e.g., 20px) for `dwell_time_ms`, trigger `click_mouse()`
+
+### Smoothing
+
+Simple exponential moving average to reduce jitter:
+
+```rust
+fn smooth_gaze(&mut self, new: GazePoint) -> GazePoint {
+    let alpha = 0.3; // Smoothing factor
+    GazePoint {
+        x: self.smoothed_x * alpha + new.x * (1.0 - alpha),
+        y: self.smoothed_y * alpha + new.y * (1.0 - alpha),
+        ..new
+    }
+}
+```
+
+### Midas Touch Prevention
+
+The "Midas Touch Problem" — you don't want to click everything you look at. Multiple strategies:
+
+| Strategy | How It Works | Config |
+|----------|-------------|--------|
+| **Dwell time** | Must hold gaze on a point for X ms before clicking | `dwell_time_ms` (default 1000ms) |
+| **Blink to click** | Use blink detection as explicit click trigger | `blink_to_click` toggle |
+| **Voice confirm** | Look + say "click" to confirm | Uses existing Handy voice pipeline |
+| **Click mode** | Toggle a "click enabled" state via voice/keyboard | Future enhancement |
+
+---
+
+## Phase 4: Multi-Monitor + Window Switching
+
+### New Window Module
+
+`src-tauri/src/window.rs`:
+
+```rust
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct WindowInfo {
+    pub id: u32,
+    pub title: String,
+    pub app_name: String,
+    pub bounds: Rect,  // x, y, width, height
+    pub screen_id: u32,
+    pub is_active: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct MonitorFrame {
+    pub id: u32,
+    pub x: i32,
+    pub y: i32,
+    pub width: u32,
+    pub height: u32,
+    pub is_primary: bool,
+}
+
+pub fn get_window_at_point(x: i32, y: i32) -> Option<WindowInfo>;
+pub fn focus_window(window_id: u32) -> Result<(), String>;
+pub fn get_all_windows() -> Vec<WindowInfo>;
+pub fn get_monitors() -> Vec<MonitorFrame>;
+```
+
+### Platform-Specific Implementation
+
+- **macOS:** Use `core-graphics` crate for `CGDisplay` APIs (monitor frames), `AppKit`/`pyobjc` bridge or `cocoa` crate for `CGWindowListCopyWindowInfo` and window focus
+- **Windows:** `EnumWindows` + `GetWindowRect` + `SetForegroundWindow` via `windows` crate
+- **Linux:** `xdotool` subprocess or `wl-clipboard`/Wayland protocols
+
+### Window Switching Modes
+
+| Mode | Behavior | Config |
+|------|----------|--------|
+| **Auto-focus** | Cursor moves to window, auto-focuses on entry | May be too aggressive |
+| **Dwell-to-focus** | Gaze on window for X seconds switches focus | `dwell_time_ms` |
+| **Gaze + voice** | Look at window, say "switch" or "focus" | Best UX, leverages Handy voice |
+
+---
+
+## Phase 5: Gaze-Triggered Transcription
+
+### Integration with TranscriptionCoordinator
+
+The existing `TranscriptionCoordinator` in `src-tauri/src/transcription/coordinator.rs` already handles input from keyboard, voice, and clipboard. Add a new input source:
+
+```rust
+// Extend InputSource enum
+#[derive(Debug, Clone, PartialEq)]
+pub enum InputSource {
+    Voice,
+    Keyboard,
+    Clipboard,
+    EyeTracking,  // NEW
+}
+
+// New method on TranscriptionCoordinator
+impl TranscriptionCoordinator {
+    pub fn on_gaze_in_trigger_zone(&self, in_zone: bool) {
+        if in_zone && self.settings.eye_tracking.enabled {
+            self.send_input("transcribe", InputSource::EyeTracking, true, false);
+        }
+    }
+}
+```
+
+### Trigger Zones
+
+Define screen regions where gazing starts/stops transcription. Configurable via `TriggerZone` struct in settings. Multiple zones supported (e.g., top-center of primary monitor, floating overlay button).
+
+---
+
+## Phase 6: Frontend UI
+
+### New Settings Components
+
+In `src/components/settings/`:
+
+- **`EyeTrackingSettings.tsx`** — Main settings panel:
+  - Enable/disable toggle
+  - Provider selection (webcam / pupil)
+  - Sensitivity slider (0.5x - 2.0x)
+  - Dwell time slider (500ms - 2000ms)
+  - Smoothing toggle
+  - Window switch mode toggle
+  - Cursor visibility dropdown
+  - Blink-to-click toggle
+
+- **`CalibrationWizard.tsx`** — Step-by-step calibration:
+  - 5-point or 9-point calibration grid
+  - Animated dot moves to each point, user looks at it
+  - Samples gaze position at each point
+  - Computes calibration offset
+  - Saves to persistent storage
+
+- **`TriggerZoneEditor.tsx`** — Visual editor:
+  - Drag-to-resize rectangle on a screen map
+  - Preview trigger zone boundaries
+  - Add/remove multiple zones
+
+### Overlay Enhancements
+
+In `src/overlay/`:
+
+- **Gaze indicator** — Small semi-transparent circle following eye gaze position
+- **Dwell progress ring** — Circular progress indicator that fills as you hold gaze on a point (visual feedback for dwell-to-click)
+- **Trigger zone boundaries** — Show dotted rectangles around active trigger zones
+- **Status indicator** — Small icon in overlay showing eye tracking active/inactive/calibrating
+
+### Tauri Events
+
+Frontend subscribes to gaze events via Tauri's event system:
+
+```typescript
+// In the overlay or a gaze indicator component
+import { listen } from '@tauri-apps/api/event';
+
+listen<'eyetracking|gaze-update'>('eyetracking|gaze-update', (event) => {
+  const { x, y, confidence } = event.payload;
+  setGazePosition({ x, y });
+  setConfidence(confidence);
+});
+
+listen<'eyetracking|dwell-progress'>('eyetracking|dwell-progress', (event) => {
+  const { progress } = event.payload; // 0.0 - 1.0
+  setDwellProgress(progress);
+});
+```
+
+Rust side emits events from the gaze processing loop:
+
+```rust
+// In EyeTrackingManager gaze loop
+app.emit_all("eyetracking|gaze-update", &gaze_point)?;
+app.emit_all("eyetracking|dwell-progress", &dwell_progress)?;
+```
+
+---
+
+## Phase 7: Voice + Gaze Fusion Commands (Handy-Specific)
+
+Since Handy already handles voice, the killer differentiator is **gaze + voice fusion**:
+
+| Gaze Action | Voice Command | Result |
+|-------------|---------------|--------|
+| Look at window | "switch" / "focus" | Switch to that window |
+| Look at text field | "type" / "transcribe" | Start transcription targeting that field |
+| Look at button | "click" | Click the element |
+| Look at URL bar | "go to ..." | Navigate to URL |
+| Look at app dock icon | "open" | Launch the app |
+| Look at trigger zone | (nothing) | Start/stop transcription |
+
+### Implementation
+
+Extend the existing command system in `src-tauri/src/commands/`:
+
+```rust
+// In the command execution pipeline, when a voice command is ambiguous,
+// resolve it using current gaze position:
+
+pub fn resolve_command_with_gaze(command: &str, gaze: &GazePoint) -> ExecutedCommand {
+    let window_under_gaze = get_window_at_point(gaze.screen_x, gaze.screen_y);
+
+    match command {
+        "switch" | "focus" => {
+            if let Some(window) = window_under_gaze {
+                focus_window(window.id);
+            }
+        }
+        "click" => {
+            click_mouse(); // Cursor is already at gaze position
+        }
+        "transcribe" | "type" => {
+            // Focus window under gaze, then start transcription
+            if let Some(window) = window_under_gaze {
+                focus_window(window.id);
+            }
+            transcription_coordinator.start();
+        }
+        _ => {} // Fall through to existing command handling
+    }
+}
+```
+
+This requires the gaze position to be available when voice commands are processed. Store the latest gaze point in `AppState` and reference it during command resolution.
+
+---
+
+## Implementation Order
+
+| Phase | What | Depends On | Est. Effort |
+|-------|------|------------|-------------|
+| 1 | Gaze detection backend (webcam provider) | — | Medium |
+| 2 | Settings & configuration | 1 | Small |
+| 3 | Gaze-to-cursor + dwell click | 1, 2 | Medium |
+| 4 | Multi-monitor + window switching | 3 | Medium |
+| 5 | Gaze-triggered transcription | 3, existing transcription | Small |
+| 6 | Frontend UI (settings + overlay) | 2, 3 | Medium |
+| 7 | Voice + gaze fusion commands | 4, 5, existing voice | Medium |
+
+## Key Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| **Webcam gaze accuracy** (~20-40px error) | Cursor feels imprecise | Smoothing + calibration + large click targets + sensitivity tuning |
+| **Midas touch problem** | Accidental clicks on everything | Dwell time (default 1s), blink-to-click, voice confirmation |
+| **Multi-monitor calibration drift** | Gaze jumps between screens | Per-monitor calibration zones, separate calibration offsets |
+| **CPU load from gaze processing** | Drops transcription quality | Run gaze detection in separate Python process, Rust side is lightweight |
+| **Privacy concerns** (webcam always on) | User trust | Visual indicator in overlay, easy toggle off, no video stored |
+| **Lighting conditions** | Gaze tracking degrades in poor light | Document requirements, fallback to keyboard/mouse |
+
+## Dependencies to Add
+
+### Rust (Cargo.toml)
+- No new heavy dependencies — subprocess management uses existing `std::process`
+- `core-graphics` (macOS monitor/window APIs) — may already be available via Tauri deps
+- `cocoa` or `objc2` for macOS window management
+
+### Python (bundled script requirements)
+- `gaze-tracking` — webcam-based eye tracking
+- `opencv-python-headless` — required by gaze-tracking
+- `dlib` — required by gaze-tracking (may need system-level installation)
+
+### Frontend
+- No new npm packages needed — use existing Tailwind + shadcn/ui + Tauri event system
+
+## Open Questions
+
+1. **Calibration persistence** — Should calibration profiles be per-user and persisted across sessions? (Recommended: yes, use `gaze_tracking`'s built-in profile system)
+2. **Blink detection** — Does `GazeTracking` expose blink data? If not, may need a different library for blink-to-click feature
+3. **Virtual cursor vs. real cursor** — Should we hide the real OS cursor and show a custom gaze cursor in the overlay? Or move the real cursor?
+4. **Gaze smoothing algorithm** — Exponential moving average is simple but may lag. Consider Kalman filter for better tracking
+5. **Multi-user calibration** — Should multiple users have separate calibration profiles?
+6. **Fallback behavior** — What happens when gaze tracking loses the face? Pause cursor movement? Return to last known position?
+
+## References
+
+- [Nicmcd-GazeTracking](https://github.com/StephanL/Nicmcd-GazeTracking) — Python webcam eye tracking library (2.6k ⭐)
+- [OptiKey](https://github.com/OptiKey/OptiKey) — Full eye-controlled computer access (4.4k ⭐) — inspiration for dwell-click and trigger zones
+- [Pupil Labs](https://github.com/PupilLabs/pupil) — Research-grade eye tracking (1.7k ⭐) — future hardware provider
+- [Talon Voice + talon-gaze-ocr](https://github.com/wolfmanstout/talon-gaze-ocr) — Voice + gaze fusion inspiration

--- a/docs/projects/transcription-cleanup.md
+++ b/docs/projects/transcription-cleanup.md
@@ -1,0 +1,398 @@
+# Transcription Cleanup — LLM Post-Processing with Audit Trail
+
+## Problem
+
+STT models (Whisper, Parakeet, etc.) produce raw transcription that often contains:
+- Minor grammar issues, awkward phrasing
+- Missing punctuation or capitalization
+- Homophone errors ("their/there", "its/it's")
+- Inconsistent formatting
+
+The existing `post_process` feature in Handy solves this, but has gaps:
+1. **It's opt-in per transcription** — two shortcut bindings (`transcribe` vs `transcribe_with_post_process`). Users forget which to trigger.
+2. **Original text is lost** — `transcription_history` stores the raw STT output in `transcription_text`, but after post-processing the cleaned text overwrites `final_text` that gets pasted. The raw text IS preserved in the DB, but there's no separate "always-on" cleanup path.
+3. **No lightweight cleanup mode** — existing post-processing uses user-defined prompts that can do arbitrary transformations. What we want is a simple "fix grammar and punctuation, keep meaning intact" pass that's always on.
+4. **Audit trail incomplete** — history stores `transcription_text` (raw) and `post_processed_text` (cleaned), but only when post-processing was explicitly triggered. No log of the LLM prompt used for lightweight cleanup.
+
+## Goal
+
+Add an **always-on, lightweight LLM cleanup step** that runs after STT transcription, with:
+- Configurable OpenAI-compatible endpoint and model
+- Original → cleaned audit trail in history DB
+- Independent toggle from existing post-processing
+- Fast, cheap model (small model, simple prompt)
+
+## Design
+
+### Where It Fits in the Pipeline
+
+```
+Audio → VAD → STT Model → Raw Text → [Cleanup LLM] → Clean Text → Paste
+                                                    ↓
+                                            History DB (original + cleaned)
+```
+
+The cleanup step sits **after** STT but **before** the existing post-processing step. This gives three layers:
+
+| Layer | When | Purpose | Config |
+|-------|------|---------|--------|
+| **Cleanup** (NEW) | Always on (or per-transcription) | Light grammar/punctuation fix | Endpoint, model, system prompt |
+| **Post-processing** (existing) | Opt-in via shortcut or toggle | Arbitrary LLM transformation | User-defined prompts |
+| **Chinese variant** (existing) | When language is zh-Hans/zh-Hant | Traditional ↔ Simplified conversion | Language setting |
+
+### New Settings
+
+Add to `AppSettings` in `src-tauri/src/settings.rs`:
+
+```rust
+pub struct AppSettings {
+    // ... existing fields ...
+
+    // --- NEW: Transcription cleanup ---
+    pub cleanup_enabled: bool,                  // Default: false (opt-in until verified)
+    pub cleanup_provider_id: String,            // Reuses PostProcessProvider system
+    pub cleanup_api_key: String,               // Per-provider, reuses existing key store
+    pub cleanup_model: String,                 // e.g. "gpt-4o-mini", "llama-3.1-8b"
+    pub cleanup_prompt_id: Option<String>,     // Selected cleanup prompt
+    pub cleanup_prompts: Vec<LLMCleanupPrompt>, // Pre-defined + custom cleanup prompts
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LLMCleanupPrompt {
+    pub id: String,
+    pub name: String,        // Display name: "Light cleanup", "Heavy grammar fix", etc.
+    pub system_prompt: String, // System message sent to LLM
+    pub built_in: bool,      // Can't delete built-in prompts
+}
+```
+
+**Built-in cleanup prompts** (shipped with Handy):
+
+| ID | Name | System Prompt |
+|----|------|---------------|
+| `light` | Light cleanup | "Fix minor grammar, punctuation, and capitalization errors. Preserve the original meaning, tone, and wording as much as possible. Do not rewrite or rephrase — only fix clear errors." |
+| `medium` | Moderate cleanup | "Fix grammar, punctuation, capitalization, and awkward phrasing. Improve readability while preserving the original meaning and tone. Keep technical terms and proper nouns intact." |
+| `heavy` | Full rewrite | "Rewrite this transcription for clarity and correctness. Fix all grammar, punctuation, and phrasing issues. Preserve the original meaning but improve the overall quality." |
+
+### Reusing Existing Infrastructure
+
+The cleanup step **reuses** the existing post-processing infrastructure:
+
+| Component | How It's Reused |
+|-----------|----------------|
+| `PostProcessProvider` | Same provider list (OpenAI, OpenRouter, Custom, etc.). Cleanup uses its own `provider_id` field but same provider configs |
+| `post_process_api_keys` | Same `SecretMap` — cleanup reads from the same key store |
+| `llm_client.rs` | Same `send_chat_completion()` and `send_chat_completion_with_schema()` functions |
+| Settings commands | Same pattern: `#[tauri::command]` getters/setters in `shortcut/mod.rs` |
+| Frontend settings | Same settings store pattern, new UI section |
+
+### History Database Changes
+
+Add two new columns to `transcription_history` via `rusqlite_migration`:
+
+```sql
+ALTER TABLE transcription_history ADD COLUMN cleanup_original_text TEXT;
+-- Stores the raw STT output BEFORE cleanup (for audit)
+
+ALTER TABLE transcription_history ADD COLUMN cleanup_prompt_used TEXT;
+-- Stores the system prompt that was applied (for audit/reproducibility)
+```
+
+**When cleanup is enabled:**
+- `transcription_text` = raw STT output (unchanged)
+- `cleanup_original_text` = same as `transcription_text` (redundant but explicit for audit)
+- `post_processed_text` = cleanup output (when cleanup runs without post-processing)
+- `cleanup_prompt_used` = the system prompt text that was sent to the LLM
+
+**When both cleanup AND post-processing run:**
+- `transcription_text` = raw STT output
+- `cleanup_original_text` = raw STT output
+- `post_processed_text` = final post-processed output (after cleanup + post-process)
+- `cleanup_prompt_used` = cleanup system prompt
+- `post_process_prompt` = post-processing prompt
+
+Actually, simpler approach: **add a dedicated cleanup output column** to avoid ambiguity with existing `post_processed_text`:
+
+```sql
+ALTER TABLE transcription_history ADD COLUMN cleanup_text TEXT;
+ALTER TABLE transcription_history ADD COLUMN cleanup_prompt_used TEXT;
+```
+
+| Column | Meaning |
+|--------|---------|
+| `transcription_text` | Raw STT output (never changes) |
+| `cleanup_text` | Output after cleanup LLM (NULL if cleanup didn't run) |
+| `cleanup_prompt_used` | System prompt for cleanup (NULL if cleanup didn't run) |
+| `post_processed_text` | Output after post-processing (NULL if post-process didn't run) |
+| `post_process_prompt` | Prompt template for post-processing (NULL if post-process didn't run) |
+
+This makes the audit trail explicit: you can see raw → cleaned → post-processed at each step.
+
+### New Migration
+
+Add to `MIGRATIONS` in `src-tauri/src/managers/history.rs`:
+
+```rust
+M::up("ALTER TABLE transcription_history ADD COLUMN cleanup_text TEXT;"),
+M::up("ALTER TABLE transcription_history ADD COLUMN cleanup_prompt_used TEXT;"),
+```
+
+Update `HistoryEntry` struct:
+
+```rust
+pub struct HistoryEntry {
+    // ... existing fields ...
+    pub cleanup_text: Option<String>,
+    pub cleanup_prompt_used: Option<String>,
+}
+```
+
+Update all SQL queries in `history.rs` to include the new columns (there are ~8 query sites: `save_entry`, `update_transcription`, `get_history_entries`, `get_entry_by_id`, `map_history_entry`, and test helpers).
+
+### Cleanup Function
+
+New function in `src-tauri/src/actions.rs`, parallel to `post_process_transcription()`:
+
+```rust
+async fn cleanup_transcription(settings: &AppSettings, transcription: &str) -> Option<String> {
+    // 1. Resolve provider (reuses active_post_process_provider() pattern)
+    // 2. Resolve model from settings.cleanup_model
+    // 3. Resolve prompt from settings.cleanup_prompts by cleanup_prompt_id
+    // 4. Call llm_client::send_chat_completion_with_schema() with:
+    //    - system_prompt: selected cleanup prompt
+    //    - user_content: transcription
+    //    - schema: same TRANSCRIPTION_FIELD schema as post-processing
+    // 5. Return cleaned text or None on failure
+}
+```
+
+Uses **structured output** (JSON schema) by default for reliable parsing. Falls back to raw text if structured output fails.
+
+### Integration in `process_transcription_output()`
+
+Modify the existing function in `src-tauri/src/actions.rs`:
+
+```rust
+pub(crate) struct ProcessedTranscription {
+    pub final_text: String,
+    pub post_processed_text: Option<String>,
+    pub post_process_prompt: Option<String>,
+    pub cleanup_text: Option<String>,        // NEW
+    pub cleanup_prompt_used: Option<String>, // NEW
+}
+
+pub(crate) async fn process_transcription_output(
+    app: &AppHandle,
+    transcription: &str,
+    post_process: bool,
+) -> ProcessedTranscription {
+    let settings = get_settings(app);
+    let mut text = transcription.to_string();
+
+    // 1. Chinese variant conversion (existing)
+    if let Some(converted) = maybe_convert_chinese_variant(&settings, transcription).await {
+        text = converted;
+    }
+
+    // 2. Cleanup (NEW) — runs BEFORE post-processing
+    let (mut cleanup_text, mut cleanup_prompt_used) = (None, None);
+    if settings.cleanup_enabled {
+        if let Some(cleaned) = cleanup_transcription(&settings, &text).await {
+            cleanup_text = Some(cleaned.clone());
+            text = cleaned;
+
+            // Capture prompt for audit
+            if let Some(prompt_id) = &settings.cleanup_prompt_id {
+                if let Some(prompt) = settings.cleanup_prompts.iter()
+                    .find(|p| &p.id == prompt_id)
+                {
+                    cleanup_prompt_used = Some(prompt.system_prompt.clone());
+                }
+            }
+        }
+    }
+
+    // 3. Post-processing (existing) — runs AFTER cleanup
+    let (mut post_processed_text, mut post_process_prompt) = (None, None);
+    if post_process {
+        if let Some(processed) = post_process_transcription(&settings, &text).await {
+            post_processed_text = Some(processed.clone());
+            text = processed;
+            // ... existing prompt capture logic ...
+        }
+    }
+
+    ProcessedTranscription {
+        final_text: text,
+        post_processed_text,
+        post_process_prompt,
+        cleanup_text,
+        cleanup_prompt_used,
+    }
+}
+```
+
+### Update `TranscribeAction::stop()` to Save Cleanup Data
+
+In the `actions.rs` `stop()` method, update the `save_entry` call:
+
+```rust
+hm.save_entry(
+    file_name,
+    transcription,                    // raw STT text
+    post_process,                     // was post-processing requested?
+    processed.cleanup_text.clone(),   // NEW: cleanup output
+    processed.cleanup_prompt_used.clone(), // NEW: cleanup prompt
+    processed.post_processed_text,    // post-processing output
+    processed.post_process_prompt,    // post-processing prompt
+);
+```
+
+And update `HistoryManager::save_entry()` signature to accept the new fields.
+
+### Tauri Commands
+
+Add to `src-tauri/src/shortcut/mod.rs` (follow existing pattern):
+
+```rust
+#[tauri::command]
+async fn get_cleanup_enabled(state: State<AppState>) -> Result<bool, String> { /* ... */ }
+#[tauri::command]
+async fn set_cleanup_enabled(state: State<AppState>, enabled: bool) -> Result<(), String> { /* ... */ }
+#[tauri::command]
+async fn get_cleanup_provider_id(state: State<AppState>) -> Result<String, String> { /* ... */ }
+#[tauri::command]
+async fn set_cleanup_provider_id(state: State<AppState>, id: String) -> Result<(), String> { /* ... */ }
+#[tauri::command]
+async fn get_cleanup_model(state: State<AppState>) -> Result<String, String> { /* ... */ }
+#[tauri::command]
+async fn set_cleanup_model(state: State<AppState>, model: String) -> Result<(), String> { /* ... */ }
+#[tauri::command]
+async fn get_cleanup_prompts(state: State<AppState>) -> Result<Vec<LLMCleanupPrompt>, String> { /* ... */ }
+#[tauri::command]
+async fn set_cleanup_prompt_id(state: State<AppState>, id: Option<String>) -> Result<(), String> { /* ... */ }
+#[tauri::command]
+async fn get_cleanup_prompt_by_id(state: State<AppState>, id: String) -> Result<LLMCleanupPrompt, String> { /* ... */ }
+#[tauri::command]
+async fn add_cleanup_prompt(state: State<AppState>, prompt: LLMCleanupPrompt) -> Result<(), String> { /* ... */ }
+#[tauri::command]
+async fn update_cleanup_prompt(state: State<AppState>, prompt: LLMCleanupPrompt) -> Result<(), String> { /* ... */ }
+#[tauri::command]
+async fn delete_cleanup_prompt(state: State<AppState>, id: String) -> Result<(), String> { /* ... */ }
+```
+
+Register in `lib.rs` `collect_commands![]` macro.
+
+### Frontend UI
+
+New settings section in `src/components/settings/`:
+
+**`TranscriptionCleanupSettings.tsx`** — placed alongside existing `PostProcessingSettings.tsx`:
+
+- Enable/disable toggle
+- Provider selector (dropdown — reuses existing provider list)
+- Model selector (dropdown — populated from `fetch_models` API call)
+- Prompt selector (dropdown — built-in + custom prompts)
+- Prompt editor (view/edit selected prompt's system prompt)
+- "Add custom prompt" button
+- "Test cleanup" button (send current transcription through cleanup, show result)
+
+**History view updates** — in the existing history panel:
+- Show original → cleaned diff when cleanup was applied
+- Collapsible "cleanup" section showing the prompt used and the cleaned output
+- Side-by-side comparison: raw STT vs cleaned vs post-processed
+
+### Frontend Store Updates
+
+Extend `src/stores/settingsStore.ts`:
+
+```typescript
+interface SettingsStore {
+  // ... existing ...
+
+  // Cleanup settings
+  cleanupEnabled: boolean;
+  cleanupProviderId: string;
+  cleanupModel: string;
+  cleanupPromptId: string | null;
+  cleanupPrompts: LLMCleanupPrompt[];
+
+  setCleanupEnabled: (enabled: boolean) => void;
+  setCleanupProviderId: (id: string) => void;
+  setCleanupModel: (model: string) => void;
+  setCleanupPromptId: (id: string | null) => void;
+  // ... etc
+}
+```
+
+### Recommended Default Model
+
+For lightweight cleanup, recommend fast/cheap models:
+
+| Provider | Model | Why |
+|----------|-------|-----|
+| OpenAI | `gpt-4o-mini` | Fast, cheap, good at grammar |
+| OpenRouter | `meta-llama/llama-3.1-8b-instruct` | Free/cheap, capable |
+| Groq | `llama-3.1-8b` | Extremely fast inference |
+| Cerebras | `llama-3.1-8b` | Sub-100ms latency |
+| Custom | Any small model | For local/self-hosted |
+
+The cleanup prompt is simple (grammar fix), so small models work well. No need for large/expensive models.
+
+## Implementation Plan
+
+| Step | What | Files | Effort |
+|------|------|-------|--------|
+| 1 | Add settings fields + defaults | `settings.rs` | Small |
+| 2 | Add built-in cleanup prompts | `settings.rs` | Small |
+| 3 | Add DB migration + HistoryEntry fields | `history.rs` | Small |
+| 4 | Implement `cleanup_transcription()` function | `actions.rs` | Medium |
+| 5 | Update `process_transcription_output()` | `actions.rs` | Small |
+| 6 | Update `save_entry()` signature + calls | `history.rs`, `actions.rs` | Small |
+| 7 | Add Tauri commands | `shortcut/mod.rs`, `lib.rs` | Medium |
+| 8 | Generate TypeScript types | `tauri-specta` codegen | Auto |
+| 9 | Frontend: cleanup settings UI | `TranscriptionCleanupSettings.tsx`, `settingsStore.ts` | Medium |
+| 10 | Frontend: history view updates | History panel components | Medium |
+
+## Open Questions
+
+1. **Should cleanup use structured output or raw completion?** Structured output is more reliable (JSON schema enforces a `transcription` field), but adds a slight overhead. Recommendation: structured output by default, fall back to raw.
+
+2. **Should cleanup run on `transcribe` (no post-process) shortcut only, or always?** If always-on, it runs even when user triggers `transcribe_with_post_process`. Recommendation: always-on when `cleanup_enabled` is true, regardless of which shortcut is used. The two layers are independent.
+
+3. **Should we show a processing overlay during cleanup?** Existing `show_processing_overlay()` is shown during post-processing. For lightweight cleanup with fast models (Groq, Cerebras), the delay may be <500ms — no overlay needed. But for slower providers, an overlay would be good. Recommendation: skip overlay for cleanup, keep it for post-processing.
+
+4. **Error handling: fallback to raw text?** If the LLM call fails (network error, rate limit, etc.), should we fall back to raw STT text? Recommendation: yes, always fall back to raw. Never block transcription output on LLM failure.
+
+5. **Should cleanup have its own API key or share with post-processing?** They could share (same provider = same key), but some users may want different accounts/quotas. Recommendation: reuse the same `post_process_api_keys` SecretMap — cleanup reads the key for its selected provider. Simpler, fewer settings fields.
+
+6. **Prompt templates: should `${output}` placeholder work in cleanup prompts?** Existing post-processing prompts support `${output}` substitution. For cleanup, we're using system prompts + user message pattern (not template substitution). Recommendation: cleanup prompts are system messages only, no variable substitution. Simpler mental model.
+
+## Audit Trail Example
+
+After a transcription with cleanup enabled:
+
+```
+HistoryEntry {
+  id: 42,
+  transcription_text: "hey so i was thinking like we should probably um meet tomorrow at like three",
+  cleanup_text: Some("Hey, so I was thinking we should probably meet tomorrow at three."),
+  cleanup_prompt_used: Some("Fix minor grammar, punctuation, and capitalization errors..."),
+  post_processed_text: None,
+  post_process_prompt: None,
+}
+```
+
+User can see in the history panel:
+- **Original:** "hey so i was thinking like we should probably um meet tomorrow at like three"
+- **Cleaned:** "Hey, so I was thinking we should probably meet tomorrow at three."
+- **Prompt used:** "Fix minor grammar, punctuation, and capitalization errors..."
+
+## References
+
+- Existing post-processing: `src-tauri/src/actions.rs` (line ~68, `post_process_transcription()`)
+- LLM client: `src-tauri/src/llm_client.rs` (`send_chat_completion()`, `send_chat_completion_with_schema()`)
+- History manager: `src-tauri/src/managers/history.rs`
+- Settings: `src-tauri/src/settings.rs` (`PostProcessProvider`, `AppSettings`)
+- Frontend settings: `src/components/settings/post-processing/PostProcessingSettings.tsx`
+- Settings store: `src/stores/settingsStore.ts`


### PR DESCRIPTION
## Summary

Two research/spec documents for upcoming features:

### 1. Gaze Detection & Eye Tracking (`docs/projects/gaze-detection.md`)

7-phase plan for adding eye-tracking to Handy via webcam-based gaze detection:

- **Phase 1-2:** Gaze detection backend (Python `GazeTracking` subprocess) + settings
- **Phase 3:** Gaze-to-cursor mapping with dwell-to-click
- **Phase 4:** Multi-monitor window switching (macOS `CGWindowListCopyWindowInfo`, Windows `EnumWindows`)
- **Phase 5:** Gaze-triggered transcription (trigger zones)
- **Phase 6:** Frontend UI (calibration wizard, gaze indicator overlay, settings)
- **Phase 7:** Voice + gaze fusion commands (look at window + say "switch")

Key design: Rust provider trait pattern (mirrors existing AudioManager/ModelManager), Python subprocess for webcam gaze to avoid heavy Rust OpenCV deps.

### 2. Transcription Cleanup (`docs/projects/transcription-cleanup.md`)

Always-on lightweight LLM cleanup step after STT, with `original → cleaned` audit trail:

- New DB columns: `cleanup_text`, `cleanup_prompt_used`
- 3 built-in prompts (light/medium/heavy grammar cleanup) + custom prompt support
- Runs **before** existing post-processing (3-layer pipeline: STT → cleanup → post-process)
- Reuses existing `PostProcessProvider` list, `llm_client.rs`, and settings infrastructure
- Recommended models: `gpt-4o-mini`, `llama-3.1-8b` on Groq/Cerebras for speed/cost
- 10-step implementation plan with file-level breakdown

### Status

Research and spec only — no code changes. Ready for review before implementation.