### PR TITLE
docs: add overlay/pasting issue workaround for Linux to Known Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ This project is actively being developed and has some [known issues](https://git
 
 - Limited or no support for Wayland display server
 
+**Overlay & Pasting Issues (Linux):**
+
+- The recording overlay window can interfere with pasting transcribed text into target applications on Linux (X11)
+- **Solution:** Open **Settings > Advanced** and set **"Overlay Position"** to **"None"** to disable the overlay
+- Enable **"Audio Feedback"** (also in Advanced) if you still want audible confirmation of recording state
+- Users who upgrade from older versions or import settings from other platforms may need to manually apply this change
+
+
 ### Platform Support
 
 - **macOS (both Intel and Apple Silicon)**


### PR DESCRIPTION
## Summary

Adds documentation for a known Linux issue where the recording overlay window interferes with pasting transcribed text into target applications.

This addresses the request in #327 to document this on the main page, as the workaround (disabling overlay, enabling audio feedback) is simple but not obvious to users.

## Changes

Added a new subsection "Overlay & Pasting Issues (Linux)" under "Known Issues & Current Limitations" in `README.md`, documenting:
- The problem: overlay window intercepting focus/input during paste on Linux X11
- The solution: set Overlay Position to None in Settings > Advanced
- Compensation: enable Audio Feedback for audible confirmation
- Note about users upgrading from older versions or importing settings

Closes #327