### PR TITLE
feat: add prompt-only post-processing provider

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -5,7 +5,9 @@ use crate::audio_toolkit::{is_microphone_access_denied, is_no_input_device_error
 use crate::managers::audio::AudioRecordingManager;
 use crate::managers::history::HistoryManager;
 use crate::managers::transcription::TranscriptionManager;
-use crate::settings::{get_settings, AppSettings, APPLE_INTELLIGENCE_PROVIDER_ID};
+use crate::settings::{
+    get_settings, AppSettings, APPLE_INTELLIGENCE_PROVIDER_ID, PROMPT_ONLY_PROVIDER_ID,
+};
 use crate::shortcut;
 use crate::tray::{change_tray_icon, TrayIconState};
 use crate::utils::{
@@ -78,7 +80,8 @@ async fn post_process_transcription(settings: &AppSettings, transcription: &str)
         .cloned()
         .unwrap_or_default();
 
-    if model.trim().is_empty() {
+    // Prompt-only provider has no model — it just emits the substituted prompt.
+    if provider.id != PROMPT_ONLY_PROVIDER_ID && model.trim().is_empty() {
         debug!(
             "Post-processing skipped because provider '{}' has no model configured",
             provider.id
@@ -112,6 +115,15 @@ async fn post_process_transcription(settings: &AppSettings, transcription: &str)
     if prompt.trim().is_empty() {
         debug!("Post-processing skipped because the selected prompt is empty");
         return None;
+    }
+
+    if provider.id == PROMPT_ONLY_PROVIDER_ID {
+        let result = strip_invisible_chars(&prompt.replace("${output}", transcription));
+        debug!(
+            "Prompt-only post-processing produced {} chars (no provider call)",
+            result.len()
+        );
+        return Some(result);
     }
 
     debug!(

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -9,6 +9,11 @@ use tauri_plugin_store::StoreExt;
 
 pub const APPLE_INTELLIGENCE_PROVIDER_ID: &str = "apple_intelligence";
 pub const APPLE_INTELLIGENCE_DEFAULT_MODEL_ID: &str = "Apple Intelligence";
+/// Local "provider" that skips any network/LLM call and just returns the
+/// selected prompt template with `${output}` substituted. Handy when the
+/// downstream consumer (e.g. Claude Code) handles raw phonetic input fine
+/// and only needs a prefix telling it the input is a transcription.
+pub const PROMPT_ONLY_PROVIDER_ID: &str = "prompt_only";
 
 #[derive(Serialize, Debug, Clone, Copy, PartialEq, Eq, Type)]
 #[serde(rename_all = "lowercase")]
@@ -599,6 +604,17 @@ fn default_post_process_providers() -> Vec<PostProcessProvider> {
         supports_structured_output: true,
     });
 
+    // Local prompt-only "provider": no network call, no model. Just emits the
+    // selected prompt template with ${output} substituted.
+    providers.push(PostProcessProvider {
+        id: PROMPT_ONLY_PROVIDER_ID.to_string(),
+        label: "Prompt only (no provider)".to_string(),
+        base_url: String::new(),
+        allow_base_url_edit: false,
+        models_endpoint: None,
+        supports_structured_output: false,
+    });
+
     // Custom provider always comes last
     providers.push(PostProcessProvider {
         id: "custom".to_string(),
@@ -639,11 +655,18 @@ fn default_post_process_models() -> HashMap<String, String> {
 }
 
 fn default_post_process_prompts() -> Vec<LLMPrompt> {
-    vec![LLMPrompt {
-        id: "default_improve_transcriptions".to_string(),
-        name: "Improve Transcriptions".to_string(),
-        prompt: "Clean this transcript:\n1. Fix spelling, capitalization, and punctuation errors\n2. Convert number words to digits (twenty-five → 25, ten percent → 10%, five dollars → $5)\n3. Replace spoken punctuation with symbols (period → ., comma → ,, question mark → ?)\n4. Remove filler words (um, uh, like as filler)\n5. Keep the language in the original version (if it was french, keep it in french for example)\n\nPreserve exact meaning and word order. Do not paraphrase or reorder content.\n\nReturn only the cleaned transcript.\n\nTranscript:\n${output}".to_string(),
-    }]
+    vec![
+        LLMPrompt {
+            id: "default_improve_transcriptions".to_string(),
+            name: "Improve Transcriptions".to_string(),
+            prompt: "Clean this transcript:\n1. Fix spelling, capitalization, and punctuation errors\n2. Convert number words to digits (twenty-five → 25, ten percent → 10%, five dollars → $5)\n3. Replace spoken punctuation with symbols (period → ., comma → ,, question mark → ?)\n4. Remove filler words (um, uh, like as filler)\n5. Keep the language in the original version (if it was french, keep it in french for example)\n\nPreserve exact meaning and word order. Do not paraphrase or reorder content.\n\nReturn only the cleaned transcript.\n\nTranscript:\n${output}".to_string(),
+        },
+        LLMPrompt {
+            id: "default_phonetic_prefix".to_string(),
+            name: "Phonetic prefix (Claude Code)".to_string(),
+            prompt: "[🎤 may contain phonetic errors]\n${output}".to_string(),
+        },
+    ]
 }
 
 fn default_whisper_gpu_device() -> i32 {

--- a/src/components/settings/PostProcessingSettingsApi/usePostProcessProviderState.ts
+++ b/src/components/settings/PostProcessingSettingsApi/usePostProcessProviderState.ts
@@ -10,6 +10,7 @@ type PostProcessProviderState = {
   selectedProvider: PostProcessProvider | undefined;
   isCustomProvider: boolean;
   isAppleProvider: boolean;
+  isPromptOnlyProvider: boolean;
   appleIntelligenceUnavailable: boolean;
   baseUrl: string;
   handleBaseUrlChange: (value: string) => void;
@@ -29,6 +30,7 @@ type PostProcessProviderState = {
 };
 
 const APPLE_PROVIDER_ID = "apple_intelligence";
+const PROMPT_ONLY_PROVIDER_ID = "prompt_only";
 
 export const usePostProcessProviderState = (): PostProcessProviderState => {
   const {
@@ -57,6 +59,7 @@ export const usePostProcessProviderState = (): PostProcessProviderState => {
   }, [providers, selectedProviderId]);
 
   const isAppleProvider = selectedProvider?.id === APPLE_PROVIDER_ID;
+  const isPromptOnlyProvider = selectedProvider?.id === PROMPT_ONLY_PROVIDER_ID;
   const [appleIntelligenceUnavailable, setAppleIntelligenceUnavailable] =
     useState(false);
 
@@ -96,7 +99,10 @@ export const usePostProcessProviderState = (): PostProcessProviderState => {
       // a previous provider/base_url can persist and silently 404 at runtime.
       // Skip when the provider isn't configured yet (no API key / empty base URL)
       // to avoid unnecessary backend errors.
-      if (providerId !== APPLE_PROVIDER_ID) {
+      if (
+        providerId !== APPLE_PROVIDER_ID &&
+        providerId !== PROMPT_ONLY_PROVIDER_ID
+      ) {
         const provider = providers.find((p) => p.id === providerId);
         const apiKey = settings?.post_process_api_keys?.[providerId] ?? "";
         const hasBaseUrl = (provider?.base_url ?? "").trim() !== "";
@@ -215,6 +221,7 @@ export const usePostProcessProviderState = (): PostProcessProviderState => {
     selectedProvider,
     isCustomProvider,
     isAppleProvider,
+    isPromptOnlyProvider,
     appleIntelligenceUnavailable,
     baseUrl,
     handleBaseUrlChange,

--- a/src/components/settings/post-processing/PostProcessingSettings.tsx
+++ b/src/components/settings/post-processing/PostProcessingSettings.tsx
@@ -44,7 +44,11 @@ const PostProcessingSettingsApiComponent: React.FC = () => {
         </div>
       </SettingContainer>
 
-      {state.isAppleProvider ? (
+      {state.isPromptOnlyProvider ? (
+        <Alert variant="info" contained>
+          {t("settings.postProcessing.api.promptOnly.description")}
+        </Alert>
+      ) : state.isAppleProvider ? (
         state.appleIntelligenceUnavailable ? (
           <Alert variant="error" contained>
             {t("settings.postProcessing.api.appleIntelligence.unavailable")}
@@ -96,7 +100,7 @@ const PostProcessingSettingsApiComponent: React.FC = () => {
         </>
       )}
 
-      {!state.isAppleProvider && (
+      {!state.isAppleProvider && !state.isPromptOnlyProvider && (
         <SettingContainer
           title={t("settings.postProcessing.api.model.title")}
           description={

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -375,6 +375,9 @@
           "requirements": "Requires an Apple Silicon Mac running macOS Tahoe (26.0) or later. Apple Intelligence must be enabled in System Settings.",
           "unavailable": "Apple Intelligence is not available on this device. Requires an Apple Silicon Mac running macOS Tahoe (26.0) or later with Apple Intelligence enabled in System Settings."
         },
+        "promptOnly": {
+          "description": "No provider is called. The selected prompt is emitted directly with ${output} replaced by the transcription — useful when the downstream tool (e.g. Claude Code) can handle raw phonetic text and just needs a short prefix."
+        },
         "baseUrl": {
           "title": "Base URL",
           "description": "API base URL for the selected provider. Only the custom provider can be edited.",


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Human Written Description

For people using coding agents, we don't need to post process for resolving phonetic transcription issues etc. but we should notify the agent that this was not wrrite via keyboard

## Related Issues/Discussions

Fixes #
Discussion: https://discord.com/channels/1391636091853078608/1395929320303890514/1509870522492522599

## Community Feedback

n/a

## Testing

- Built backend (`cargo check` — passes for the Rust portion; the only failure on my machine was a pre-existing `whisper-rs-sys` C++ header issue unrelated to these changes).
- Built frontend (`bun run build` — clean).
- Manual: select **"Prompt only (no provider)"** from the post-processing provider dropdown, pick the new **"Phonetic prefix (Claude Code)"** prompt, bind the post-process hotkey, record. The output is
the prompt template with `${output}` replaced by the transcription — no API call.

## Screenshots/Videos (if applicable)

<!-- Add a quick screenshot of the new provider option + the info Alert if helpful. -->

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Opus 4.7)
- How extensively: AI wrote the code changes from a spec I iterated on in conversation. I directed the design (started with a shell-command provider, simplified to a prompt-only provider that reuses the
existing prompt template infrastructure). I'm reviewing and submitting the PR myself.

## Summary of changes

- New `prompt_only` post-process provider id. When selected, the chosen prompt template is emitted directly with `${output}` substituted — no LLM call, no API key, no model.
- Built-in **"Phonetic prefix (Claude Code)"** prompt that pairs with this provider.
- Frontend: when the prompt-only provider is selected, the API base URL / API key / model fields are hidden and an info alert explains the mode. The existing prompt selector stays visible.
- 5 files changed, 59 +, 10 −. No new modules, no new dependencies.

## Motivation

Downstream tools like Claude Code tolerate raw phonetic transcription fine — they don't need cleanup, just a short prefix telling them "this came from voice, may contain phonetic errors." Routing that
through a real LLM provider is overkill and adds latency, an API key, and cost. A local template substitution is enough.
