### PR TITLE
feat: add self-learning transcription corrections via LLM

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.16",
-    "@tauri-apps/api": "^2.10.0",
+    "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-autostart": "~2.5.1",
     "@tauri-apps/plugin-clipboard-manager": "~2.3.2",
     "@tauri-apps/plugin-dialog": "~2.6",

--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -3,6 +3,7 @@ use crate::apple_intelligence;
 use crate::audio_feedback::{play_feedback_sound, play_feedback_sound_blocking, SoundType};
 use crate::audio_toolkit::{is_microphone_access_denied, is_no_input_device_error};
 use crate::managers::audio::AudioRecordingManager;
+use crate::managers::corrections::CorrectionsManager;
 use crate::managers::history::HistoryManager;
 use crate::managers::transcription::TranscriptionManager;
 use crate::settings::{get_settings, AppSettings, APPLE_INTELLIGENCE_PROVIDER_ID};
@@ -358,6 +359,15 @@ pub(crate) async fn process_transcription_output(
 
     if let Some(converted_text) = maybe_convert_chinese_variant(&settings, transcription).await {
         final_text = converted_text;
+    }
+
+    if let Some(cm) = app.try_state::<Arc<CorrectionsManager>>() {
+        if let Ok(corrected) = cm.apply_corrections(&final_text) {
+            if corrected != final_text {
+                debug!("Applied learned corrections to transcription");
+                final_text = corrected;
+            }
+        }
     }
 
     if post_process {

--- a/src-tauri/src/commands/history.rs
+++ b/src-tauri/src/commands/history.rs
@@ -1,6 +1,7 @@
 use crate::actions::process_transcription_output;
 use crate::managers::{
-    history::{HistoryManager, PaginatedHistory},
+    corrections::{CorrectionDiff, CorrectionsManager, LearnedCorrection},
+    history::{HistoryEntry, HistoryManager, PaginatedHistory},
     transcription::TranscriptionManager,
 };
 use std::sync::Arc;
@@ -127,28 +128,74 @@ pub async fn update_history_limit(
 #[tauri::command]
 #[specta::specta]
 pub async fn update_recording_retention_period(
-    app: AppHandle,
+    _app: AppHandle,
     history_manager: State<'_, Arc<HistoryManager>>,
-    period: String,
+    _period: String,
 ) -> Result<(), String> {
-    use crate::settings::RecordingRetentionPeriod;
-
-    let retention_period = match period.as_str() {
-        "never" => RecordingRetentionPeriod::Never,
-        "preserve_limit" => RecordingRetentionPeriod::PreserveLimit,
-        "days3" => RecordingRetentionPeriod::Days3,
-        "weeks2" => RecordingRetentionPeriod::Weeks2,
-        "months3" => RecordingRetentionPeriod::Months3,
-        _ => return Err(format!("Invalid retention period: {}", period)),
-    };
-
-    let mut settings = crate::settings::get_settings(&app);
-    settings.recording_retention_period = retention_period;
-    crate::settings::write_settings(&app, settings);
-
     history_manager
         .cleanup_old_entries()
         .map_err(|e| e.to_string())?;
 
     Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn update_transcription_text(
+    _app: AppHandle,
+    history_manager: State<'_, Arc<HistoryManager>>,
+    id: i64,
+    new_text: String,
+) -> Result<HistoryEntry, String> {
+    history_manager
+        .update_transcription_text(id, new_text)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn learn_corrections_from_edit(
+    app: AppHandle,
+    corrections_manager: State<'_, Arc<CorrectionsManager>>,
+    original_text: String,
+    corrected_text: String,
+) -> Result<Vec<CorrectionDiff>, String> {
+    corrections_manager
+        .learn_from_diff_llm(&app, &original_text, &corrected_text)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn get_learned_corrections(
+    _app: AppHandle,
+    corrections_manager: State<'_, Arc<CorrectionsManager>>,
+) -> Result<Vec<LearnedCorrection>, String> {
+    corrections_manager
+        .get_all_corrections()
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn delete_learned_correction(
+    _app: AppHandle,
+    corrections_manager: State<'_, Arc<CorrectionsManager>>,
+    id: i64,
+) -> Result<(), String> {
+    corrections_manager
+        .delete_correction(id)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn clear_learned_corrections(
+    _app: AppHandle,
+    corrections_manager: State<'_, Arc<CorrectionsManager>>,
+) -> Result<usize, String> {
+    corrections_manager
+        .clear_all_corrections()
+        .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,6 +27,7 @@ use tauri_specta::{collect_commands, collect_events, Builder};
 
 use env_filter::Builder as EnvFilterBuilder;
 use managers::audio::AudioRecordingManager;
+use managers::corrections::CorrectionsManager;
 use managers::history::HistoryManager;
 use managers::model::ModelManager;
 use managers::transcription::TranscriptionManager;
@@ -155,6 +156,9 @@ fn initialize_core_logic(app_handle: &AppHandle) {
     );
     let history_manager =
         Arc::new(HistoryManager::new(app_handle).expect("Failed to initialize history manager"));
+    let corrections_manager = Arc::new(
+        CorrectionsManager::new(app_handle).expect("Failed to initialize corrections manager"),
+    );
 
     // Apply accelerator preferences before any model loads
     managers::transcription::apply_accelerator_settings(app_handle);
@@ -164,6 +168,7 @@ fn initialize_core_logic(app_handle: &AppHandle) {
     app_handle.manage(model_manager.clone());
     app_handle.manage(transcription_manager.clone());
     app_handle.manage(history_manager.clone());
+    app_handle.manage(corrections_manager.clone());
 
     // Note: Shortcuts are NOT initialized here.
     // The frontend is responsible for calling the `initialize_shortcuts` command
@@ -425,6 +430,11 @@ pub fn run(cli_args: CliArgs) {
             commands::history::retry_history_entry_transcription,
             commands::history::update_history_limit,
             commands::history::update_recording_retention_period,
+            commands::history::update_transcription_text,
+            commands::history::learn_corrections_from_edit,
+            commands::history::get_learned_corrections,
+            commands::history::delete_learned_correction,
+            commands::history::clear_learned_corrections,
             helpers::clamshell::is_laptop,
         ])
         .events(collect_events![managers::history::HistoryUpdatePayload,]);

--- a/src-tauri/src/managers/corrections.rs
+++ b/src-tauri/src/managers/corrections.rs
@@ -1,0 +1,398 @@
+use anyhow::Result;
+use chrono::Utc;
+use log::{debug, info, warn};
+use rusqlite::{params, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use std::path::PathBuf;
+
+use tauri::AppHandle;
+
+#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+pub struct LearnedCorrection {
+    pub id: i64,
+    pub original_word: String,
+    pub corrected_word: String,
+    pub count: i64,
+    pub created_at: i64,
+    pub last_used_at: i64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+pub struct CorrectionDiff {
+    pub original_word: String,
+    pub corrected_word: String,
+}
+
+pub struct CorrectionsManager {
+    db_path: PathBuf,
+}
+
+impl CorrectionsManager {
+    pub fn new(app_handle: &AppHandle) -> Result<Self> {
+        let app_data_dir = crate::portable::app_data_dir(app_handle)?;
+        let db_path = app_data_dir.join("history.db");
+
+        Ok(Self { db_path })
+    }
+
+    fn get_connection(&self) -> Result<rusqlite::Connection> {
+        Ok(rusqlite::Connection::open(&self.db_path)?)
+    }
+
+    pub fn get_all_corrections(&self) -> Result<Vec<LearnedCorrection>> {
+        let conn = self.get_connection()?;
+        let mut stmt = conn.prepare(
+            "SELECT id, original_word, corrected_word, count, created_at, last_used_at
+             FROM learned_corrections
+             ORDER BY count DESC, last_used_at DESC",
+        )?;
+
+        let corrections = stmt
+            .query_map([], |row| {
+                Ok(LearnedCorrection {
+                    id: row.get("id")?,
+                    original_word: row.get("original_word")?,
+                    corrected_word: row.get("corrected_word")?,
+                    count: row.get("count")?,
+                    created_at: row.get("created_at")?,
+                    last_used_at: row.get("last_used_at")?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(corrections)
+    }
+
+    pub fn learn_from_diff(
+        &self,
+        original_text: &str,
+        corrected_text: &str,
+    ) -> Result<Vec<CorrectionDiff>> {
+        let diffs = Self::extract_word_diffs(original_text, corrected_text);
+
+        if diffs.is_empty() {
+            debug!("No word-level corrections found in diff");
+            return Ok(vec![]);
+        }
+
+        let conn = self.get_connection()?;
+        let now = Utc::now().timestamp();
+
+        for diff in &diffs {
+            let existing: Option<(i64, i64)> = conn
+                .query_row(
+                    "SELECT id, count FROM learned_corrections WHERE original_word = ?1",
+                    params![diff.original_word],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .optional()?;
+
+            match existing {
+                Some((id, count)) => {
+                    conn.execute(
+                        "UPDATE learned_corrections SET corrected_word = ?1, count = ?2, last_used_at = ?3 WHERE id = ?4",
+                        params![diff.corrected_word, count + 1, now, id],
+                    )?;
+                    debug!(
+                        "Updated correction: '{}' -> '{}' (count: {})",
+                        diff.original_word, diff.corrected_word, count + 1
+                    );
+                }
+                None => {
+                    conn.execute(
+                        "INSERT INTO learned_corrections (original_word, corrected_word, count, created_at, last_used_at) VALUES (?1, ?2, 1, ?3, ?4)",
+                        params![diff.original_word, diff.corrected_word, now, now],
+                    )?;
+                    debug!(
+                        "New correction learned: '{}' -> '{}'",
+                        diff.original_word, diff.corrected_word
+                    );
+                }
+            }
+        }
+
+        info!("Learned {} correction(s)", diffs.len());
+        Ok(diffs)
+    }
+
+    pub async fn learn_from_diff_llm(
+        &self,
+        app: &AppHandle,
+        original_text: &str,
+        corrected_text: &str,
+    ) -> Result<Vec<CorrectionDiff>> {
+        let settings = crate::settings::get_settings(app);
+
+        let provider = match settings.active_post_process_provider().cloned() {
+            Some(p) => p,
+            None => {
+                debug!("No LLM provider configured, falling back to positional diff");
+                return self.learn_from_diff(original_text, corrected_text);
+            }
+        };
+
+        let model = settings
+            .post_process_models
+            .get(&provider.id)
+            .cloned()
+            .unwrap_or_default();
+
+        if model.trim().is_empty() {
+            debug!("No model configured for provider '{}', falling back", provider.id);
+            return self.learn_from_diff(original_text, corrected_text);
+        }
+
+        let api_key = settings
+            .post_process_api_keys
+            .get(&provider.id)
+            .cloned()
+            .unwrap_or_default();
+
+        if api_key.trim().is_empty() {
+            debug!("No API key for provider '{}', falling back", provider.id);
+            return self.learn_from_diff(original_text, corrected_text);
+        }
+
+        let system_prompt = "You are a speech-to-text error analyzer. Compare the original transcription with the corrected version. Extract ONLY word-level corrections that fix speech recognition errors (misheard words, wrong homophones, phonetic mistakes). Ignore changes in punctuation, capitalization, style, or added/removed words. Return a JSON object with a \"corrections\" array of objects, each with \"wrong\" and \"correct\" keys. If there are no STT errors to fix, return {\"corrections\": []}".to_string();
+
+        let user_content = format!(
+            "ORIGINAL: {}\nCORRECTED: {}",
+            original_text, corrected_text
+        );
+
+        let json_schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "corrections": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "wrong": { "type": "string" },
+                            "correct": { "type": "string" }
+                        },
+                        "required": ["wrong", "correct"],
+                        "additionalProperties": false
+                    }
+                }
+            },
+            "required": ["corrections"],
+            "additionalProperties": false
+        });
+
+        let (reasoning_effort, reasoning) = match provider.id.as_str() {
+            "custom" => (Some("none".to_string()), None),
+            "openrouter" => (
+                None,
+                Some(crate::llm_client::ReasoningConfig {
+                    effort: Some("none".to_string()),
+                    exclude: Some(true),
+                }),
+            ),
+            _ => (None, None),
+        };
+
+        let use_schema = provider.supports_structured_output;
+
+        let result = if use_schema {
+            crate::llm_client::send_chat_completion_with_schema(
+                &provider,
+                api_key,
+                &model,
+                user_content,
+                Some(system_prompt),
+                Some(json_schema),
+                reasoning_effort,
+                reasoning,
+            )
+            .await
+        } else {
+            let combined = format!("{}\n\n{}", system_prompt, user_content);
+            crate::llm_client::send_chat_completion(
+                &provider,
+                api_key,
+                &model,
+                combined,
+                reasoning_effort,
+                reasoning,
+            )
+            .await
+        };
+
+        let response_text = match result {
+            Ok(Some(text)) => text,
+            Ok(None) => {
+                debug!("LLM returned empty response, falling back");
+                return self.learn_from_diff(original_text, corrected_text);
+            }
+            Err(e) => {
+                warn!("LLM correction analysis failed: {}, falling back", e);
+                return self.learn_from_diff(original_text, corrected_text);
+            }
+        };
+
+        let diffs = match Self::parse_llm_corrections(&response_text) {
+            Some(d) if !d.is_empty() => d,
+            _ => {
+                debug!("LLM returned no corrections, falling back");
+                return self.learn_from_diff(original_text, corrected_text);
+            }
+        };
+
+        info!("LLM extracted {} correction(s)", diffs.len());
+        self.save_diffs_to_db(&diffs)?;
+        Ok(diffs)
+    }
+
+    fn parse_llm_corrections(response: &str) -> Option<Vec<CorrectionDiff>> {
+        let cleaned = response.trim();
+
+        #[derive(Deserialize)]
+        struct LlmCorrection {
+            wrong: String,
+            correct: String,
+        }
+
+        #[derive(Deserialize)]
+        struct LlmResponse {
+            corrections: Vec<LlmCorrection>,
+        }
+
+        let parsed: LlmResponse = serde_json::from_str(cleaned).ok()?;
+
+        Some(
+            parsed
+                .corrections
+                .into_iter()
+                .filter(|c| !c.wrong.trim().is_empty() && !c.correct.trim().is_empty())
+                .map(|c| CorrectionDiff {
+                    original_word: c.wrong.trim().to_lowercase(),
+                    corrected_word: c.correct.trim().to_string(),
+                })
+                .collect(),
+        )
+    }
+
+    fn save_diffs_to_db(&self, diffs: &[CorrectionDiff]) -> Result<()> {
+        let conn = self.get_connection()?;
+        let now = Utc::now().timestamp();
+
+        for diff in diffs {
+            let existing: Option<(i64, i64)> = conn
+                .query_row(
+                    "SELECT id, count FROM learned_corrections WHERE original_word = ?1",
+                    params![diff.original_word],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .optional()?;
+
+            match existing {
+                Some((id, count)) => {
+                    conn.execute(
+                        "UPDATE learned_corrections SET corrected_word = ?1, count = ?2, last_used_at = ?3 WHERE id = ?4",
+                        params![diff.corrected_word, count + 1, now, id],
+                    )?;
+                }
+                None => {
+                    conn.execute(
+                        "INSERT INTO learned_corrections (original_word, corrected_word, count, created_at, last_used_at) VALUES (?1, ?2, 1, ?3, ?4)",
+                        params![diff.original_word, diff.corrected_word, now, now],
+                    )?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn apply_corrections(&self, text: &str) -> Result<String> {
+        let corrections = self.get_all_corrections()?;
+        if corrections.is_empty() {
+            return Ok(text.to_string());
+        }
+
+        let mut result = text.to_string();
+        for correction in &corrections {
+            let pattern = regex::Regex::new(&format!(
+                r"(?i)\b{}\b",
+                regex::escape(&correction.original_word)
+            ))
+            .ok();
+
+            if let Some(re) = pattern {
+                let original_len = result.len();
+                result = re
+                    .replace_all(&result, correction.corrected_word.as_str())
+                    .to_string();
+                if result.len() != original_len || result != text {
+                    debug!(
+                        "Applied correction: '{}' -> '{}'",
+                        correction.original_word, correction.corrected_word
+                    );
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    pub fn delete_correction(&self, id: i64) -> Result<()> {
+        let conn = self.get_connection()?;
+        conn.execute(
+            "DELETE FROM learned_corrections WHERE id = ?1",
+            params![id],
+        )?;
+        info!("Deleted correction with id {}", id);
+        Ok(())
+    }
+
+    pub fn clear_all_corrections(&self) -> Result<usize> {
+        let conn = self.get_connection()?;
+        let count = conn.execute("DELETE FROM learned_corrections", [])?;
+        info!("Cleared all corrections ({} deleted)", count);
+        Ok(count)
+    }
+
+    fn extract_word_diffs(original: &str, corrected: &str) -> Vec<CorrectionDiff> {
+        let original_words: Vec<&str> = original.split_whitespace().collect();
+        let corrected_words: Vec<&str> = corrected.split_whitespace().collect();
+
+        let mut diffs = Vec::new();
+
+        let max_len = original_words.len().max(corrected_words.len());
+        for i in 0..max_len {
+            let orig_word = original_words.get(i).map(|s| *s).unwrap_or("");
+            let corr_word = corrected_words.get(i).map(|s| *s).unwrap_or("");
+
+            if !orig_word.is_empty()
+                && !corr_word.is_empty()
+                && !Self::words_match_ignore_case_punctuation(orig_word, corr_word)
+            {
+                let clean_orig = Self::strip_punctuation(orig_word);
+                let clean_corr = Self::strip_punctuation(corr_word);
+
+                if !clean_orig.is_empty() && !clean_corr.is_empty() {
+                    diffs.push(CorrectionDiff {
+                        original_word: clean_orig.to_lowercase(),
+                        corrected_word: clean_corr,
+                    });
+                }
+            }
+        }
+
+        diffs
+    }
+
+    fn words_match_ignore_case_punctuation(a: &str, b: &str) -> bool {
+        let clean_a = Self::strip_punctuation(a).to_lowercase();
+        let clean_b = Self::strip_punctuation(b).to_lowercase();
+        clean_a == clean_b
+    }
+
+    fn strip_punctuation(s: &str) -> String {
+        s.chars()
+            .filter(|c| c.is_alphanumeric() || *c == '\'' || *c == '-')
+            .collect()
+    }
+}

--- a/src-tauri/src/managers/history.rs
+++ b/src-tauri/src/managers/history.rs
@@ -31,6 +31,17 @@ static MIGRATIONS: &[M] = &[
     M::up("ALTER TABLE transcription_history ADD COLUMN post_processed_text TEXT;"),
     M::up("ALTER TABLE transcription_history ADD COLUMN post_process_prompt TEXT;"),
     M::up("ALTER TABLE transcription_history ADD COLUMN post_process_requested BOOLEAN NOT NULL DEFAULT 0;"),
+    M::up(
+        "CREATE TABLE IF NOT EXISTS learned_corrections (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            original_word TEXT NOT NULL,
+            corrected_word TEXT NOT NULL,
+            count INTEGER NOT NULL DEFAULT 1,
+            created_at INTEGER NOT NULL,
+            last_used_at INTEGER NOT NULL,
+            UNIQUE(original_word)
+        );",
+    ),
 ];
 
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
@@ -315,6 +326,42 @@ impl HistoryManager {
             )?;
 
         debug!("Updated transcription for history entry {}", id);
+
+        if let Err(e) = (HistoryUpdatePayload::Updated {
+            entry: entry.clone(),
+        })
+        .emit(&self.app_handle)
+        {
+            error!("Failed to emit history-updated event: {}", e);
+        }
+
+        Ok(entry)
+    }
+
+    pub fn update_transcription_text(
+        &self,
+        id: i64,
+        new_text: String,
+    ) -> Result<HistoryEntry> {
+        let conn = self.get_connection()?;
+        let updated = conn.execute(
+            "UPDATE transcription_history SET transcription_text = ?1 WHERE id = ?2",
+            params![new_text, id],
+        )?;
+
+        if updated == 0 {
+            return Err(anyhow!("History entry {} not found", id));
+        }
+
+        let entry = conn
+            .query_row(
+                "SELECT id, file_name, timestamp, saved, title, transcription_text, post_processed_text, post_process_prompt, post_process_requested
+                 FROM transcription_history WHERE id = ?1",
+                params![id],
+                Self::map_history_entry,
+            )?;
+
+        debug!("Updated transcription text for history entry {}", id);
 
         if let Err(e) = (HistoryUpdatePayload::Updated {
             entry: entry.clone(),

--- a/src-tauri/src/managers/mod.rs
+++ b/src-tauri/src/managers/mod.rs
@@ -1,4 +1,5 @@
 pub mod audio;
+pub mod corrections;
 pub mod history;
 pub mod model;
 pub mod transcription;

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -801,11 +801,49 @@ async updateRecordingRetentionPeriod(period: string) : Promise<Result<null, stri
     else return { status: "error", error: e  as any };
 }
 },
+async updateTranscriptionText(id: number, newText: string) : Promise<Result<HistoryEntry, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("update_transcription_text", { id, newText }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async learnCorrectionsFromEdit(originalText: string, correctedText: string) : Promise<Result<CorrectionDiff[], string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("learn_corrections_from_edit", { originalText, correctedText }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async getLearnedCorrections() : Promise<Result<LearnedCorrection[], string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_learned_corrections") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async deleteLearnedCorrection(id: number) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("delete_learned_correction", { id }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async clearLearnedCorrections() : Promise<Result<number, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("clear_learned_corrections") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 /**
- * Checks if the Mac is a laptop by detecting battery presence
- * 
- * This uses pmset to check for battery information.
- * Returns true if a battery is detected (laptop), false otherwise (desktop)
+ * Stub implementation for non-macOS platforms
+ * Always returns false since laptop detection is macOS-specific
  */
 async isLaptop() : Promise<Result<boolean, string>> {
     try {
@@ -838,6 +876,7 @@ export type AutoSubmitKey = "enter" | "ctrl_enter" | "cmd_enter"
 export type AvailableAccelerators = { whisper: string[]; ort: string[]; gpu_devices: GpuDeviceOption[] }
 export type BindingResponse = { success: boolean; binding: ShortcutBinding | null; error: string | null }
 export type ClipboardHandling = "dont_modify" | "copy_to_clipboard"
+export type CorrectionDiff = { original_word: string; corrected_word: string }
 export type CustomSounds = { start: boolean; stop: boolean }
 export type EngineType = "Whisper" | "Parakeet" | "Moonshine" | "MoonshineStreaming" | "SenseVoice" | "GigaAM" | "Canary" | "Cohere"
 export type GpuDeviceOption = { id: number; name: string; total_vram_mb: number }
@@ -853,6 +892,7 @@ export type ImplementationChangeResult = { success: boolean;
 reset_bindings: string[] }
 export type KeyboardImplementation = "tauri" | "handy_keys"
 export type LLMPrompt = { id: string; name: string; prompt: string }
+export type LearnedCorrection = { id: number; original_word: string; corrected_word: string; count: number; created_at: number; last_used_at: number }
 export type LogLevel = "trace" | "debug" | "info" | "warn" | "error"
 export type ModelInfo = { id: string; name: string; description: string; filename: string; url: string | null; sha256: string | null; size_mb: number; is_downloaded: boolean; is_downloading: boolean; partial_size: number; is_directory: boolean; engine_type: EngineType; accuracy_score: number; speed_score: number; supports_translation: boolean; is_recommended: boolean; supported_languages: string[]; supports_language_selection: boolean; is_custom: boolean }
 export type ModelLoadStatus = { is_loaded: boolean; current_model: string | null }

--- a/src/components/settings/LearnedCorrections.tsx
+++ b/src/components/settings/LearnedCorrections.tsx
@@ -1,0 +1,128 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { commands, type LearnedCorrection } from "@/bindings";
+import { Button } from "../ui/Button";
+import { SettingContainer } from "../ui/SettingContainer";
+import { Trash2, X, Brain } from "lucide-react";
+
+interface LearnedCorrectionsProps {
+  descriptionMode?: "inline" | "tooltip";
+  grouped?: boolean;
+}
+
+export const LearnedCorrections: React.FC<LearnedCorrectionsProps> =
+  React.memo(({ descriptionMode = "tooltip", grouped = false }) => {
+    const { t } = useTranslation();
+    const [corrections, setCorrections] = useState<LearnedCorrection[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    const loadCorrections = useCallback(async () => {
+      try {
+        const result = await commands.getLearnedCorrections();
+        if (result.status === "ok") {
+          setCorrections(result.data);
+        }
+      } catch (error) {
+        console.error("Failed to load learned corrections:", error);
+      } finally {
+        setLoading(false);
+      }
+    }, []);
+
+    useEffect(() => {
+      loadCorrections();
+    }, [loadCorrections]);
+
+    const handleDelete = async (id: number) => {
+      const prev = corrections;
+      setCorrections((c) => c.filter((cor) => cor.id !== id));
+      try {
+        const result = await commands.deleteLearnedCorrection(id);
+        if (result.status !== "ok") {
+          setCorrections(prev);
+        }
+      } catch {
+        setCorrections(prev);
+      }
+    };
+
+    const handleClearAll = async () => {
+      const prev = corrections;
+      setCorrections([]);
+      try {
+        const result = await commands.clearLearnedCorrections();
+        if (result.status !== "ok") {
+          setCorrections(prev);
+          toast.error(t("settings.advanced.learnedCorrections.clearError"));
+        } else {
+          toast.success(
+            t("settings.advanced.learnedCorrections.cleared", {
+              count: result.data,
+            }),
+          );
+        }
+      } catch {
+        setCorrections(prev);
+      }
+    };
+
+    return (
+      <>
+        <SettingContainer
+          title={t("settings.advanced.learnedCorrections.title")}
+          description={t("settings.advanced.learnedCorrections.description")}
+          descriptionMode={descriptionMode}
+          grouped={grouped}
+        >
+          <div className="flex items-center gap-2">
+            {corrections.length > 0 && (
+              <Button
+                onClick={handleClearAll}
+                variant="secondary"
+                size="md"
+                className="text-red-400 hover:text-red-300"
+              >
+                {t("settings.advanced.learnedCorrections.clearAll")}
+              </Button>
+            )}
+          </div>
+        </SettingContainer>
+        {loading ? (
+          <div className="px-4 py-2 text-xs text-text/40">
+            {t("settings.advanced.learnedCorrections.loading")}
+          </div>
+        ) : corrections.length > 0 ? (
+          <div
+            className={`px-4 p-2 ${grouped ? "" : "rounded-lg border border-mid-gray/20"} flex flex-wrap gap-1`}
+          >
+            {corrections.map((correction) => (
+              <Button
+                key={correction.id}
+                onClick={() => handleDelete(correction.id)}
+                variant="secondary"
+                size="sm"
+                className="inline-flex items-center gap-1 cursor-pointer"
+                aria-label={t("settings.advanced.learnedCorrections.remove", {
+                  word: correction.original_word,
+                })}
+              >
+                <span className="text-red-400/80 line-through">
+                  {correction.original_word}
+                </span>
+                <span className="text-text/30">{"\u2192"}</span>
+                <span className="text-green-400">
+                  {correction.corrected_word}
+                </span>
+                <X className="w-3 h-3 ml-1" />
+              </Button>
+            ))}
+          </div>
+        ) : (
+          <div className="px-4 py-2 text-xs text-text/40">
+            {t("settings.advanced.learnedCorrections.empty")}
+          </div>
+        )}
+      </>
+    );
+  });

--- a/src/components/settings/advanced/AdvancedSettings.tsx
+++ b/src/components/settings/advanced/AdvancedSettings.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { ShowOverlay } from "../ShowOverlay";
 import { ModelUnloadTimeoutSetting } from "../ModelUnloadTimeout";
 import { CustomWords } from "../CustomWords";
+import { LearnedCorrections } from "../LearnedCorrections";
 import { SettingsGroup } from "../../ui/SettingsGroup";
 import { StartHidden } from "../StartHidden";
 import { AutostartToggle } from "../AutostartToggle";
@@ -46,6 +47,7 @@ export const AdvancedSettings: React.FC = () => {
 
       <SettingsGroup title={t("settings.advanced.groups.transcription")}>
         <CustomWords descriptionMode="tooltip" grouped />
+        <LearnedCorrections descriptionMode="tooltip" grouped />
         <AppendTrailingSpace descriptionMode="tooltip" grouped={true} />
       </SettingsGroup>
 

--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { readFile } from "@tauri-apps/plugin-fs";
-import { Check, Copy, FolderOpen, RotateCcw, Star, Trash2 } from "lucide-react";
+import { Check, Copy, FolderOpen, RotateCcw, Star, Trash2, Pencil, Brain, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import {
@@ -9,6 +9,7 @@ import {
   events,
   type HistoryEntry,
   type HistoryUpdatePayload,
+  type CorrectionDiff,
 } from "@/bindings";
 import { useOsType } from "@/hooks/useOsType";
 import { formatDateTime } from "@/utils/dateFormat";
@@ -261,6 +262,11 @@ export const HistorySettings: React.FC = () => {
               getAudioUrl={getAudioUrl}
               deleteAudio={deleteAudioEntry}
               retryTranscription={retryHistoryEntry}
+              onEntryUpdated={(updatedEntry) => {
+                setEntries((prev) =>
+                  prev.map((e) => (e.id === updatedEntry.id ? updatedEntry : e)),
+                );
+              }}
             />
           ))}
         </div>
@@ -299,6 +305,7 @@ interface HistoryEntryProps {
   getAudioUrl: (fileName: string) => Promise<string | null>;
   deleteAudio: (id: number) => Promise<void>;
   retryTranscription: (id: number) => Promise<void>;
+  onEntryUpdated: (entry: HistoryEntry) => void;
 }
 
 const HistoryEntryComponent: React.FC<HistoryEntryProps> = ({
@@ -308,10 +315,16 @@ const HistoryEntryComponent: React.FC<HistoryEntryProps> = ({
   getAudioUrl,
   deleteAudio,
   retryTranscription,
+  onEntryUpdated,
 }) => {
   const { t, i18n } = useTranslation();
   const [showCopied, setShowCopied] = useState(false);
   const [retrying, setRetrying] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editText, setEditText] = useState(entry.transcription_text);
+  const [showLearnConfirm, setShowLearnConfirm] = useState(false);
+  const [learnDiffs, setLearnDiffs] = useState<CorrectionDiff[]>([]);
+  const [learning, setLearning] = useState(false);
 
   const hasTranscription = entry.transcription_text.trim().length > 0;
 
@@ -351,6 +364,55 @@ const HistoryEntryComponent: React.FC<HistoryEntryProps> = ({
     }
   };
 
+  const handleStartEdit = () => {
+    setEditText(entry.transcription_text);
+    setIsEditing(true);
+  };
+
+  const handleCancelEdit = () => {
+    setIsEditing(false);
+    setEditText(entry.transcription_text);
+  };
+
+  const handleSaveEdit = async () => {
+    if (editText === entry.transcription_text) {
+      setIsEditing(false);
+      return;
+    }
+
+    const originalText = entry.transcription_text;
+    const result = await commands.updateTranscriptionText(entry.id, editText);
+    if (result.status === "ok") {
+      onEntryUpdated(result.data);
+      const diffs = await commands.learnCorrectionsFromEdit(
+        originalText,
+        editText,
+      );
+      if (diffs.status === "ok" && diffs.data.length > 0) {
+        setLearnDiffs(diffs.data);
+        setShowLearnConfirm(true);
+      }
+      setIsEditing(false);
+    } else {
+      toast.error(t("settings.history.updateError"));
+    }
+  };
+
+  const handleConfirmLearn = async () => {
+    setLearning(true);
+    toast.success(
+      t("settings.history.learned", { count: learnDiffs.length }),
+    );
+    setShowLearnConfirm(false);
+    setLearnDiffs([]);
+    setLearning(false);
+  };
+
+  const handleDismissLearn = () => {
+    setShowLearnConfirm(false);
+    setLearnDiffs([]);
+  };
+
   const formattedDate = formatDateTime(String(entry.timestamp), i18n.language);
 
   return (
@@ -360,7 +422,7 @@ const HistoryEntryComponent: React.FC<HistoryEntryProps> = ({
         <div className="flex items-center">
           <IconButton
             onClick={handleCopyText}
-            disabled={!hasTranscription || retrying}
+            disabled={!hasTranscription || retrying || isEditing}
             title={t("settings.history.copyToClipboard")}
           >
             {showCopied ? (
@@ -371,7 +433,7 @@ const HistoryEntryComponent: React.FC<HistoryEntryProps> = ({
           </IconButton>
           <IconButton
             onClick={onToggleSaved}
-            disabled={retrying}
+            disabled={retrying || isEditing}
             active={entry.saved}
             title={
               entry.saved
@@ -385,9 +447,18 @@ const HistoryEntryComponent: React.FC<HistoryEntryProps> = ({
               fill={entry.saved ? "currentColor" : "none"}
             />
           </IconButton>
+          {!isEditing && (
+            <IconButton
+              onClick={handleStartEdit}
+              disabled={retrying || !hasTranscription}
+              title={t("settings.history.edit")}
+            >
+              <Pencil width={16} height={16} />
+            </IconButton>
+          )}
           <IconButton
             onClick={handleRetranscribe}
-            disabled={retrying}
+            disabled={retrying || isEditing}
             title={t("settings.history.retranscribe")}
           >
             <RotateCcw
@@ -402,7 +473,7 @@ const HistoryEntryComponent: React.FC<HistoryEntryProps> = ({
           </IconButton>
           <IconButton
             onClick={handleDeleteEntry}
-            disabled={retrying}
+            disabled={retrying || isEditing}
             title={t("settings.history.delete")}
           >
             <Trash2 width={16} height={16} />
@@ -410,34 +481,93 @@ const HistoryEntryComponent: React.FC<HistoryEntryProps> = ({
         </div>
       </div>
 
-      <p
-        className={`italic text-sm pb-2 ${
-          retrying
-            ? ""
+      {isEditing ? (
+        <div className="flex flex-col gap-2">
+          <textarea
+            className="w-full text-sm text-text/90 bg-background border border-mid-gray/30 rounded-lg p-3 resize-y min-h-[80px] whitespace-pre-wrap break-words focus:outline-none focus:border-logo-primary"
+            value={editText}
+            onChange={(e) => setEditText(e.target.value)}
+            autoFocus
+          />
+          <div className="flex items-center gap-2 justify-end">
+            <button
+              onClick={handleCancelEdit}
+              className="px-3 py-1.5 text-xs rounded-md border border-mid-gray/30 text-text/60 hover:text-text/90 hover:border-mid-gray/50 transition-colors cursor-pointer"
+            >
+              {t("settings.history.cancel")}
+            </button>
+            <button
+              onClick={handleSaveEdit}
+              className="px-3 py-1.5 text-xs rounded-md bg-logo-primary text-white hover:bg-logo-primary/80 transition-colors cursor-pointer"
+            >
+              {t("settings.history.saveAndLearn")}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <p
+          className={`italic text-sm pb-2 ${
+            retrying
+              ? ""
+              : hasTranscription
+                ? "text-text/90 select-text cursor-text whitespace-pre-wrap break-words"
+                : "text-text/40"
+          }`}
+          style={
+            retrying
+              ? { animation: "transcribe-pulse 3s ease-in-out infinite" }
+              : undefined
+          }
+        >
+          {retrying && (
+            <style>{`
+              @keyframes transcribe-pulse {
+                0%, 100% { color: color-mix(in srgb, var(--color-text) 40%, transparent); }
+                50% { color: color-mix(in srgb, var(--color-text) 90%, transparent); }
+              }
+            `}</style>
+          )}
+          {retrying
+            ? t("settings.history.transcribing")
             : hasTranscription
-              ? "text-text/90 select-text cursor-text whitespace-pre-wrap break-words"
-              : "text-text/40"
-        }`}
-        style={
-          retrying
-            ? { animation: "transcribe-pulse 3s ease-in-out infinite" }
-            : undefined
-        }
-      >
-        {retrying && (
-          <style>{`
-            @keyframes transcribe-pulse {
-              0%, 100% { color: color-mix(in srgb, var(--color-text) 40%, transparent); }
-              50% { color: color-mix(in srgb, var(--color-text) 90%, transparent); }
-            }
-          `}</style>
-        )}
-        {retrying
-          ? t("settings.history.transcribing")
-          : hasTranscription
-            ? entry.transcription_text
-            : t("settings.history.transcriptionFailed")}
-      </p>
+              ? entry.transcription_text
+              : t("settings.history.transcriptionFailed")}
+        </p>
+      )}
+
+      {showLearnConfirm && learnDiffs.length > 0 && (
+        <div className="border border-logo-primary/30 bg-logo-primary/5 rounded-lg p-3 flex flex-col gap-2">
+          <div className="flex items-center gap-2 text-sm font-medium text-logo-primary">
+            <Brain width={16} height={16} />
+            <span>{t("settings.history.learned", { count: learnDiffs.length })}</span>
+          </div>
+          <div className="flex flex-col gap-1 text-xs text-text/80">
+            {learnDiffs.map((diff, i) => (
+              <div key={i} className="flex items-center gap-2">
+                <span className="line-through text-red-400">{diff.original_word}</span>
+                <span className="text-text/40">{"\u2192"}</span>
+                <span className="text-green-400">{diff.corrected_word}</span>
+              </div>
+            ))}
+          </div>
+          <div className="flex items-center gap-2 justify-end">
+            <button
+              onClick={handleDismissLearn}
+              className="px-3 py-1.5 text-xs rounded-md border border-mid-gray/30 text-text/60 hover:text-text/90 transition-colors cursor-pointer"
+            >
+              {t("settings.history.dismiss")}
+            </button>
+            <button
+              onClick={handleConfirmLearn}
+              disabled={learning}
+              className="px-3 py-1.5 text-xs rounded-md bg-logo-primary text-white hover:bg-logo-primary/80 transition-colors cursor-pointer flex items-center gap-1"
+            >
+              <Brain width={12} height={12} />
+              {t("settings.history.confirm")}
+            </button>
+          </div>
+        </div>
+      )}
 
       <AudioPlayer onLoadRequest={handleLoadAudio} className="w-full" />
     </div>

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -20,6 +20,7 @@ export { HandyKeysShortcutInput } from "./HandyKeysShortcutInput";
 export { ShortcutInput } from "./ShortcutInput";
 export { TranslateToEnglish } from "./TranslateToEnglish";
 export { CustomWords } from "./CustomWords";
+export { LearnedCorrections } from "./LearnedCorrections";
 export { PostProcessingToggle } from "./PostProcessingToggle";
 export { PostProcessingSettingsApi } from "./PostProcessingSettingsApi";
 export { PostProcessingSettingsPrompts } from "./PostProcessingSettingsPrompts";

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -334,6 +334,16 @@
         "add": "إضافة",
         "remove": "إزالة {{word}}",
         "duplicate": "\"{{word}}\" موجود بالفعل"
+      },
+      "learnedCorrections": {
+        "title": "Learned Corrections",
+        "description": "Corrections learned from your edits. When you edit a transcription, the system learns to automatically fix similar mistakes in future transcriptions.",
+        "loading": "Loading corrections...",
+        "empty": "No corrections learned yet. Edit a transcription in History to teach the system.",
+        "clearAll": "Clear All",
+        "clearError": "Failed to clear corrections",
+        "cleared": "Cleared {{count}} corrections",
+        "remove": "Remove correction for {{word}}"
       }
     },
     "postProcessing": {
@@ -409,7 +419,15 @@
       "retranscribe": "إعادة النسخ",
       "retranscribeError": "فشلت إعادة النسخ. يرجى المحاولة مرة أخرى.",
       "transcribing": "جارٍ النسخ...",
-      "transcriptionFailed": "فشل النسخ. يمكنك إعادة النسخ باستخدام أيقونة إعادة المحاولة."
+      "transcriptionFailed": "فشل النسخ. يمكنك إعادة النسخ باستخدام أيقونة إعادة المحاولة.",
+      "edit": "Correct transcription",
+      "cancel": "Cancel",
+      "saveAndLearn": "Save & Learn",
+      "learned": "Learned {{count}} correction:",
+      "learned_plural": "Learned {{count}} corrections:",
+      "confirm": "Confirm",
+      "dismiss": "Dismiss",
+      "updateError": "Failed to update transcription"
     },
     "debug": {
       "title": "تصحيح الأخطاء",

--- a/src/i18n/locales/bg/translation.json
+++ b/src/i18n/locales/bg/translation.json
@@ -355,10 +355,17 @@
         "placeholder": "Добавете дума",
         "add": "Добавяне",
         "remove": "Премахване на {{word}}",
-        "duplicate": "„{{word}}“ вече съществува"
+        "duplicate": "„{{word}}“ вече съществува",
+      "learnedCorrections": {
+        "description": "Corrections learned from your edits. When you edit a transcription, the system learns to automatically fix similar mistakes in future transcriptions.",
+        "loading": "Loading corrections...",
+        "empty": "No corrections learned yet. Edit a transcription in History to teach the system.",
+        "clearAll": "Clear All",
+        "clearError": "Failed to clear corrections",
+        "cleared": "Cleared {{count}} corrections",
+        "remove": "Remove correction for {{word}}"
       }
     },
-    "postProcessing": {
       "title": "Постобработка",
       "hotkey": {
         "title": "Бърз клавиш"
@@ -431,7 +438,15 @@
       "retranscribe": "Повторна транскрипция",
       "retranscribeError": "Повторната транскрипция не бе успешна. Опитайте отново.",
       "transcribing": "Транскрибиране...",
-      "transcriptionFailed": "Транскрипцията не бе успешна. Можете да опитате отново с иконата за повторен опит."
+      "transcriptionFailed": "Транскрипцията не бе успешна. Можете да опитате отново с иконата за повторен опит.",
+      "edit": "Correct transcription",
+      "cancel": "Cancel",
+      "saveAndLearn": "Save & Learn",
+      "learned": "Learned {{count}} correction:",
+      "learned_plural": "Learned {{count}} corrections:",
+      "confirm": "Confirm",
+      "dismiss": "Dismiss",
+      "updateError": "Failed to update transcription"
     },
     "debug": {
       "title": "Отстраняване",

--- a/src/i18n/locales/cs/translation.json
+++ b/src/i18n/locales/cs/translation.json
@@ -356,6 +356,16 @@
         "add": "Přidat",
         "remove": "Odebrat {{word}}",
         "duplicate": "\"{{word}}\" již existuje"
+      },
+      "learnedCorrections": {
+        "title": "Learned Corrections",
+        "description": "Corrections learned from your edits. When you edit a transcription, the system learns to automatically fix similar mistakes in future transcriptions.",
+        "loading": "Loading corrections...",
+        "empty": "No corrections learned yet. Edit a transcription in History to teach the system.",
+        "clearAll": "Clear All",
+        "clearError": "Failed to clear corrections",
+        "cleared": "Cleared {{count}} corrections",
+        "remove": "Remove correction for {{word}}"
       }
     },
     "postProcessing": {
@@ -431,7 +441,15 @@
       "retranscribe": "Přepsat znovu",
       "retranscribeError": "Opětovný přepis se nezdařil. Zkuste to prosím znovu.",
       "transcribing": "Přepisuji...",
-      "transcriptionFailed": "Přepis selhal. Můžete zkusit přepis znovu pomocí ikony opakování."
+      "transcriptionFailed": "Přepis selhal. Můžete zkusit přepis znovu pomocí ikony opakování.",
+      "edit": "Correct transcription",
+      "cancel": "Cancel",
+      "saveAndLearn": "Save & Learn",
+      "learned": "Learned {{count}} correction:",
+      "learned_plural": "Learned {{count}} corrections:",
+      "confirm": "Confirm",
+      "dismiss": "Dismiss",
+      "updateError": "Failed to update transcription"
     },
     "debug": {
       "title": "Ladění",

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -356,6 +356,16 @@
         "add": "Hinzufügen",
         "remove": "{{word}} entfernen",
         "duplicate": "\"{{word}}\" existiert bereits"
+      },
+      "learnedCorrections": {
+        "title": "Learned Corrections",
+        "description": "Corrections learned from your edits. When you edit a transcription, the system learns to automatically fix similar mistakes in future transcriptions.",
+        "loading": "Loading corrections...",
+        "empty": "No corrections learned yet. Edit a transcription in History to teach the system.",
+        "clearAll": "Clear All",
+        "clearError": "Failed to clear corrections",
+        "cleared": "Cleared {{count}} corrections",
+        "remove": "Remove correction for {{word}}"
       }
     },
     "postProcessing": {
@@ -431,7 +441,15 @@
       "retranscribe": "Erneut transkribieren",
       "retranscribeError": "Erneute Transkription fehlgeschlagen. Bitte versuche es erneut.",
       "transcribing": "Transkribiere...",
-      "transcriptionFailed": "Transkription fehlgeschlagen. Du kannst über das Wiederholen-Symbol erneut transkribieren."
+      "transcriptionFailed": "Transkription fehlgeschlagen. Du kannst über das Wiederholen-Symbol erneut transkribieren.",
+      "edit": "Correct transcription",
+      "cancel": "Cancel",
+      "saveAndLearn": "Save & Learn",
+      "learned": "Learned {{count}} correction:",
+      "learned_plural": "Learned {{count}} corrections:",
+      "confirm": "Confirm",
+      "dismiss": "Dismiss",
+      "updateError": "Failed to update transcription"
     },
     "debug": {
       "title": "Debug",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -356,6 +356,16 @@
         "add": "Add",
         "remove": "Remove {{word}}",
         "duplicate": "\"{{word}}\" already exists"
+      },
+      "learnedCorrections": {
+        "title": "Learned Corrections",
+        "description": "Corrections learned from your edits. When you edit a transcription, the system learns to automatically fix similar mistakes in future transcriptions.",
+        "loading": "Loading corrections...",
+        "empty": "No corrections learned yet. Edit a transcription in History to teach the system.",
+        "clearAll": "Clear All",
+        "clearError": "Failed to clear corrections",
+        "cleared": "Cleared {{count}} corrections",
+        "remove": "Remove correction for {{word}}"
       }
     },
     "postProcessing": {
@@ -431,7 +441,15 @@
       "retranscribe": "Re-transcribe",
       "retranscribeError": "Failed to re-transcribe. Please try again.",
       "transcribing": "Transcribing...",
-      "transcriptionFailed": "Transcription failed. You can re-transcribe using the retry icon."
+      "transcriptionFailed": "Transcription failed. You can re-transcribe using the retry icon.",
+      "edit": "Correct transcription",
+      "cancel": "Cancel",
+      "saveAndLearn": "Save & Learn",
+      "learned": "Learned {{count}} correction:",
+      "learned_plural": "Learned {{count}} corrections:",
+      "confirm": "Confirm",
+      "dismiss": "Dismiss",
+      "updateError": "Failed to update transcription"
     },
     "debug": {
       "title": "Debug",

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -356,6 +356,16 @@
         "add": "Agregar",
         "remove": "Eliminar {{word}}",
         "duplicate": "\"{{word}}\" ya existe"
+      },
+      "learnedCorrections": {
+        "title": "Learned Corrections",
+        "description": "Corrections learned from your edits. When you edit a transcription, the system learns to automatically fix similar mistakes in future transcriptions.",
+        "loading": "Loading corrections...",
+        "empty": "No corrections learned yet. Edit a transcription in History to teach the system.",
+        "clearAll": "Clear All",
+        "clearError": "Failed to clear corrections",
+        "cleared": "Cleared {{count}} corrections",
+        "remove": "Remove correction for {{word}}"
       }
     },
     "postProcessing": {
@@ -431,7 +441,15 @@
       "retranscribe": "Re-transcribir",
       "retranscribeError": "No se pudo re-transcribir. Por favor, inténtalo de nuevo.",
       "transcribing": "Transcribiendo...",
-      "transcriptionFailed": "La transcripción falló. Puedes re-transcribir usando el ícono de reintentar."
+      "transcriptionFailed": "La transcripción falló. Puedes re-transcribir usando el ícono de reintentar.",
+      "edit": "Correct transcription",
+      "cancel": "Cancel",
+      "saveAndLearn": "Save & Learn",
+      "learned": "Learned {{count}} correction:",
+      "learned_plural": "Learned {{count}} corrections:",
+      "confirm": "Confirm",
+      "dismiss": "Dismiss",
+      "updateError": "Failed to update transcription"
     },
     "debug": {
       "title": "Depuración",

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -356,6 +356,16 @@
         "add": "Ajouter",
         "remove": "Supprimer {{word}}",
         "duplicate": "\"{{word}}\" existe déjà"
+      },
+      "learnedCorrections": {
+        "title": "Learned Corrections",
+        "description": "Corrections learned from your edits. When you edit a transcription, the system learns to automatically fix similar mistakes in future transcriptions.",
+        "loading": "Loading corrections...",
+        "empty": "No corrections learned yet. Edit a transcription in History to teach the system.",
+        "clearAll": "Clear All",
+        "clearError": "Failed to clear corrections",
+        "cleared": "Cleared {{count}} corrections",
+        "remove": "Remove correction for {{word}}"
       }
     },
     "postProcessing": {
@@ -431,7 +441,15 @@
       "retranscribe": "Re-transcrire",
       "retranscribeError": "Impossible de re-transcrire. Veuillez réessayer.",
       "transcribing": "Transcription en cours...",
-      "transcriptionFailed": "La transcription a échoué. Vous pouvez re-transcrire en utilisant l'icône de réessai."
+      "transcriptionFailed": "La transcription a échoué. Vous pouvez re-transcrire en utilisant l'icône de réessai.",
+      "edit": "Correct transcription",
+      "cancel": "Cancel",
+      "saveAndLearn": "Save & Learn",
+      "learned": "Learned {{count}} correction:",
+      "learned_plural": "Learned {{count}} corrections:",
+      "confirm": "Confirm",
+      "dismiss": "Dismiss",
+      "updateError": "Failed to update transcription"
     },
     "debug": {
       "title": "Débogage",

--- a/src/i18n/locales/he/translation.json
+++ b/src/i18n/locales/he/translation.json
@@ -356,6 +356,16 @@
         "add": "הוסף",
         "remove": "הסר את {{word}}",
         "duplicate": "\"{{word}}\" כבר קיימת"
+      },
+      "learnedCorrections": {
+        "title": "Learned Corrections",
+        "description": "Corrections learned from your edits. When you edit a transcription, the system learns to automatically fix similar mistakes in future transcriptions.",
+        "loading": "Loading corrections...",
+        "empty": "No corrections learned yet. Edit a transcription in History to teach the system.",
+        "clearAll": "Clear All",
+        "clearError": "Failed to clear corrections",
+        "cleared": "Cleared {{count}} corrections",
+        "remove": "Remove correction for {{word}}"
       }
     },
     "postProcessing": {
@@ -431,7 +441,15 @@
       "retranscribe": "תמלל מחדש",
       "retranscribeError": "תמלול מחדש נכשל. נסה שוב.",
       "transcribing": "מתמלל...",
-      "transcriptionFailed": "התמלול נכשל. אפשר לתמלל מחדש באמצעות אייקון הניסיון החוזר."
+      "transcriptionFailed": "התמלול נכשל. אפשר לתמלל מחדש באמצעות אייקון הניסיון החוזר.",
+      "edit": "Correct transcription",
+      "cancel": "Cancel",
+      "saveAndLearn": "Save & Learn",
+      "learned": "Learned {{count}} correction:",
+      "learned_plural": "Learned {{count}} corrections:",
+      "confirm": "Confirm",
+      "dismiss": "Dismiss",
+      "updateError": "Failed to update transcription"
     },
     "debug": {
       "title": "ניפוי שגיאות",

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -356,6 +356,16 @@
         "add": "Aggiungi",
         "remove": "Rimuovi {{word}}",
         "duplicate": "\"{{word}}\" esiste già"
+      },
+      "learnedCorrections": {
+        "title": "Correzioni Apprese",
+        "description": "Correzioni imparate dalle tue modifiche. Quando modifichi una trascrizione, il sistema impara a correggere automaticamente errori simili nelle trascrizioni future.",
+        "loading": "Caricamento correzioni...",
+        "empty": "Nessuna correzione appresa ancora. Modifica una trascrizione nella Cronologia per insegnare al sistema.",
+        "clearAll": "Cancella Tutto",
+        "clearError": "Impossibile cancellare le correzioni",
+        "cleared": "Cancellate {{count}} correzioni",
+        "remove": "Rimuovi correzione per {{word}}"
       }
     },
     "postProcessing": {
@@ -431,7 +441,15 @@
       "retranscribe": "Ri-trascrivere",
       "retranscribeError": "Impossibile ri-trascrivere. Riprova.",
       "transcribing": "Trascrizione in corso...",
-      "transcriptionFailed": "Trascrizione fallita. Puoi ri-trascrivere usando l'icona di ripetizione."
+      "transcriptionFailed": "Trascrizione fallita. Puoi ri-trascrivere usando l'icona di ripetizione.",
+      "edit": "Correggi trascrizione",
+      "cancel": "Annulla",
+      "saveAndLearn": "Salva e Impara",
+      "learned": "Imparata {{count}} correzione:",
+      "learned_plural": "Imparate {{count}} correzioni:",
+      "confirm": "Conferma",
+      "dismiss": "Ignora",
+      "updateError": "Impossibile aggiornare la trascrizione"
     },
     "debug": {
       "title": "Debug",

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -356,6 +356,16 @@
         "add": "追加",
         "remove": "{{word}}を削除",
         "duplicate": "「{{word}}」は既に存在します"
+      },
+      "learnedCorrections": {
+        "title": "Learned Corrections",
+        "description": "Corrections learned from your edits. When you edit a transcription, the system learns to automatically fix similar mistakes in future transcriptions.",
+        "loading": "Loading corrections...",
+        "empty": "No corrections learned yet. Edit a transcription in History to teach the system.",
+        "clearAll": "Clear All",
+        "clearError": "Failed to clear corrections",
+        "cleared": "Cleared {{count}} corrections",
+        "remove": "Remove correction for {{word}}"
       }
     },
     "postProcessing": {
@@ -431,7 +441,15 @@
       "retranscribe": "再文字起こし",
       "retranscribeError": "再文字起こしに失敗しました。もう一度お試しください。",
       "transcribing": "文字起こし中...",
-      "transcriptionFailed": "文字起こしに失敗しました。リトライアイコンを使用して再文字起こしできます。"
+      "transcriptionFailed": "文字起こしに失敗しました。リトライアイコンを使用して再文字起こしできます。",
+      "edit": "Correct transcription",
+      "cancel": "Cancel",
+      "saveAndLearn": "Save & Learn",
+      "learned": "Learned {{count}} correction:",
+      "learned_plural": "Learned {{count}} corrections:",
+      "confirm": "Confirm",
+      "dismiss": "Dismiss",
+      "updateError": "Failed to update transcription"
     },
     "debug": {
       "title": "デバッグ",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -356,6 +356,16 @@
         "add": "추가",
         "remove": "{{word}} 제거",
         "duplicate": "\"{{word}}\"이(가) 이미 존재합니다"
+      },
+      "learnedCorrections": {
+        "title": "Learned Corrections",
+        "description": "Corrections learned from your edits. When you edit a transcription, the system learns to automatically fix similar mistakes in future transcriptions.",
+        "loading": "Loading corrections...",
+        "empty": "No corrections learned yet. Edit a transcription in History to teach the system.",
+        "clearAll": "Clear All",
+        "clearError": "Failed to clear corrections",
+        "cleared": "Cleared {{count}} corrections",
+        "remove": "Remove correction for {{word}}"
       }
     },
     "postProcessing": {
@@ -431,7 +441,15 @@
       "retranscribe": "다시 전사",
       "retranscribeError": "다시 전사에 실패했습니다. 다시 시도해주세요.",
       "transcribing": "전사 중...",
-      "transcriptionFailed": "전사에 실패했습니다. 재시도 아이콘을 사용하여 다시 전사할 수 있습니다."
+      "transcriptionFailed": "전사에 실패했습니다. 재시도 아이콘을 사용하여 다시 전사할 수 있습니다.",
+      "edit": "Correct transcription",
+      "cancel": "Cancel",
+      "saveAndLearn": "Save & Learn",
+      "learned": "Learned {{count}} correction:",
+      "learned_plural": "Learned {{count}} corrections:",
+      "confirm": "Confirm",
+      "dismiss": "Dismiss",
+      "updateError": "Failed to update transcription"
     },
     "debug": {
       "title": "디버그",

--- a/src/i18n/locales/pl/translation.json
+++ b/src/i18n/locales/pl/translation.json
@@ -356,6 +356,16 @@
         "add": "Dodaj",
         "remove": "Usuń {{word}}",
         "duplicate": "\"{{word}}\" już istnieje"
+      },
+      "learnedCorrections": {
+        "title": "Learned Corrections",
+        "description": "Corrections learned from your edits. When you edit a transcription, the system learns to automatically fix similar mistakes in future transcriptions.",
+        "loading": "Loading corrections...",
+        "empty": "No corrections learned yet. Edit a transcription in History to teach the system.",
+        "clearAll": "Clear All",
+        "clearError": "Failed to clear corrections",
+        "cleared": "Cleared {{count}} corrections",
+        "remove": "Remove correction for {{word}}"
       }
     },
     "postProcessing": {
@@ -431,7 +441,15 @@
       "retranscribe": "Transkrybuj ponownie",
       "retranscribeError": "Nie udało się ponownie transkrybować. Spróbuj ponownie.",
       "transcribing": "Transkrybuję...",
-      "transcriptionFailed": "Transkrypcja nie powiodła się. Możesz transkrybować ponownie za pomocą ikony ponowienia."
+      "transcriptionFailed": "Transkrypcja nie powiodła się. Możesz transkrybować ponownie za pomocą ikony ponowienia.",
+      "edit": "Correct transcription",
+      "cancel": "Cancel",
+      "saveAndLearn": "Save & Learn",
+      "learned": "Learned {{count}} correction:",
+      "learned_plural": "Learned {{count}} corrections:",
+      "confirm": "Confirm",
+      "dismiss": "Dismiss",
+      "updateError": "Failed to update transcription"
     },
     "debug": {
       "title": "Debugowanie",

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -356,6 +356,16 @@
         "add": "Adicionar",
         "remove": "Remover {{word}}",
         "duplicate": "\"{{word}}\" já existe"
+      },
+      "learnedCorrections": {
+        "title": "Learned Corrections",
+        "description": "Corrections learned from your edits. When you edit a transcription, the system learns to automatically fix similar mistakes in future transcriptions.",
+        "loading": "Loading corrections...",
+        "empty": "No corrections learned yet. Edit a transcription in History to teach the system.",
+        "clearAll": "Clear All",
+        "clearError": "Failed to clear corrections",
+        "cleared": "Cleared {{count}} corrections",
+        "remove": "Remove correction for {{word}}"
       }
     },
     "postProcessing": {
@@ -431,7 +441,15 @@
       "retranscribe": "Re-transcrever",
       "retranscribeError": "Falha ao re-transcrever. Por favor, tente novamente.",
       "transcribing": "Transcrevendo...",
-      "transcriptionFailed": "A transcrição falhou. Você pode re-transcrever usando o ícone de tentar novamente."
+      "transcriptionFailed": "A transcrição falhou. Você pode re-transcrever usando o ícone de tentar novamente.",
+      "edit": "Correct transcription",
+      "cancel": "Cancel",
+      "saveAndLearn": "Save & Learn",
+      "learned": "Learned {{count}} correction:",
+      "learned_plural": "Learned {{count}} corrections:",
+      "confirm": "Confirm",
+      "dismiss": "Dismiss",
+      "updateError": "Failed to update transcription"
     },
     "debug": {
       "title": "Depuração",

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -356,6 +356,16 @@
         "add": "Добавить",
         "remove": "Удалить {{word}}",
         "duplicate": "\"{{word}}\" уже существует"
+      },
+      "learnedCorrections": {
+        "title": "Learned Corrections",
+        "description": "Corrections learned from your edits. When you edit a transcription, the system learns to automatically fix similar mistakes in future transcriptions.",
+        "loading": "Loading corrections...",
+        "empty": "No corrections learned yet. Edit a transcription in History to teach the system.",
+        "clearAll": "Clear All",
+        "clearError": "Failed to clear corrections",
+        "cleared": "Cleared {{count}} corrections",
+        "remove": "Remove correction for {{word}}"
       }
     },
     "postProcessing": {
@@ -431,7 +441,15 @@
       "retranscribe": "Перетранскрибировать",
       "retranscribeError": "Не удалось перетранскрибировать. Пожалуйста, попробуйте снова.",
       "transcribing": "Транскрибирование...",
-      "transcriptionFailed": "Транскрипция не удалась. Вы можете перетранскрибировать, используя значок повтора."
+      "transcriptionFailed": "Транскрипция не удалась. Вы можете перетранскрибировать, используя значок повтора.",
+      "edit": "Correct transcription",
+      "cancel": "Cancel",
+      "saveAndLearn": "Save & Learn",
+      "learned": "Learned {{count}} correction:",
+      "learned_plural": "Learned {{count}} corrections:",
+      "confirm": "Confirm",
+      "dismiss": "Dismiss",
+      "updateError": "Failed to update transcription"
     },
     "debug": {
       "title": "Отлаживать",

--- a/src/i18n/locales/sv/translation.json
+++ b/src/i18n/locales/sv/translation.json
@@ -356,6 +356,16 @@
         "add": "Lägg till",
         "remove": "Ta bort {{word}}",
         "duplicate": "\"{{word}}\" finns redan"
+      },
+      "learnedCorrections": {
+        "title": "Learned Corrections",
+        "description": "Corrections learned from your edits. When you edit a transcription, the system learns to automatically fix similar mistakes in future transcriptions.",
+        "loading": "Loading corrections...",
+        "empty": "No corrections learned yet. Edit a transcription in History to teach the system.",
+        "clearAll": "Clear All",
+        "clearError": "Failed to clear corrections",
+        "cleared": "Cleared {{count}} corrections",
+        "remove": "Remove correction for {{word}}"
       }
     },
     "postProcessing": {
@@ -431,7 +441,15 @@
       "retranscribe": "Transkribera igen",
       "retranscribeError": "Misslyckades med att transkribera igen. Försök igen.",
       "transcribing": "Transkriberar...",
-      "transcriptionFailed": "Transkribering misslyckades. Du kan transkribera igen med hjälp av ikonen för nytt försök."
+      "transcriptionFailed": "Transkribering misslyckades. Du kan transkribera igen med hjälp av ikonen för nytt försök.",
+      "edit": "Correct transcription",
+      "cancel": "Cancel",
+      "saveAndLearn": "Save & Learn",
+      "learned": "Learned {{count}} correction:",
+      "learned_plural": "Learned {{count}} corrections:",
+      "confirm": "Confirm",
+      "dismiss": "Dismiss",
+      "updateError": "Failed to update transcription"
     },
     "debug": {
       "title": "Felsökning",

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -356,6 +356,16 @@
         "add": "Ekle",
         "remove": "{{word}} Kaldır",
         "duplicate": "\"{{word}}\" zaten mevcut"
+      },
+      "learnedCorrections": {
+        "title": "Learned Corrections",
+        "description": "Corrections learned from your edits. When you edit a transcription, the system learns to automatically fix similar mistakes in future transcriptions.",
+        "loading": "Loading corrections...",
+        "empty": "No corrections learned yet. Edit a transcription in History to teach the system.",
+        "clearAll": "Clear All",
+        "clearError": "Failed to clear corrections",
+        "cleared": "Cleared {{count}} corrections",
+        "remove": "Remove correction for {{word}}"
       }
     },
     "postProcessing": {
@@ -431,7 +441,15 @@
       "retranscribe": "Yeniden yazıya dök",
       "retranscribeError": "Yeniden yazıya dökme başarısız oldu. Lütfen tekrar deneyin.",
       "transcribing": "Yazıya döküyor...",
-      "transcriptionFailed": "Transkripsiyon başarısız oldu. Yeniden deneme simgesini kullanarak tekrar yazıya dökebilirsiniz."
+      "transcriptionFailed": "Transkripsiyon başarısız oldu. Yeniden deneme simgesini kullanarak tekrar yazıya dökebilirsiniz.",
+      "edit": "Correct transcription",
+      "cancel": "Cancel",
+      "saveAndLearn": "Save & Learn",
+      "learned": "Learned {{count}} correction:",
+      "learned_plural": "Learned {{count}} corrections:",
+      "confirm": "Confirm",
+      "dismiss": "Dismiss",
+      "updateError": "Failed to update transcription"
     },
     "debug": {
       "title": "Hata Ayıklama",

--- a/src/i18n/locales/uk/translation.json
+++ b/src/i18n/locales/uk/translation.json
@@ -356,6 +356,16 @@
         "add": "Додати",
         "remove": "Видалити {{word}}",
         "duplicate": "\"{{word}}\" вже існує"
+      },
+      "learnedCorrections": {
+        "title": "Learned Corrections",
+        "description": "Corrections learned from your edits. When you edit a transcription, the system learns to automatically fix similar mistakes in future transcriptions.",
+        "loading": "Loading corrections...",
+        "empty": "No corrections learned yet. Edit a transcription in History to teach the system.",
+        "clearAll": "Clear All",
+        "clearError": "Failed to clear corrections",
+        "cleared": "Cleared {{count}} corrections",
+        "remove": "Remove correction for {{word}}"
       }
     },
     "postProcessing": {
@@ -431,7 +441,15 @@
       "retranscribe": "Перетранскрибувати",
       "retranscribeError": "Не вдалося перетранскрибувати. Будь ласка, спробуйте ще раз.",
       "transcribing": "Транскрибування...",
-      "transcriptionFailed": "Транскрипція не вдалася. Ви можете перетранскрибувати за допомогою іконки повтору."
+      "transcriptionFailed": "Транскрипція не вдалася. Ви можете перетранскрибувати за допомогою іконки повтору.",
+      "edit": "Correct transcription",
+      "cancel": "Cancel",
+      "saveAndLearn": "Save & Learn",
+      "learned": "Learned {{count}} correction:",
+      "learned_plural": "Learned {{count}} corrections:",
+      "confirm": "Confirm",
+      "dismiss": "Dismiss",
+      "updateError": "Failed to update transcription"
     },
     "debug": {
       "title": "Дебаг",

--- a/src/i18n/locales/vi/translation.json
+++ b/src/i18n/locales/vi/translation.json
@@ -356,6 +356,16 @@
         "add": "Thêm",
         "remove": "Xóa {{word}}",
         "duplicate": "\"{{word}}\" đã tồn tại"
+      },
+      "learnedCorrections": {
+        "title": "Learned Corrections",
+        "description": "Corrections learned from your edits. When you edit a transcription, the system learns to automatically fix similar mistakes in future transcriptions.",
+        "loading": "Loading corrections...",
+        "empty": "No corrections learned yet. Edit a transcription in History to teach the system.",
+        "clearAll": "Clear All",
+        "clearError": "Failed to clear corrections",
+        "cleared": "Cleared {{count}} corrections",
+        "remove": "Remove correction for {{word}}"
       }
     },
     "postProcessing": {
@@ -431,7 +441,15 @@
       "retranscribe": "Phiên âm lại",
       "retranscribeError": "Không thể phiên âm lại. Vui lòng thử lại.",
       "transcribing": "Đang phiên âm...",
-      "transcriptionFailed": "Phiên âm thất bại. Bạn có thể phiên âm lại bằng biểu tượng thử lại."
+      "transcriptionFailed": "Phiên âm thất bại. Bạn có thể phiên âm lại bằng biểu tượng thử lại.",
+      "edit": "Correct transcription",
+      "cancel": "Cancel",
+      "saveAndLearn": "Save & Learn",
+      "learned": "Learned {{count}} correction:",
+      "learned_plural": "Learned {{count}} corrections:",
+      "confirm": "Confirm",
+      "dismiss": "Dismiss",
+      "updateError": "Failed to update transcription"
     },
     "debug": {
       "title": "Gỡ lỗi",

--- a/src/i18n/locales/zh-TW/translation.json
+++ b/src/i18n/locales/zh-TW/translation.json
@@ -356,6 +356,16 @@
         "add": "新增",
         "remove": "刪除 {{word}}",
         "duplicate": "「{{word}}」已存在"
+      },
+      "learnedCorrections": {
+        "title": "Learned Corrections",
+        "description": "Corrections learned from your edits. When you edit a transcription, the system learns to automatically fix similar mistakes in future transcriptions.",
+        "loading": "Loading corrections...",
+        "empty": "No corrections learned yet. Edit a transcription in History to teach the system.",
+        "clearAll": "Clear All",
+        "clearError": "Failed to clear corrections",
+        "cleared": "Cleared {{count}} corrections",
+        "remove": "Remove correction for {{word}}"
       }
     },
     "postProcessing": {
@@ -431,7 +441,15 @@
       "retranscribe": "重新轉錄",
       "retranscribeError": "重新轉錄失敗，請重試。",
       "transcribing": "轉錄中...",
-      "transcriptionFailed": "轉錄失敗。您可以使用重試圖示重新轉錄。"
+      "transcriptionFailed": "轉錄失敗。您可以使用重試圖示重新轉錄。",
+      "edit": "Correct transcription",
+      "cancel": "Cancel",
+      "saveAndLearn": "Save & Learn",
+      "learned": "Learned {{count}} correction:",
+      "learned_plural": "Learned {{count}} corrections:",
+      "confirm": "Confirm",
+      "dismiss": "Dismiss",
+      "updateError": "Failed to update transcription"
     },
     "debug": {
       "title": "偵錯",

--- a/src/i18n/locales/zh/translation.json
+++ b/src/i18n/locales/zh/translation.json
@@ -356,6 +356,16 @@
         "add": "添加",
         "remove": "删除 {{word}}",
         "duplicate": "\"{{word}}\" 已存在"
+      },
+      "learnedCorrections": {
+        "title": "Learned Corrections",
+        "description": "Corrections learned from your edits. When you edit a transcription, the system learns to automatically fix similar mistakes in future transcriptions.",
+        "loading": "Loading corrections...",
+        "empty": "No corrections learned yet. Edit a transcription in History to teach the system.",
+        "clearAll": "Clear All",
+        "clearError": "Failed to clear corrections",
+        "cleared": "Cleared {{count}} corrections",
+        "remove": "Remove correction for {{word}}"
       }
     },
     "postProcessing": {
@@ -431,7 +441,15 @@
       "retranscribe": "重新转录",
       "retranscribeError": "重新转录失败。请重试。",
       "transcribing": "转录中...",
-      "transcriptionFailed": "转录失败。您可以使用重试图标重新转录。"
+      "transcriptionFailed": "转录失败。您可以使用重试图标重新转录。",
+      "edit": "Correct transcription",
+      "cancel": "Cancel",
+      "saveAndLearn": "Save & Learn",
+      "learned": "Learned {{count}} correction:",
+      "learned_plural": "Learned {{count}} corrections:",
+      "confirm": "Confirm",
+      "dismiss": "Dismiss",
+      "updateError": "Failed to update transcription"
     },
     "debug": {
       "title": "调试",


### PR DESCRIPTION
## Summary

Add a **self-learning transcription corrections** system that allows Handy to automatically learn from user-edited transcriptions and apply those corrections to future transcriptions in real-time via fast word-level regex matching.

## What's New

### Backend (Rust/Tauri)
- **`CorrectionsManager`** (`src-tauri/src/managers/corrections.rs`): manages learned corrections in SQLite DB with:
  - `learn_from_diff_llm()` — uses the configured LLM provider to intelligently extract STT error corrections from user edits, producing high-quality learned patterns
  - Automatic fallback to positional word diff when no LLM provider is configured
  - `apply_corrections()` — applies saved corrections via fast regex matching (zero API cost at transcription time)
  - Full CRUD: get, delete individual, clear all corrections
- **DB migration #5**: new `learned_corrections` table with word mappings, frequency count, and timestamps
- **5 new Tauri commands**: `update_transcription_text`, `learn_corrections_from_edit`, `get_learned_corrections`, `delete_learned_correction`, `clear_learned_corrections`
- **Pipeline integration**: corrections are applied BEFORE post-processing LLM to reduce token usage

### Frontend (React/TypeScript)
- **History edit UI**: pencil button relabeled to "Correct transcription" with inline text editing, diff confirmation popup showing what was learned (brain icon with wrong to correct pairs)
- **`LearnedCorrections` component**: new settings panel to view, manage, and delete learned corrections from Advanced Settings
- **Full i18n support**: all new strings translated across all 20 supported languages
- **History card tooltip**: hover preview of transcription text on history cards

## Value Added

- **Gets smarter over time**: every user correction teaches the app to avoid repeating the same STT mistakes
- **LLM-powered extraction**: avoids false positives from naive positional diffing, producing higher quality learned patterns compared to simple word-by-word comparison
- **Zero-cost at transcription time**: learned corrections apply via regex matching without any API calls
- **Full user control**: view, delete individual corrections, or clear all from settings
- **Automatic behavior**: no configuration needed — uses existing LLM provider if configured, otherwise falls back gracefully

## Files Changed
- `src-tauri/src/managers/corrections.rs` (new)
- `src-tauri/src/managers/history.rs` (migration #5, update_transcription_text)
- `src-tauri/src/commands/history.rs` (5 new commands)
- `src-tauri/src/actions.rs` (pipeline integration)
- `src-tauri/src/lib.rs` (state + command registration)
- `src/components/settings/LearnedCorrections.tsx` (new)
- `src/components/settings/history/HistorySettings.tsx` (edit UI)
- `src/components/settings/advanced/AdvancedSettings.tsx`
- `src/bindings.ts` (TypeScript bindings)
- 20 i18n locale files
