### PR TITLE
fix(parakeet): chunk long audio to avoid encoder positional encoding …

### DIFF
--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -25,8 +25,116 @@ use transcribe_rs::{
         Quantization,
     },
     whisper_cpp::{WhisperEngine, WhisperInferenceParams},
-    SpeechModel, TranscribeOptions,
+    SpeechModel, TranscribeError, TranscribeOptions, TranscriptionResult, TranscriptionSegment,
 };
+
+// Parakeet's ONNX encoder caps positional encoding around 4875 subsampled
+// frames (~6.5 min of 16kHz audio at subsampling factor 8). Feeding longer
+// audio in one pass triggers a broadcast error at the first self-attention
+// layer. Chunk long audio and stitch by segment timestamps so it transcribes
+// cleanly.
+const PARAKEET_SAMPLE_RATE: usize = 16_000;
+const PARAKEET_CHUNK_DURATION_S: f32 = 120.0;
+const PARAKEET_OVERLAP_DURATION_S: f32 = 15.0;
+
+fn transcribe_parakeet_chunked(
+    engine: &mut ParakeetModel,
+    audio: &[f32],
+    params: &ParakeetParams,
+) -> Result<TranscriptionResult, TranscribeError> {
+    let chunk_samples = (PARAKEET_CHUNK_DURATION_S * PARAKEET_SAMPLE_RATE as f32) as usize;
+    if audio.len() <= chunk_samples {
+        return engine.transcribe_with(audio, params);
+    }
+
+    let overlap_samples = (PARAKEET_OVERLAP_DURATION_S * PARAKEET_SAMPLE_RATE as f32) as usize;
+    let step = chunk_samples.saturating_sub(overlap_samples).max(1);
+
+    let total_chunks = ((audio.len() - 1) / step) + 1;
+    debug!(
+        "Parakeet: chunking {:.1}s audio into ~{} windows of {:.0}s ({:.0}s overlap)",
+        audio.len() as f32 / PARAKEET_SAMPLE_RATE as f32,
+        total_chunks,
+        PARAKEET_CHUNK_DURATION_S,
+        PARAKEET_OVERLAP_DURATION_S,
+    );
+
+    let mut all_segments: Vec<TranscriptionSegment> = Vec::new();
+    let mut all_text = String::new();
+    let mut start: usize = 0;
+    let mut chunk_idx: usize = 0;
+
+    while start < audio.len() {
+        let end = (start + chunk_samples).min(audio.len());
+        let chunk = &audio[start..end];
+        let offset_s = start as f32 / PARAKEET_SAMPLE_RATE as f32;
+
+        let chunk_start = std::time::Instant::now();
+        let mut result = engine.transcribe_with(chunk, params)?;
+        result.offset_timestamps(offset_s);
+        debug!(
+            "Parakeet: chunk {}/{} ({:.1}s-{:.1}s) in {}ms",
+            chunk_idx + 1,
+            total_chunks,
+            offset_s,
+            end as f32 / PARAKEET_SAMPLE_RATE as f32,
+            chunk_start.elapsed().as_millis()
+        );
+
+        // Drop any segment whose midpoint falls inside the first half of the
+        // overlap region — the previous chunk already covered it.
+        let dedup_cutoff_s = if chunk_idx == 0 {
+            f32::MIN
+        } else {
+            offset_s + PARAKEET_OVERLAP_DURATION_S / 2.0
+        };
+
+        match result.segments {
+            Some(segs) => {
+                for seg in segs {
+                    let mid = (seg.start + seg.end) / 2.0;
+                    if mid < dedup_cutoff_s {
+                        continue;
+                    }
+                    let trimmed = seg.text.trim();
+                    if !trimmed.is_empty() {
+                        if !all_text.is_empty() && !all_text.ends_with(' ') {
+                            all_text.push(' ');
+                        }
+                        all_text.push_str(trimmed);
+                    }
+                    all_segments.push(seg);
+                }
+            }
+            None => {
+                // Without segments we can't dedup the overlap region; append
+                // raw text and accept some duplicated words at boundaries.
+                let trimmed = result.text.trim();
+                if !trimmed.is_empty() {
+                    if !all_text.is_empty() && !all_text.ends_with(' ') {
+                        all_text.push(' ');
+                    }
+                    all_text.push_str(trimmed);
+                }
+            }
+        }
+
+        if end >= audio.len() {
+            break;
+        }
+        start += step;
+        chunk_idx += 1;
+    }
+
+    Ok(TranscriptionResult {
+        text: all_text.trim().to_string(),
+        segments: if all_segments.is_empty() {
+            None
+        } else {
+            Some(all_segments)
+        },
+    })
+}
 
 #[derive(Clone, Debug, Serialize)]
 pub struct ModelStateEvent {
@@ -560,8 +668,7 @@ impl TranscriptionManager {
                                 timestamp_granularity: Some(TimestampGranularity::Segment),
                                 ..Default::default()
                             };
-                            parakeet_engine
-                                .transcribe_with(&audio, &params)
+                            transcribe_parakeet_chunked(parakeet_engine, &audio, &params)
                                 .map_err(|e| {
                                     anyhow::anyhow!("Parakeet transcription failed: {}", e)
                                 })


### PR DESCRIPTION
…overflow

Parakeet's int8 ONNX encoder caps positional encoding around 4875 subsampled frames (~6.5 min of 16kHz audio at subsampling factor 8). Feeding audio longer than that into a single transcribe_with() call fails inside the first self-attention layer:

  Non-zero status code returned while running Add node.
  Name:'/layers.0/self_attn/Add_2' Status Message: ...
  Attempting to broadcast an axis by a dimension other than 1.
  4875 by 9875

Fix: split audio longer than 120s into overlapping 120s windows (15s overlap) before calling the engine, then stitch segments using their timestamps. Audio at or under 120s still flows through a single call with zero overhead.

Dedup: any segment whose midpoint falls inside the first half of the overlap region of a non-first chunk is dropped (the previous chunk already covered it). When the engine returns no segments we fall back to raw text concatenation, which can duplicate words at boundaries but keeps output usable.

Repro before this fix: record/transcribe any audio >~6.5 min with parakeet-tdt-0.6b-v3. After this fix a 13-min recording transcribes end to end.

## Before Submitting This PR

<!--
HANDY IS UNDERGOING A FEATURE FREEZE. IF YOU ARE SUBMITTING A PR WHICH IS A NEW FEATURE THAT THE COMMUNITY HAS NOT ASKED FOR: PREPARE TO BE REJECTED. IF THE COMMUNITY HAS ASKED FOR IT, OR YOU HAVE EXPLICITLY GATHERED SUPPORT IT MAY STILL BE CONSIDERED.

BUG FIXES ARE THE TOP PRIORITY. THERE ARE 60+ ISSUES TO FIX.
-->

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

<!-- Describe your changes clearly and concisely

Please write 2-3 sentences in your own words explaining:
- What problem you noticed or idea you had
- Why you think this change matters

This section should be YOUR thinking, not AI-generated text. Even if AI helped write the code, we want to hear from you directly. Your perspective as a human is what makes contributions meaningful. Your PR may be rejected if you do not
include a human-written description.
-->

## Related Issues/Discussions

<!-- Link to related issues, discussions, or previous PRs -->
<!-- If reopening something previously closed, explain why this should be reconsidered -->

Fixes #
Discussion:

## Community Feedback

<!--
PRs with community support are much more likely to be merged.

For features: Link to a discussion where community members have expressed interest.
For bug fixes: Link to the issue where others have confirmed the bug.

If you haven't gathered feedback yet, consider starting a discussion first:
https://github.com/cjpais/Handy/discussions

It is not explicitly required to gather feedback, but it certainly helps your PR get merged.
-->

## Testing

<!-- Describe how you tested your changes and if you need help getting additional testing -->

## Screenshots/Videos (if applicable)

<!-- Add screenshots or videos demonstrating the change -->

## AI Assistance

<!-- AI-assisted PRs are welcome! Just let us know so we can review appropriately. -->

- [x] No AI was used in this PR
- [ ] AI was used (please describe below)

**If AI was used:**

- Tools used:
- How extensively:
