### PR TITLE
fix: eliminate WebKitWebProcess memory leak from overlay mic-level events (#1279)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -542,6 +542,14 @@ pub fn run(cli_args: CliArgs) {
 
             initialize_core_logic(&app_handle);
 
+            // Populate the overlay-enabled cache from initial settings so the
+            // audio path (overlay::emit_levels, called ~24 Hz during recording)
+            // can do a single atomic load instead of reading the Tauri store.
+            // Kept in sync by shortcut::change_overlay_position_setting.
+            overlay::update_overlay_enabled_cache(
+                settings.overlay_position != settings::OverlayPosition::None,
+            );
+
             // Pre-warm GPU/accelerator enumeration on a background thread.
             // The first call into transcribe_rs::whisper_cpp::gpu::list_gpu_devices
             // loads the Metal/Vulkan backend and probes devices, which can take

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -1,6 +1,7 @@
 use crate::input;
 use crate::settings;
 use crate::settings::OverlayPosition;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tauri::{AppHandle, Emitter, Manager, PhysicalPosition, PhysicalSize};
 
 #[cfg(not(target_os = "macos"))]
@@ -385,12 +386,41 @@ pub fn hide_recording_overlay(app_handle: &AppHandle) {
     }
 }
 
-pub fn emit_levels(app_handle: &AppHandle, levels: &Vec<f32>) {
-    // emit levels to main app
-    let _ = app_handle.emit("mic-level", levels);
+// Cached "overlay is enabled" flag, kept in sync with the
+// overlay_position setting. Avoids reading the Tauri store on every
+// audio callback (~24 Hz during recording). Defaults to false so the
+// audio path doesn't emit until lib.rs::setup populates the cache from
+// initial settings.
+static OVERLAY_ENABLED: AtomicBool = AtomicBool::new(false);
 
-    // also emit to the recording overlay if it's open
-    if let Some(overlay_window) = app_handle.get_webview_window("recording_overlay") {
-        let _ = overlay_window.emit("mic-level", levels);
+/// Update the cached overlay-enabled flag. Called from `lib.rs` at
+/// startup after settings load, and from `change_overlay_position_setting`
+/// whenever the user changes the overlay position.
+pub fn update_overlay_enabled_cache(enabled: bool) {
+    OVERLAY_ENABLED.store(enabled, Ordering::Relaxed);
+}
+
+pub fn emit_levels(app_handle: &AppHandle, levels: &[f32]) {
+    // Skip emission when the overlay is disabled. The recording_overlay
+    // window is created at boot regardless of overlay_position, so
+    // without this guard a hidden overlay's WebKit subprocess still
+    // processes every event. Each event drives some kind of WebKit
+    // C++ allocation that accumulates without bound (mechanism not
+    // directly characterized; see issue #1279 for the investigation).
+    // For users with `overlay_position: none` (the Linux default) this
+    // skip eliminates the upstream driver of that accumulation.
+    if !OVERLAY_ENABLED.load(Ordering::Relaxed) {
+        return;
     }
+
+    // Target only the overlay window. In Tauri 2 both `AppHandle::emit`
+    // and `WebviewWindow::emit` broadcast to all webviews; Tauri's
+    // listener filter then skips webviews with no registered listener
+    // for the event, so the settings webview never received `mic-level`.
+    // But the previous dual-call pattern still produced two `eval_script`
+    // calls to the overlay per audio callback (one from each .emit()).
+    // `emit_to` with the overlay's window label produces a single
+    // eval_script call per callback, cutting the per-callback WebKit
+    // dispatch work in half.
+    let _ = app_handle.emit_to("recording_overlay", "mic-level", levels);
 }

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -550,6 +550,10 @@ pub fn change_overlay_position_setting(app: AppHandle, position: String) -> Resu
     settings.overlay_position = parsed;
     settings::write_settings(&app, settings);
 
+    // Keep the cached overlay-enabled flag in sync so emit_levels stops
+    // (or resumes) emitting on the next audio callback.
+    crate::overlay::update_overlay_enabled_cache(parsed != OverlayPosition::None);
+
     // Update overlay position without recreating window
     crate::utils::update_overlay_position(&app);
 


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

**Not applicable** -- this is a bug fix for an open, maintainer-acknowledged issue, not a previously-closed change.

## Human Written Description

I use Handy as my daily driver voice transcription tool. Shortly after adoption, I encountered a particularly nasty memory leak that, when OOM-killed, destabilized my Linux session. I filed [#1279](https://github.com/cjpais/Handy/issues/1279) with detailed analysis of the issue and speculation on potential fixes. The source of the memory leak is, it turns out, upstream of Handy in WebKit but, by thoughtfully scoping the emission of microphone-level events to the visualizer overlay, the leak can be mostly eliminated. I submit this patch / pull request to resolve the leak.

## Related Issues/Discussions

Fixes #1279

Discussion: the issue thread itself -- <https://github.com/cjpais/Handy/issues/1279>.

I also wrote up the full story (and the reproducible methodology) [here](https://gallon.me/95-gb-in-36-hours-how-i-fixed-handys-memory-leak-without-knowing-rust).

## Community Feedback

This is a bug fix for an issue I filed, which the maintainer ([@cjpais](https://github.com/cjpais)) acknowledged on 2026-04-13:

> *"This is a problem, and we need to fix it. Just acknowledging it"*

When I asked whether a PR would be welcome:

> *"Definitely, there may be an outstanding PR already but I would love a PR"*

One other user ([@scr4bble](https://github.com/scr4bble)) reported a related-but-distinct observation in the same thread (memory not dropping after Cancel from a long recording). That is **not** addressed here -- it looks like a separate concern.

**On the newly-raised PR (#1444).** A PR ([#1444](https://github.com/cjpais/Handy/pull/1444)) was raised today which also targets this issue by throttling `mic-level` emissions to ~30 FPS. I began working on this pull request nearly 2 weeks ago and have just concluded today in the ~ 6 day patched build soak described below. I've seen the alternative PR, but I think this PR is the better fix -- not as a knock on that work, but because the measurements say so. I bisected three candidate fixes (skip-when-disabled, targeted `emit_to`, and throttling) against a controlled workload, isolating each one. **Throttling showed no effect distinguishable from measurement noise**, which is why I dropped it. 

One note on the rate, since Hz and FPS are the same unit here -- each emission drives one visualizer frame: my instrumented measurement put the natural emit rate at ~24 Hz, so the throttle I tested capped it *further*, to 20 Hz, and it still came out as noise. A 33 ms / ~30 FPS cap sits *above* my measured ~24 Hz rate, so on my data it would drop essentially nothing -- which leaves the targeted `emit_to` as the only component of that approach doing real work, and this PR already includes it. (It's also noteworthy that I initially proposed this `emit_to` target in the initial analysis I filed in [#1279](https://github.com/cjpais/Handy/issues/1279).) 

The lever that actually matters is skipping emission entirely when the overlay is disabled -- and since the overlay is off by default on Linux, that's the configuration most users are running. Even with a throttle in place, ~24 events/sec still hit the hidden WebKit subprocess that's driving the leak; it slows the bleed at best, it doesn't stop it. This PR takes that subprocess to zero emissions for the default config, and keeps the `emit_to` improvement for users who do enable the overlay. The numbers backing all of this are in the Testing section below.

## Testing

I deliberately scoped this fix to Handy's own code. The ultimate source of the leak appears to be upstream in WebKit; I did not try to analyze or patch WebKit itself.

**What's going on.** Handy's recording overlay (the voice visualizer, off by default) is driven by `mic-level` events that `emit_levels` broadcasts at the audio-callback rate (~24 Hz) during recording. On Linux the `recording_overlay` window is created at boot *regardless* of `overlay_position` -- when the overlay is disabled it exists but is never shown. The hidden overlay's WebKit subprocess still receives every event and leaks memory on each one. The actual accumulation is in WebKit's C++ side, upstream of Handy, so the only lever reachable from Handy's code is to reduce the event traffic that drives it.

**How I found it.** I built a small reversible harness so my tooling could run Handy end-to-end on a dedicated Xvfb display with deterministic test audio (a PipeWire null sink) and a `SIGUSR2` trigger, then instrumented the runtime with four tools at once -- `uftrace` (Rust calls), `strace` (syscalls + IPC), the WebKit Remote Inspector (JS heap), and a `smaps_rollup` sampler (per-process memory). That narrowed eight candidate mechanisms to one:

- `smaps_rollup` localized the sustained growth to the overlay's WebKit subprocess (the Rust process and the settings webview were flat after warmup).
- A WebKit `Heap.snapshot` diff showed the JS heap accounts for only **~1.2%** of the growth, and 100% of the growth is in private-anonymous pages -- so the leak is in WebKit's native C++ side, **by exclusion** (I did not directly characterize the C++ allocation; that would need `heaptrack` on the WebKit subprocess, outside the scope of a Handy change).
- `uftrace`/`strace` confirmed the driver: `emit_levels` firing at ~24 Hz and double-broadcasting to the hidden overlay.

**The fix (two parts).**

1. **Skip emission when the overlay is disabled.** Cache `overlay_position != None` in an `AtomicBool` (populated at startup in `lib.rs`, kept in sync by `change_overlay_position_setting` in `shortcut/mod.rs`). `emit_levels` does a single relaxed atomic load and returns early when the overlay is off. The audio path no longer touches the Tauri store at ~24 Hz, and for the default Linux config the leak's driver goes silent entirely.
2. **Target the overlay when it *is* enabled.** In Tauri 2 both `AppHandle::emit` and `WebviewWindow::emit` are global broadcasts; the old code produced two `eval_script` dispatches to the overlay per callback. Replacing them with a single `emit_to("recording_overlay", "mic-level", levels)` halves the per-callback WebKit dispatch work.

**Before → after, measured.** I validated with a bisect: the same controlled 50-cycle workload, each fix component behind its own env-var toggle, measuring sustained-phase RSS growth (cycle 10→50) of the overlay's WebKit process.

- **Overlay disabled (`overlay_position: none` -- Linux default):** unfixed control ≈ **4.5 MB/min** of sustained growth; with the fix, growth drops to the measurement-noise floor (effectively flat). This agrees within ~10% with my real-world observation of ~4.0 MB/min sustained (249 MB at launch → 1,230 MB after ~2 h → 9.5 GB / OOM after ~36 h). After applying the fix, this same workload measured 0.0 KB/min of sustained growth with both fixes enabled (and −4.3 KB/min with the skip-when-disabled change alone) -- both statistically indistinguishable from zero. Per recording cycle that's roughly 0 KB, against the control's ~5,585 KB/cycle: the overlay process simply stops growing.
- **Overlay enabled:** the targeted `emit_to` reduced the leak rate by **~33%** (single trial -- weaker evidence than the `none` result, but directionally consistent with halving the dispatch work). This is quite acceptable, as the vast majority of the memory leak was triggered by the overlay disabled scenario.
- **The six-day soak.** Numbers from a lab workload aren't enough for a leak that takes hours to bite, so I ran the patched build as my actual daily driver for 5 days 18.5 hours across 7 launches, with a 30-second `smaps_rollup` poll logging per-process memory to CSV the whole time. It stayed flat, proving (in meatspace) that the fix works.

**Caveats and limitations:**

- This addresses the leak's *driver* (event traffic), not the *mechanism* of WebKit's C++ accumulation, which I did not directly characterize.
- The fix is platform-shared (no `#[cfg]` guards). I tested on **Linux only**; macOS/Windows behavior should be unchanged but I haven't verified -- please flag any platform-specific concerns.
- The `OVERLAY_ENABLED` cache defaults to `false` and is populated in `lib.rs::setup`. This is safe today because recording can't fire before setup runs; a future change that started recording earlier in the lifecycle would need to keep that ordering in mind.
- `hide_recording_overlay` still emits one `hide-overlay` event when the overlay is disabled. That's a bounded residual (one event per recording-stop vs. the hundreds of `mic-level` events the early-return now skips) and not worth addressing here.
- A third candidate fix -- throttling `emit_levels` from ~24 Hz to 20 Hz -- was evaluated and **dropped**: the analysis showed no effect distinguishable from control noise, so shipping it would add complexity for no measured benefit.

## Screenshots/Videos (if applicable)

N/A -- backend behavior change, no UI surface changes.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- **Tools used:** Claude Code (Anthropic) with a heavily customized multi-agent harness.
- **How extensively:** extensively, and disciplined -- not vibe coding. 

**The short version**:

I applied [The Framework](https://vibecodinghangover.com/) -- a comprehensive engineering discipline for AI-accelerated coding -- to diagnose and fix this leak.

- Developed and implemented an agent autonomy harness so that my AI agents could run Handy end-to-end without interrupting my work (this was massive)
- Instrumented the Handy runtime for observability and agent sensory feedback (also massive)
- Used this instrumentation to analyze and narrow systematically to isolate the source of the leak
- Fixed the leak in 3 ways, and tested each bit of the fix on its own, and together, measuring how each contributed (one of the candidate fixes was dropped after seeing its minimal contribution)
- Deployed adversarial agents to scrutinize findings
- Surfaced a patched version of the app for me to run for days to prove, via additional telemetry, that the fix worked (the important meatbag-in-the-loop bit)

Every claim in this description was independently verified against either the source code or the raw measurement data -- agent output was never trusted without recompute, which mattered because I don't have Rust familiarity to fall back on. The investigation produced large local artifacts (instrumentation procedures, per-run captures, statistical analysis, three rounds of adversarial review) that are **not** in this PR -- they're intermediate data, not appropriate for the repo.

**The long version**: I've written the entire process up [here](https://gallon.me/95-gb-in-36-hours-how-i-fixed-handys-memory-leak-without-knowing-rust).