### PR TITLE
  fix(linux): wayland paste reliability + post-process transcript loss

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -57,10 +57,23 @@ fn strip_invisible_chars(s: &str) -> String {
     s.replace(['\u{200B}', '\u{200C}', '\u{200D}', '\u{FEFF}'], "")
 }
 
-/// Build a system prompt from the user's prompt template.
-/// Removes `${output}` placeholder since the transcription is sent as the user message.
-fn build_system_prompt(prompt_template: &str) -> String {
-    prompt_template.replace("${output}", "").trim().to_string()
+/// Substitute the transcript into the user's prompt template.
+///
+/// If the template contains the `${output}` placeholder, the transcript is spliced in at
+/// that position so the prompt reaches the model exactly as the author laid it out.
+/// If the placeholder is absent, the transcript is appended under a labelled delimiter
+/// so it can't be silently dropped.
+///
+/// Why: previously the structured-output path stripped `${output}` and sent the transcript
+/// as a separate user message. That left a dangling trailing header (e.g. "Transcript:")
+/// in the system prompt, and several models interpreted the dangling header as empty
+/// input and replied asking the user to provide the transcript.
+fn render_prompt_with_transcript(prompt_template: &str, transcription: &str) -> String {
+    if prompt_template.contains("${output}") {
+        prompt_template.replace("${output}", transcription)
+    } else {
+        format!("{}\n\nTranscript:\n{}", prompt_template.trim(), transcription)
+    }
 }
 
 async fn post_process_transcription(settings: &AppSettings, transcription: &str) -> Option<String> {
@@ -144,10 +157,9 @@ async fn post_process_transcription(settings: &AppSettings, transcription: &str)
     if provider.supports_structured_output {
         debug!("Using structured outputs for provider '{}'", provider.id);
 
-        let system_prompt = build_system_prompt(&prompt);
-        let user_content = transcription.to_string();
-
-        // Handle Apple Intelligence separately since it uses native Swift APIs
+        // Handle Apple Intelligence separately since it uses native Swift APIs.
+        // The native Foundation Models API takes system instructions and user content
+        // as distinct parameters, so we keep the split there.
         if provider.id == APPLE_INTELLIGENCE_PROVIDER_ID {
             #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
             {
@@ -158,6 +170,8 @@ async fn post_process_transcription(settings: &AppSettings, transcription: &str)
                     return None;
                 }
 
+                let system_prompt = prompt.replace("${output}", "").trim().to_string();
+                let user_content = transcription.to_string();
                 let token_limit = model.trim().parse::<i32>().unwrap_or(0);
                 return match apple_intelligence::process_text_with_system_prompt(
                     &system_prompt,
@@ -204,12 +218,18 @@ async fn post_process_transcription(settings: &AppSettings, transcription: &str)
             "additionalProperties": false
         });
 
+        // Inline the transcript into the template (the layout the prompt author wrote)
+        // and send as a single user message. Splitting template/transcript across
+        // system+user messages caused some models to treat the transcript as empty
+        // when the template ended in a placeholder header like "Transcript:".
+        let user_content = render_prompt_with_transcript(&prompt, transcription);
+
         match crate::llm_client::send_chat_completion_with_schema(
             &provider,
             api_key.clone(),
             &model,
             user_content,
-            Some(system_prompt),
+            None,
             Some(json_schema),
             reasoning_effort.clone(),
             reasoning.clone(),
@@ -258,8 +278,9 @@ async fn post_process_transcription(settings: &AppSettings, transcription: &str)
         }
     }
 
-    // Legacy mode: Replace ${output} variable in the prompt with the actual text
-    let processed_prompt = prompt.replace("${output}", transcription);
+    // Legacy mode: inline the transcript into the template (and append it under a
+    // labelled delimiter if the template has no ${output} placeholder).
+    let processed_prompt = render_prompt_with_transcript(&prompt, transcription);
     debug!("Processed prompt length: {} chars", processed_prompt.len());
 
     match crate::llm_client::send_chat_completion(

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -1,9 +1,9 @@
 use crate::input::{self, EnigoState};
 #[cfg(target_os = "linux")]
 use crate::settings::TypingTool;
-use crate::settings::{get_settings, AutoSubmitKey, ClipboardHandling, PasteMethod};
+use crate::settings::{get_settings, AppSettings, AutoSubmitKey, ClipboardHandling, PasteMethod};
 use enigo::{Direction, Enigo, Key, Keyboard};
-use log::info;
+use log::{error, info, warn};
 use std::process::Command;
 use std::time::Duration;
 use tauri::{AppHandle, Manager};
@@ -300,9 +300,13 @@ fn type_text_via_wtype(text: &str) -> Result<(), String> {
 /// Type text directly via xdotool on X11.
 #[cfg(target_os = "linux")]
 fn type_text_via_xdotool(text: &str) -> Result<(), String> {
+    // xdotool defaults to a 12ms inter-key delay, which makes long transcripts
+    // type out visibly slow. Set it to 0 for snappier output.
     let output = Command::new("xdotool")
         .arg("type")
         .arg("--clearmodifiers")
+        .arg("--delay")
+        .arg("0")
         .arg("--")
         .arg(text)
         .output()
@@ -348,8 +352,12 @@ fn type_text_via_dotool(text: &str) -> Result<(), String> {
 /// Type text directly via ydotool (uinput-based, requires ydotoold daemon).
 #[cfg(target_os = "linux")]
 fn type_text_via_ydotool(text: &str) -> Result<(), String> {
+    // ydotool defaults to a 12ms inter-key delay, which makes long transcripts
+    // type out visibly slow. Set it to 0 — the uinput path is fast enough.
     let output = Command::new("ydotool")
         .arg("type")
+        .arg("--key-delay")
+        .arg("0")
         .arg("--")
         .arg(text)
         .output()
@@ -588,6 +596,43 @@ fn should_send_auto_submit(auto_submit: bool, paste_method: PasteMethod) -> bool
     auto_submit && paste_method != PasteMethod::None
 }
 
+/// Run one paste attempt. Factored out of `paste()` so we can retry against a
+/// freshly-recreated Enigo on failure (recovers from stale libei sessions on Wayland).
+fn run_paste_action(
+    enigo: &mut Enigo,
+    text: &str,
+    app_handle: &AppHandle,
+    paste_method: PasteMethod,
+    paste_delay_ms: u64,
+    settings: &AppSettings,
+) -> Result<(), String> {
+    match paste_method {
+        PasteMethod::None => {
+            info!("PasteMethod::None selected - skipping paste action");
+        }
+        PasteMethod::Direct => {
+            paste_direct(
+                enigo,
+                text,
+                #[cfg(target_os = "linux")]
+                settings.typing_tool,
+            )?;
+        }
+        PasteMethod::CtrlV | PasteMethod::CtrlShiftV | PasteMethod::ShiftInsert => {
+            paste_via_clipboard(enigo, text, app_handle, &paste_method, paste_delay_ms)?
+        }
+        PasteMethod::ExternalScript => {
+            let script_path = settings
+                .external_script_path
+                .as_ref()
+                .filter(|p| !p.is_empty())
+                .ok_or("External script path is not configured")?;
+            paste_via_external_script(text, script_path)?;
+        }
+    }
+    Ok(())
+}
+
 pub fn paste(text: String, app_handle: AppHandle) -> Result<(), String> {
     let settings = get_settings(&app_handle);
     let paste_method = settings.paste_method;
@@ -605,49 +650,64 @@ pub fn paste(text: String, app_handle: AppHandle) -> Result<(), String> {
         paste_method, paste_delay_ms
     );
 
-    // Get the managed Enigo instance
     let enigo_state = app_handle
         .try_state::<EnigoState>()
         .ok_or("Enigo state not initialized")?;
-    let mut enigo = enigo_state
-        .0
-        .lock()
-        .map_err(|e| format!("Failed to lock Enigo: {}", e))?;
 
-    // Perform the paste operation
-    match paste_method {
-        PasteMethod::None => {
-            info!("PasteMethod::None selected - skipping paste action");
-        }
-        PasteMethod::Direct => {
-            paste_direct(
-                &mut enigo,
-                &text,
-                #[cfg(target_os = "linux")]
-                settings.typing_tool,
-            )?;
-        }
-        PasteMethod::CtrlV | PasteMethod::CtrlShiftV | PasteMethod::ShiftInsert => {
-            paste_via_clipboard(
-                &mut enigo,
-                &text,
-                &app_handle,
-                &paste_method,
-                paste_delay_ms,
-            )?
-        }
-        PasteMethod::ExternalScript => {
-            let script_path = settings
-                .external_script_path
-                .as_ref()
-                .filter(|p| !p.is_empty())
-                .ok_or("External script path is not configured")?;
-            paste_via_external_script(&text, script_path)?;
+    // Try the paste once. If Enigo returns an error, the libei portal session
+    // may have died (common on Wayland after suspend/resume or compositor restart).
+    // Drop the lock, rebuild the Enigo instance, and retry once before giving up.
+    let first_attempt = {
+        let mut enigo = enigo_state
+            .0
+            .lock()
+            .map_err(|e| format!("Failed to lock Enigo: {}", e))?;
+        run_paste_action(
+            &mut enigo,
+            &text,
+            &app_handle,
+            paste_method,
+            paste_delay_ms,
+            &settings,
+        )
+    };
+
+    if let Err(e) = first_attempt {
+        warn!(
+            "Paste failed: {} — reconnecting Enigo and retrying once",
+            e
+        );
+        match enigo_state.reconnect() {
+            Ok(()) => {
+                let mut enigo = enigo_state
+                    .0
+                    .lock()
+                    .map_err(|le| format!("Failed to lock Enigo after reconnect: {}", le))?;
+                run_paste_action(
+                    &mut enigo,
+                    &text,
+                    &app_handle,
+                    paste_method,
+                    paste_delay_ms,
+                    &settings,
+                )?;
+            }
+            Err(reconnect_err) => {
+                error!(
+                    "Failed to reconnect Enigo: {} (original paste error: {})",
+                    reconnect_err, e
+                );
+                return Err(e);
+            }
         }
     }
 
     if should_send_auto_submit(settings.auto_submit, paste_method) {
         std::thread::sleep(Duration::from_millis(50));
+        let mut enigo = enigo_state
+            .0
+            .lock()
+            .map_err(|e| format!("Failed to lock Enigo for auto-submit: {}", e))?;
         send_return_key(&mut enigo, settings.auto_submit_key)?;
     }
 

--- a/src-tauri/src/input.rs
+++ b/src-tauri/src/input.rs
@@ -12,6 +12,24 @@ impl EnigoState {
             .map_err(|e| format!("Failed to initialize Enigo: {}", e))?;
         Ok(Self(Mutex::new(enigo)))
     }
+
+    /// Rebuild the inner Enigo instance.
+    ///
+    /// Why: on Wayland (especially GNOME mutter) Enigo holds a libei session via
+    /// xdg-desktop-portal RemoteDesktop. That session can go dead after compositor
+    /// restarts, suspend/resume, or screen-lock — after which `enigo.text(...)` and
+    /// `enigo.key(...)` either return errors or silently no-op for the rest of the
+    /// app's lifetime. Recreating the instance reopens the portal session.
+    pub fn reconnect(&self) -> Result<(), String> {
+        let new_enigo = Enigo::new(&Settings::default())
+            .map_err(|e| format!("Failed to reinitialize Enigo: {}", e))?;
+        let mut guard = self
+            .0
+            .lock()
+            .map_err(|e| format!("Failed to lock Enigo for reconnect: {}", e))?;
+        *guard = new_enigo;
+        Ok(())
+    }
 }
 
 /// Get the current mouse cursor position using the managed Enigo instance.


### PR DESCRIPTION
I just upgraded to Ubuntu 26.04 and I wanted to run Handy. However pasting was unreliable using Ctrl+Shift+V, so I decided to figure out why. Also my OpenRouter LLM kept asking to provide copy of transcript. I figured out Wayland was causing issues so I looked into that on paste. I also decided to look at the pipeline for LLM processing and made the changes needed there.

## Related Issues/Discussions

Fixes #1261 — *Post-processing often misbehaves due to prompt injection by the spoken utterance*. The reporter's repro ("'What do you think about this?'" → "'Please provide the transcript you would like me to clean'") is exactly the failure mode this PR addresses. The mechanism isn't really prompt injection — it's `build_system_prompt` stripping `${output}` and leaving a dangling `Transcript:` header in the system message, which several model families read as "field is empty."

Fixes #1130 — *Why does Handy types so slow?*. Closed without a code change, but a comment on the issue correctly identified the cause (xdotool's default 12ms inter-key delay). Same applies to ydotool. Fixed here for both.

Also closely related: #1201 — *Post-processing returns LLM system instructions instead of cleaned transcript*. Closed as user error / "use a different model," but in retrospect that was the same root cause as #1261. Not re-opening, just flagging that this PR fixes that report's case too.

## Community Feedback

Both #1261 and #1130 are user-reported bug reports with clear repros. 

## What this PR does

This PR fixes three independent bugs that surface reliably on Linux/Wayland — confirmed on Ubuntu 26.04 + GNOME mutter, though the fixes are general and benefit any Linux user.

### 1. Post-processor returns "Please provide the transcript" instead of the cleaned text

**Symptom (per #1261, #1201):** with post-processing enabled and the default "Improve Transcriptions" prompt, the transcribed dictation is sometimes never seen by the LLM. The LLM responds with something like *"Please provide the transcript you'd like me to clean up"* and that response is pasted into the focused window. Reproduces most reliably with short utterances (1–3 words) and with smaller/less-aligned models on OpenRouter, local OpenAI-compatible servers, Gemini, etc.

**Root cause:** the structured-output path in `actions.rs::post_process_transcription` stripped `${output}` from the prompt template via `build_system_prompt`, used the result as a *system* message, and sent the transcript in a *separate user* message. The default prompt template (`settings.rs::default_post_process_prompts`) ends in:

```
Transcript:
${output}
```

After the placeholder strip, the system message ends with a dangling `Transcript:` header and no content underneath. Several model families read that as "the transcript field is empty" and respond by asking for input. Because the response is valid JSON against the schema, it passes the parse at `actions.rs:222-225`, becomes `final_text`, and is pasted verbatim. The legacy fallback at the bottom of the function compounded this: `prompt.replace("${output}", transcription)` is a no-op when the user's template lacks `${output}`, so structured-output errors that fell through to legacy mode would silently send the transcript-less template to the model.

**Fix:** introduced `render_prompt_with_transcript(prompt, transcription)` which splices the transcript into the `${output}` placeholder, or appends it under a labelled `Transcript:` delimiter if the placeholder is absent. The structured-output path now sends a single user message with the transcript inlined where the prompt author intended; no system/user split. The legacy fallback uses the same renderer so it can never lose the transcript. Apple Intelligence keeps its system+user split since its native Foundation Models API expects that.

### 2. Paste sometimes silently fails until app restart (Linux/Wayland)

**Symptom:** dictation transcribes fine, the overlay disappears, and nothing pastes into the focused window. Reproducibly triggered by a screen lock, suspend/resume, or compositor restart. The only fix was restarting Handy.

**Root cause:** `EnigoState` (in `input.rs`) is constructed once at startup and held in a `Mutex` for the app's lifetime. On Wayland, Enigo's keyboard/text simulation goes through libei via xdg-desktop-portal RemoteDesktop. That session can die — lock screen / sleep / portal restart / compositor restart. After it dies, every `enigo.text(...)` and `enigo.key(...)` either errors or no-ops silently. There was no reconnect logic.

**Fix:** added `EnigoState::reconnect()` (rebuilds the inner `Enigo`, reopening the portal session) and a retry-once wrapper in `clipboard.rs::paste`. On any paste failure, the lock is dropped, `Enigo` is recreated, and the paste is retried. Auto-submit and clipboard-copy operations now acquire fresh locks so they always run against the live instance. Recovers from stale libei sessions without an app restart.

### 3. `Direct` paste method types too slowly

**Symptom (per #1130):** with `Paste Method → Direct`, long transcripts visibly type out character-by-character with a noticeable delay. A user-side comment on #1130 already identified the cause but no fix landed.

**Root cause:** both `ydotool type` and `xdotool type` default to a 12ms inter-key delay. For a 100-character transcript that's >1s of typing animation, on top of the transcription itself. There was no `--key-delay` / `--delay` argument being passed.

**Fix:** pass `--key-delay 0` to ydotool and `--delay 0` to xdotool. The uinput (ydotool) and X11 (xdotool) input paths handle zero-delay typing fine; output becomes near-instant.

### Files changed

- `src-tauri/src/actions.rs` — replace `build_system_prompt` with `render_prompt_with_transcript`; structured-output path sends a single user message with the transcript inlined.
- `src-tauri/src/input.rs` — add `EnigoState::reconnect()`.
- `src-tauri/src/clipboard.rs` — factor `run_paste_action`; retry-once with reconnect on failure; auto-submit and clipboard-copy use fresh locks; `--key-delay 0` for ydotool and `--delay 0` for xdotool.

## Testing

Tested on Ubuntu 26.04 (GNOME Wayland on mutter), NVIDIA RTX 5070 with proprietary drivers, Parakeet via ORT-CUDA.

**Post-processor (issue 1 in this PR):**
- Default "Improve Transcriptions" prompt on a structured-output-capable provider (OpenRouter).
- Short utterances (1–3 words) — previously the worst-case repro — now consistently return cleaned text rather than the model echoing instructions back. Reproduced #1261's "What do you think about this?" case as a regression test; it now works correctly.
- Legacy fallback path still works for providers with `supports_structured_output: false`.

**Paste reliability (issue 2 in this PR):**
- Repeated dictations work as before.
- Locked + unlocked screen; dictation immediately afterwards still pasted successfully. Previously the libei session was dead and paste silently failed until restart.
- Both `Direct` (via `ydotool`) and `CtrlShiftV` (via `wl-copy` + `ydotool`) paste paths exercised.

**Typing speed (issue 3 in this PR):**
- `Direct` paste of a multi-sentence transcript is now visually instant rather than typing-animation-paced.

**Note on local build:** Building from source on Ubuntu 26.04 currently fails on `whisper-rs 0.16.0` + `whisper-rs-sys 0.15.0` — the published versions have a symbol mismatch in the Vulkan codepath (`ggml_backend_vk_*` symbols expected by `whisper-rs/vulkan.rs` are not in `whisper-rs-sys 0.15.0`'s generated bindings when apt's newer ggml/shaderc headers are visible to bindgen). That's a pre-existing upstream issue, unrelated to this PR. For testing I swapped `whisper-vulkan` → `ort-cuda` in `Cargo.toml` locally and used Parakeet via ORT-CUDA; **that Cargo.toml change is not included in this PR**. Worth a separate issue at some point.

## Screenshots/Videos (if applicable)

N/A — all three fixes are diagnosable from logs, not visual.

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Opus 4.7)
- How extensively: AI helped trace the post-processor call chain, the Linux paste fallback chain, and the Enigo lifecycle to root-cause the bugs; drafted the patches; helped surface and link related existing issues. I reviewed and integrated all changes, verified behaviour on my hardware (Ubuntu 26.04 + Blackwell NVIDIA on Wayland) by running real dictations against my OpenRouter setup and exercising a lock/unlock cycle. The "Human Written Description" section above is mine.
