### PR TITLE
fix(post-processing): support DeepSeek custom endpoints

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -125,12 +125,16 @@ async fn post_process_transcription(settings: &AppSettings, transcription: &str)
         .cloned()
         .unwrap_or_default();
 
+    let is_deepseek_custom =
+        provider.id == "custom" && provider.base_url.contains("api.deepseek.com");
+
     // Disable reasoning for providers where post-processing rarely benefits from it.
-    // - custom: top-level reasoning_effort (works for local OpenAI-compat servers)
-    // - openrouter: nested reasoning object; exclude:true also keeps reasoning text
-    //   out of the response so it can't pollute structured-output JSON parsing
+    // Most local OpenAI-compatible servers accept `reasoning_effort: "none"`,
+    // but DeepSeek rejects that enum.
+    // OpenRouter uses a nested reasoning object; exclude:true also keeps reasoning
+    // text out of the response so it can't pollute structured-output JSON parsing.
     let (reasoning_effort, reasoning) = match provider.id.as_str() {
-        "custom" => (Some("none".to_string()), None),
+        "custom" if !is_deepseek_custom => (Some("none".to_string()), None),
         "openrouter" => (
             None,
             Some(crate::llm_client::ReasoningConfig {


### PR DESCRIPTION
## Summary

Fixes Custom post-processing against DeepSeek-compatible endpoints.

PR #1221 started sending `reasoning_effort: "none"` for Custom providers to avoid thinking-mode latency in local OpenAI-compatible servers such as Ollama. DeepSeek rejects that value with HTTP 400, so Custom post-processing falls back to the original transcription.

This keeps the existing Custom behavior for non-DeepSeek endpoints, but skips `reasoning_effort: "none"` when the Custom provider points at DeepSeek.

## Changes

- Detect Custom providers whose base URL points to `api.deepseek.com`.
- Preserve `reasoning_effort: "none"` for other Custom providers.
- Omit `reasoning_effort` for DeepSeek Custom endpoints.

## Validation

- Manually tested with:
  - Provider: Custom
  - Base URL: `https://api.deepseek.com`
  - Model: `deepseek-v4-flash`
- Verified post-processing no longer returns the `reasoning_effort` HTTP 400.
- `cargo fmt -- --check`

I also attempted `cargo check --no-default-features`, but current `main` fails in my local macOS Command Line Tools environment while compiling the existing Apple Intelligence Swift bridge:

```text
FoundationModelsMacros.GenerableMacro could not be found
```

That failure happens in the existing build script/Swift bridge path and is unrelated to this patch.

Fixes #1342
