### PR TITLE
feat: add Hebrew speech recognition models (ivrit-ai)

### DIFF
--- a/src-tauri/src/managers/model.rs
+++ b/src-tauri/src/managers/model.rs
@@ -233,6 +233,56 @@ impl ModelManager {
         );
 
         available_models.insert(
+            "ivrit-whisper-large-v3".to_string(),
+            ModelInfo {
+                id: "ivrit-whisper-large-v3".to_string(),
+                name: "Ivrit Whisper Large".to_string(),
+                description: "Optimized for Hebrew. High accuracy.".to_string(),
+                filename: "ivrit-whisper-large-v3.bin".to_string(),
+                url: Some("https://huggingface.co/ivrit-ai/whisper-large-v3-ggml/resolve/main/ggml-model.bin".to_string()),
+                sha256: None,
+                size_mb: 2952,
+                is_downloaded: false,
+                is_downloading: false,
+                partial_size: 0,
+                is_directory: false,
+                engine_type: EngineType::Whisper,
+                accuracy_score: 0.90,
+                speed_score: 0.25,
+                supports_translation: false,
+                is_recommended: false,
+                supported_languages: vec!["he".to_string()],
+                supports_language_selection: false,
+                is_custom: false,
+            },
+        );
+
+        available_models.insert(
+            "ivrit-whisper-large-v3-turbo".to_string(),
+            ModelInfo {
+                id: "ivrit-whisper-large-v3-turbo".to_string(),
+                name: "Ivrit Whisper Turbo".to_string(),
+                description: "Optimized for Hebrew. Fast and accurate.".to_string(),
+                filename: "ivrit-whisper-large-v3-turbo.bin".to_string(),
+                url: Some("https://huggingface.co/ivrit-ai/whisper-large-v3-turbo-ggml/resolve/main/ggml-model.bin".to_string()),
+                sha256: None,
+                size_mb: 1549,
+                is_downloaded: false,
+                is_downloading: false,
+                partial_size: 0,
+                is_directory: false,
+                engine_type: EngineType::Whisper,
+                accuracy_score: 0.85,
+                speed_score: 0.40,
+                supports_translation: false,
+                is_recommended: false,
+                supported_languages: vec!["he".to_string()],
+                supports_language_selection: false,
+                is_custom: false,
+            },
+        );
+
+        available_models.insert(
             "breeze-asr".to_string(),
             ModelInfo {
                 id: "breeze-asr".to_string(),

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -69,6 +69,14 @@
         "name": "Moonshine V2 Medium",
         "description": "English only. High quality."
       },
+      "ivrit-whisper-large-v3": {
+        "name": "Ivrit Whisper Large",
+        "description": "Optimized for Hebrew. High accuracy."
+      },
+      "ivrit-whisper-large-v3-turbo": {
+        "name": "Ivrit Whisper Turbo",
+        "description": "Optimized for Hebrew. Fast and accurate."
+      },
       "breeze-asr": {
         "name": "Breeze ASR",
         "description": "Optimized for Taiwanese Mandarin. Code-switching support."


### PR DESCRIPTION
## Summary
- Add two Hebrew-optimized Whisper models from [ivrit-ai](https://huggingface.co/ivrit-ai):
  - **Ivrit Whisper Large** (~2.95 GB) — fine-tuned `whisper-large-v3` for Hebrew, highest accuracy
  - **Ivrit Whisper Turbo** (~1.55 GB) — fine-tuned `whisper-large-v3-turbo` for Hebrew, faster inference
- Both use GGML format downloaded from HuggingFace, fully compatible with the existing `whisper.cpp` engine
- No new dependencies, engine types, or frontend changes required
- Added English i18n entries for model names and descriptions

## Context
The original request referenced the [CTranslate2 model](https://huggingface.co/ivrit-ai/whisper-large-v3-ct2), but ivrit-ai also publishes GGML versions that are compatible with Handy's existing whisper.cpp infrastructure:
- [`ivrit-ai/whisper-large-v3-ggml`](https://huggingface.co/ivrit-ai/whisper-large-v3-ggml)
- [`ivrit-ai/whisper-large-v3-turbo-ggml`](https://huggingface.co/ivrit-ai/whisper-large-v3-turbo-ggml)

## Test plan
- [ ] Verify `cargo check` passes
- [ ] Download each model from the model selector UI
- [ ] Confirm Hebrew transcription works with both models
- [ ] Verify models appear correctly in the model dropdown with translated names