### PR TITLE
fix(custom-words): remove space restriction that conflicts with n-gram backend support

### DIFF
--- a/src-tauri/src/audio_toolkit/text.rs
+++ b/src-tauri/src/audio_toolkit/text.rs
@@ -768,7 +768,7 @@ mod tests {
         let text = "using Mac Book Pro";
         let custom_words = vec!["MacBook Pro".to_string()];
         let result = apply_custom_words(text, &custom_words, 0.5);
-        assert!(result.contains("MacBook"));
+        assert_eq!(result, "using MacBook Pro");
     }
 
     #[test]

--- a/src/components/settings/CustomWords.tsx
+++ b/src/components/settings/CustomWords.tsx
@@ -21,11 +21,7 @@ export const CustomWords: React.FC<CustomWordsProps> = React.memo(
     const handleAddWord = () => {
       const trimmedWord = newWord.trim();
       const sanitizedWord = trimmedWord.replace(/[<>"'&]/g, "");
-      if (
-        sanitizedWord &&
-        !sanitizedWord.includes(" ") &&
-        sanitizedWord.length <= 50
-      ) {
+      if (sanitizedWord && sanitizedWord.length <= 50) {
         if (customWords.includes(sanitizedWord)) {
           toast.error(
             t("settings.advanced.customWords.duplicate", {
@@ -76,7 +72,6 @@ export const CustomWords: React.FC<CustomWordsProps> = React.memo(
               onClick={handleAddWord}
               disabled={
                 !newWord.trim() ||
-                newWord.includes(" ") ||
                 newWord.trim().length > 50 ||
                 isUpdating("custom_words")
               }

--- a/src/components/settings/CustomWords.tsx
+++ b/src/components/settings/CustomWords.tsx
@@ -11,30 +11,31 @@ interface CustomWordsProps {
   grouped?: boolean;
 }
 
+const normalizeCustomWord = (word: string) =>
+  word
+    .replace(/[<>"']/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
 export const CustomWords: React.FC<CustomWordsProps> = React.memo(
   ({ descriptionMode = "tooltip", grouped = false }) => {
     const { t } = useTranslation();
     const { getSetting, updateSetting, isUpdating } = useSettings();
     const [newWord, setNewWord] = useState("");
     const customWords = getSetting("custom_words") || [];
+    const normalizedWord = normalizeCustomWord(newWord);
 
     const handleAddWord = () => {
-      const trimmedWord = newWord.trim();
-      const sanitizedWord = trimmedWord.replace(/[<>"']/g, "");
-      if (
-        sanitizedWord &&
-        !sanitizedWord.includes(" ") &&
-        sanitizedWord.length <= 50
-      ) {
-        if (customWords.includes(sanitizedWord)) {
+      if (normalizedWord && normalizedWord.length <= 50) {
+        if (customWords.includes(normalizedWord)) {
           toast.error(
             t("settings.advanced.customWords.duplicate", {
-              word: sanitizedWord,
+              word: normalizedWord,
             }),
           );
           return;
         }
-        updateSetting("custom_words", [...customWords, sanitizedWord]);
+        updateSetting("custom_words", [...customWords, normalizedWord]);
         setNewWord("");
       }
     };
@@ -75,9 +76,8 @@ export const CustomWords: React.FC<CustomWordsProps> = React.memo(
             <Button
               onClick={handleAddWord}
               disabled={
-                !newWord.trim() ||
-                newWord.includes(" ") ||
-                newWord.trim().length > 50 ||
+                !normalizedWord ||
+                normalizedWord.length > 50 ||
                 isUpdating("custom_words")
               }
               variant="primary"

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -351,8 +351,8 @@
       },
       "customWords": {
         "title": "Custom Words",
-        "description": "Add words that are often misheard or misspelled during transcription. The system will automatically correct similar-sounding words to match your list.",
-        "placeholder": "Add a word",
+        "description": "Add words or phrases that are often misheard or misspelled during transcription. The system will automatically correct similar-sounding words to match your list.",
+        "placeholder": "Add a word or phrase",
         "add": "Add",
         "remove": "Remove {{word}}",
         "duplicate": "\"{{word}}\" already exists"


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [x] I have explained in the description below why this should be reconsidered
- [x] I have gathered community feedback (link to discussion below)

## Human Written Description

It looks like this is already supported on the backend and the simple change here would open up phrases to help expand on the quality improvements one may see by adding in their own commonly mis-transcribed terms. Hitting this on `knowledge base` personally.

The 50 character limit would stay in effect to prevent sentences + paragraphs.

## Related Issues/Discussions

Discussion: #601 (Custom Phrases — canonical thread for this feature)
Fixes #1318
Fixes #1385
Related: #711 (merged n-gram backend support that made multi-word custom words work)
Related: #863 (closed — bulk import feature rejected during feature freeze; this PR is scoped to only the space restriction fix)

## Community Feedback

Both #1318 and #1385 are community-reported issues requesting multi-word custom word support, and discussion #601 is the canonical thread for custom phrase support. The backend already supports this (proven by merged PR #711) — this PR simply removes the frontend restriction that prevents users from using it.

## Changes

This is a minimal fix — 2 files changed, net -5 lines:

**`src/components/settings/CustomWords.tsx`**
- Removed `!sanitizedWord.includes(" ")` from the validation guard in `handleAddWord()`
- Removed `newWord.includes(" ")` from the Add button's `disabled` prop

**`src/i18n/locales/en/translation.json`**
- Updated placeholder: "Add a word" → "Add a word or phrase"
- Updated description: "Add words that are often…" → "Add words or phrases that are often…"

No backend changes needed — `audio_toolkit/text.rs` already handles multi-word matching via n-gram splitting.

## Testing

Validated locally by injecting multi-word phrases into `settings_store.json` while Handy was closed, then confirming they render correctly as pills in Advanced → Custom Words. No backend changes needed — `audio_toolkit/text.rs` n-gram matching already handles multi-word entries since #711.

## Screenshots/Videos (if applicable)

N/A — the change removes a restriction; the UI input field and button behavior remain visually identical.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenCode (Claude)
- How extensively: AI identified the exact lines containing the space restriction by analyzing the codebase, confirmed the backend already supports multi-word matching, and made the code edits. The PR framing and issue research were also AI-assisted.