### PR TITLE
fix: dropdown overflow in post-processing settings

### DIFF
--- a/src/components/settings/post-processing/PostProcessingSettings.tsx
+++ b/src/components/settings/post-processing/PostProcessingSettings.tsx
@@ -258,7 +258,7 @@ const PostProcessingSettingsPromptsComponent: React.FC = () => {
       grouped={true}
     >
       <div className="space-y-3">
-        <div className="flex gap-2">
+        <div className="flex gap-2 min-w-0">
           <Dropdown
             selectedValue={selectedPromptId || null}
             options={prompts.map((p) => ({
@@ -274,13 +274,14 @@ const PostProcessingSettingsPromptsComponent: React.FC = () => {
             disabled={
               isUpdating("post_process_selected_prompt_id") || isCreating
             }
-            className="flex-1"
+            className="flex-1 min-w-0"
           />
           <Button
             onClick={handleStartCreate}
             variant="primary"
             size="md"
             disabled={isCreating}
+            className="shrink-0"
           >
             {t("settings.postProcessing.prompts.createNew")}
           </Button>

--- a/src/components/ui/Dropdown.tsx
+++ b/src/components/ui/Dropdown.tsx
@@ -62,7 +62,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
     <div className={`relative ${className}`} ref={dropdownRef}>
       <button
         type="button"
-        className={`px-2 py-1 text-sm font-semibold bg-mid-gray/10 border border-mid-gray/80 rounded-md min-w-[200px] text-start flex items-center justify-between transition-all duration-150 ${
+        className={`px-2 py-[5px] text-sm font-semibold bg-mid-gray/10 border border-mid-gray/80 rounded-md min-w-[200px] w-full text-start grid grid-cols-[1fr_auto] gap-2 items-center transition-all duration-150 ${
           disabled
             ? "opacity-50 cursor-not-allowed"
             : "hover:bg-logo-primary/10 cursor-pointer hover:border-logo-primary"
@@ -72,7 +72,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
       >
         <span className="truncate">{selectedOption?.label || placeholder}</span>
         <svg
-          className={`w-4 h-4 ms-2 transition-transform duration-200 ${isOpen ? "transform rotate-180" : ""}`}
+          className={`w-4 h-4 transition-transform duration-200 ${isOpen ? "transform rotate-180" : ""}`}
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -104,7 +104,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
                 onClick={() => handleSelect(option.value)}
                 disabled={option.disabled}
               >
-                <span className="truncate">{option.label}</span>
+                <span className="whitespace-normal break-words">{option.label}</span>
               </button>
             ))
           )}


### PR DESCRIPTION
## Summary

- **Dropdown overflow fix**: Switch the `Dropdown` button layout from flexbox to CSS grid so long option labels are properly truncated instead of pushing the chevron off-screen. Dropdown options now wrap instead of truncating.
- **Post-processing layout fix**: Add `min-w-0` to flex containers and `shrink-0` to the "Create New" button to prevent the prompt selector from overflowing its parent.

## Changes

- `src/components/ui/Dropdown.tsx` — grid layout, padding tweak, word-wrap for options
- `src/components/settings/post-processing/PostProcessingSettings.tsx` — overflow guards