### PR TITLE
refactor(nix): drop redundant LD_LIBRARY_PATH wrapper prefix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -169,12 +169,6 @@
               gappsWrapperArgs+=(
                 --set WEBKIT_DISABLE_DMABUF_RENDERER 1
                 --set ALSA_PLUGIN_DIR "${combinedAlsaPlugins}"
-                --prefix LD_LIBRARY_PATH : "${
-                  lib.makeLibraryPath [
-                    pkgs.vulkan-loader
-                    pkgs.onnxruntime
-                  ]
-                }"
               )
             '';
 


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Human Written Description

While reviewing the nixpkgs package for Handy (NixOS/nixpkgs#507754), I noticed that the `--prefix LD_LIBRARY_PATH` in our wrapper is redundant — both `vulkan-loader` and `onnxruntime` are already picked up via stdenv's auto-rpath. Backporting the same simplification to our `flake.nix`.

## Related Issues/Discussions

Related: NixOS/nixpkgs#507754 (the same redundancy was spotted there during package review).

## Testing

Built locally on NixOS x86_64-linux:

- `nix build .#handy` — clean build
- `patchelf --print-rpath /nix/store/<hash>-handy/bin/.handy-wrapped` — both `vulkan-loader` and `onnxruntime` paths remain present after removing the `--prefix LD_LIBRARY_PATH`
- End-to-end test from the wrapped binary: microphone capture via PipeWire ALSA, Whisper Large v3 turbo on Vulkan GPU backend (log: `whisper_backend_init_gpu: using Vulkan0 backend`), GigaAM v3 via onnxruntime, paste via dotool — all working

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Opus 4.7)
- How extensively: Verified via `patchelf --print-rpath` that both paths are picked up via auto-rpath, drafted the code change.