### PR TITLE
feat(ibus): implement robust native IBus direct input engine and sile…

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -228,6 +228,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2483,6 +2494,7 @@ dependencies = [
  "vad-rs",
  "windows 0.61.3",
  "winreg 0.55.0",
+ "zbus 4.4.0",
 ]
 
 [[package]]
@@ -3527,6 +3539,19 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -4105,7 +4130,7 @@ checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
 dependencies = [
  "android_system_properties",
  "log",
- "nix",
+ "nix 0.30.1",
  "objc2",
  "objc2-foundation",
  "objc2-ui-kit",
@@ -5573,6 +5598,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5763,6 +5799,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strength_reduce"
@@ -6448,7 +6490,7 @@ dependencies = [
  "thiserror 2.0.18",
  "url",
  "windows 0.61.3",
- "zbus",
+ "zbus 5.13.2",
 ]
 
 [[package]]
@@ -6491,7 +6533,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "windows-sys 0.60.2",
- "zbus",
+ "zbus 5.13.2",
 ]
 
 [[package]]
@@ -8650,6 +8692,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "xkbcommon"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8691,6 +8743,44 @@ dependencies = [
 
 [[package]]
 name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix 0.29.0",
+ "ordered-stream",
+ "rand 0.8.5",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros 4.4.0",
+ "zbus_names 3.0.0",
+ "zvariant 4.2.0",
+]
+
+[[package]]
+name = "zbus"
 version = "5.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfeff997a0aaa3eb20c4652baf788d2dfa6d2839a0ead0b3ff69ce2f9c4bdd1"
@@ -8719,9 +8809,22 @@ dependencies = [
  "uuid",
  "windows-sys 0.61.2",
  "winnow 0.7.14",
- "zbus_macros",
- "zbus_names",
- "zvariant",
+ "zbus_macros 5.13.2",
+ "zbus_names 4.3.1",
+ "zvariant 5.9.2",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -8734,9 +8837,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "zbus_names",
- "zvariant",
- "zvariant_utils",
+ "zbus_names 4.3.1",
+ "zvariant 5.9.2",
+ "zvariant_utils 3.3.0",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -8747,7 +8861,7 @@ checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
 dependencies = [
  "serde",
  "winnow 0.7.14",
- "zvariant",
+ "zvariant 5.9.2",
 ]
 
 [[package]]
@@ -8865,6 +8979,19 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive 4.2.0",
+]
+
+[[package]]
+name = "zvariant"
 version = "5.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b64ef4f40c7951337ddc7023dd03528a57a3ce3408ee9da5e948bd29b232c4"
@@ -8873,8 +9000,21 @@ dependencies = [
  "enumflags2",
  "serde",
  "winnow 0.7.14",
- "zvariant_derive",
- "zvariant_utils",
+ "zvariant_derive 5.9.2",
+ "zvariant_utils 3.3.0",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -8887,7 +9027,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "zvariant_utils",
+ "zvariant_utils 3.3.0",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -258,6 +258,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2568,6 +2579,7 @@ dependencies = [
  "whatlang",
  "windows 0.61.3",
  "winreg 0.55.0",
+ "zbus 4.4.0",
 ]
 
 [[package]]
@@ -3659,6 +3671,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -5764,6 +5777,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5954,6 +5978,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strength_reduce"
@@ -6660,7 +6690,7 @@ dependencies = [
  "thiserror 2.0.18",
  "url",
  "windows 0.61.3",
- "zbus",
+ "zbus 5.13.2",
 ]
 
 [[package]]
@@ -6703,7 +6733,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "windows-sys 0.60.2",
- "zbus",
+ "zbus 5.13.2",
 ]
 
 [[package]]
@@ -8901,6 +8931,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "xkbcommon"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8942,6 +8982,44 @@ dependencies = [
 
 [[package]]
 name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix 0.29.0",
+ "ordered-stream",
+ "rand 0.8.5",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros 4.4.0",
+ "zbus_names 3.0.0",
+ "zvariant 4.2.0",
+]
+
+[[package]]
+name = "zbus"
 version = "5.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfeff997a0aaa3eb20c4652baf788d2dfa6d2839a0ead0b3ff69ce2f9c4bdd1"
@@ -8970,9 +9048,22 @@ dependencies = [
  "uuid",
  "windows-sys 0.61.2",
  "winnow 0.7.14",
- "zbus_macros",
- "zbus_names",
- "zvariant",
+ "zbus_macros 5.13.2",
+ "zbus_names 4.3.1",
+ "zvariant 5.9.2",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -8985,9 +9076,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "zbus_names",
- "zvariant",
- "zvariant_utils",
+ "zbus_names 4.3.1",
+ "zvariant 5.9.2",
+ "zvariant_utils 3.3.0",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -8998,7 +9100,7 @@ checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
 dependencies = [
  "serde",
  "winnow 0.7.14",
- "zvariant",
+ "zvariant 5.9.2",
 ]
 
 [[package]]
@@ -9116,6 +9218,19 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive 4.2.0",
+]
+
+[[package]]
+name = "zvariant"
 version = "5.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b64ef4f40c7951337ddc7023dd03528a57a3ce3408ee9da5e948bd29b232c4"
@@ -9124,8 +9239,21 @@ dependencies = [
  "enumflags2",
  "serde",
  "winnow 0.7.14",
- "zvariant_derive",
- "zvariant_utils",
+ "zvariant_derive 5.9.2",
+ "zvariant_utils 3.3.0",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -9138,7 +9266,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "zvariant_utils",
+ "zvariant_utils 3.3.0",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -88,6 +88,7 @@ hf-hub = { git = "https://github.com/cjpais/hf-hub", branch = "cancellable-downl
 [target.'cfg(unix)'.dependencies]
 signal-hook = "0.3"
 
+
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-autostart = "2.5.1"
 tauri-plugin-global-shortcut = "2.3.1"
@@ -145,6 +146,7 @@ transcribe-cpp = { version = "0.1.0", default-features = false, features = [
   "dynamic-backends",
   "vulkan",
 ] }
+zbus = "4.0"
 
 [patch.crates-io]
 tauri-runtime = { git = "https://github.com/cjpais/tauri.git", branch = "handy-2.10.2" }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -93,6 +93,7 @@ hf-hub = { git = "https://github.com/cjpais/hf-hub", branch = "cancellable-downl
 [target.'cfg(unix)'.dependencies]
 signal-hook = "0.3"
 
+
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-autostart = "2.5.1"
 tauri-plugin-global-shortcut = "2.3.1"
@@ -163,6 +164,7 @@ transcribe-cpp = { version = "0.2.0", default-features = false, features = [
   "dynamic-backends",
   "vulkan",
 ] }
+zbus = "4.0"
 
 # TEMPORARY: tao pinned past 0.35.3 for the Wayland client-side-decorations fix
 # (tao #1218, fixes tauri #11856 — dead titlebar buttons after visible(false) →

--- a/src-tauri/resources/handy.xml
+++ b/src-tauri/resources/handy.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component>
+    <name>org.freedesktop.IBus.Handy</name>
+    <description>Handy Speech-to-Text Input Method</description>
+    <version>0.8.3</version>
+    <author>pengcheng</author>
+    <homepage>https://github.com/cjpais/Handy</homepage>
+    <exec>/usr/bin/handy --ibus-engine</exec>
+    <textdomain>handy</textdomain>
+    <engines>
+        <engine>
+            <name>handy</name>
+            <language>other</language>
+            <license>MIT</license>
+            <author>pengcheng</author>
+            <icon>handy</icon>
+            <layout>default</layout>
+            <longname>Handy Voice Input</longname>
+            <description>Handy Speech-to-Text direct typing engine</description>
+            <rank>99</rank>
+        </engine>
+    </engines>
+</component>

--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -753,31 +753,89 @@ impl ShortcutAction for TranscribeAction {
                                 let paste_time = Instant::now();
                                 let final_text = processed.final_text;
                                 let rm_for_paste = Arc::clone(&rm);
-                                ah.run_on_main_thread(move || {
-                                    if rm_for_paste.was_cancelled_since(cancel_generation) {
-                                        debug!("Transcription operation cancelled before paste");
-                                        utils::hide_recording_overlay(&ah_clone);
-                                        change_tray_icon(&ah_clone, TrayIconState::Idle);
+
+                                // Check cancellation before hiding/modifying state.
+                                if rm_for_paste.was_cancelled_since(cancel_generation) {
+                                    debug!("Transcription operation cancelled before paste");
+                                    utils::hide_recording_overlay(&ah);
+                                    change_tray_icon(&ah, TrayIconState::Idle);
+                                    return;
+                                }
+
+                                // Hide the overlay immediately on the main thread to start the fade-out
+                                // and release input focus back to the target text application.
+                                utils::hide_recording_overlay(&ah);
+                                change_tray_icon(&ah, TrayIconState::Idle);
+
+                                // Platform-specific focus delay check for Linux + IBus.
+                                // Wrapped in #[cfg(target_os = "linux")] so this logic and thread spawning
+                                // are completely stripped at compile-time on Windows and macOS.
+                                #[cfg(target_os = "linux")]
+                                {
+                                    let settings = get_settings(&ah);
+                                    let has_overlay = settings.overlay_style != OverlayStyle::None;
+                                    let is_direct = settings.paste_method
+                                        == crate::settings::PasteMethod::Direct;
+                                    let is_ibus_tool = settings.typing_tool
+                                        == crate::settings::TypingTool::Ibus
+                                        || settings.typing_tool
+                                            == crate::settings::TypingTool::Auto;
+
+                                    if has_overlay && is_direct && is_ibus_tool {
+                                        // Spawn a standard OS background thread (NOT a tokio task) to handle delay.
+                                        // The blocking D-Bus query (`will_use_ibus`) is performed safely inside this thread
+                                        // to avoid deadlocking the tokio async runtime.
+                                        let rm_for_paste2 = rm_for_paste.clone();
+                                        std::thread::spawn(move || {
+                                            if crate::clipboard::will_use_ibus(&ah_clone) {
+                                                // Sleep 400ms to allow the 300ms overlay fade-out and focus transition to complete
+                                                std::thread::sleep(
+                                                    std::time::Duration::from_millis(400),
+                                                );
+                                            }
+
+                                            let ah_clone2 = ah_clone.clone();
+                                            let rm_for_paste3 = rm_for_paste2.clone();
+                                            let _ = ah_clone.run_on_main_thread(move || {
+                                                if rm_for_paste3.was_cancelled_since(cancel_generation) {
+                                                    debug!("Transcription operation cancelled before paste");
+                                                    return;
+                                                }
+                                                match utils::paste(final_text, ah_clone2.clone()) {
+                                                    Ok(()) => debug!(
+                                                        "Text pasted successfully in {:?}",
+                                                        paste_time.elapsed()
+                                                    ),
+                                                    Err(e) => {
+                                                        error!("Failed to paste transcription: {}", e);
+                                                        let _ = ah_clone2.emit("paste-error", ());
+                                                    }
+                                                }
+                                            });
+                                        });
                                         return;
                                     }
+                                }
 
-                                    match utils::paste(final_text, ah_clone.clone()) {
+                                // For all other scenarios (Windows, macOS, and Linux without IBus/Overlay),
+                                // immediately paste on the main thread without spawning threads or sleeping!
+                                let ah_clone2 = ah_clone.clone();
+                                let rm_for_paste2 = rm_for_paste.clone();
+                                let _ = ah_clone.run_on_main_thread(move || {
+                                    if rm_for_paste2.was_cancelled_since(cancel_generation) {
+                                        debug!("Transcription operation cancelled before paste");
+                                        return;
+                                    }
+                                    match utils::paste(final_text, ah_clone2.clone()) {
                                         Ok(()) => debug!(
                                             "Text pasted successfully in {:?}",
                                             paste_time.elapsed()
                                         ),
                                         Err(e) => {
                                             error!("Failed to paste transcription: {}", e);
-                                            let _ = ah_clone.emit("paste-error", ());
+                                            let _ = ah_clone2.emit("paste-error", ());
                                         }
                                     }
-                                    utils::hide_recording_overlay(&ah_clone);
-                                    change_tray_icon(&ah_clone, TrayIconState::Idle);
-                                })
-                                .unwrap_or_else(|e| {
-                                    error!("Failed to run paste on main thread: {:?}", e);
-                                    utils::hide_recording_overlay(&ah);
-                                    change_tray_icon(&ah, TrayIconState::Idle);
                                 });
                             }
                         }

--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -810,18 +810,81 @@ impl ShortcutAction for TranscribeAction {
                                 utils::hide_recording_overlay(&ah);
                                 set_tray_state(&ah, TrayIconState::Idle);
                             } else {
-                                let ah_clone = ah.clone();
                                 let paste_time = Instant::now();
                                 let final_text = processed.final_text;
                                 let rm_for_paste = Arc::clone(&rm);
+                                // Check cancellation before hiding/modifying state.
+                                if rm_for_paste.was_cancelled_since(cancel_generation) {
+                                    debug!("Transcription operation cancelled before paste");
+                                    utils::hide_recording_overlay(&ah);
+                                    set_tray_state(&ah, TrayIconState::Idle);
+                                    return;
+                                }
+
+                                // Hide the overlay immediately on the main thread to start the fade-out
+                                // and release input focus back to the target text application.
+                                utils::hide_recording_overlay(&ah);
+                                set_tray_state(&ah, TrayIconState::Idle);
+
+                                // Platform-specific focus delay check for Linux + IBus.
+                                // Wrapped in #[cfg(target_os = "linux")] so this logic and thread spawning
+                                // are completely stripped at compile-time on Windows and macOS.
+                                #[cfg(target_os = "linux")]
+                                {
+                                    let settings = get_settings(&ah);
+                                    let has_overlay = settings.overlay_style != OverlayStyle::None;
+                                    let is_direct = settings.paste_method
+                                        == crate::settings::PasteMethod::Direct;
+                                    let is_ibus_tool = settings.typing_tool
+                                        == crate::settings::TypingTool::Ibus
+                                        || settings.typing_tool
+                                            == crate::settings::TypingTool::Auto;
+
+                                    if has_overlay && is_direct && is_ibus_tool {
+                                        // Spawn a standard OS background thread (NOT a tokio task) to handle delay.
+                                        // The blocking D-Bus query (`will_use_ibus`) is performed safely inside this thread
+                                        // to avoid deadlocking the tokio async runtime.
+                                        let ah_for_thread = ah.clone();
+                                        let rm_for_thread = rm_for_paste.clone();
+                                        std::thread::spawn(move || {
+                                            if crate::clipboard::will_use_ibus(&ah_for_thread) {
+                                                // Sleep 400ms to allow the 300ms overlay fade-out and focus transition to complete
+                                                std::thread::sleep(
+                                                    std::time::Duration::from_millis(400),
+                                                );
+                                            }
+
+                                            let ah_for_paste = ah_for_thread.clone();
+                                            let rm_for_paste = rm_for_thread.clone();
+                                            let _ = ah_for_thread.run_on_main_thread(move || {
+                                                if rm_for_paste.was_cancelled_since(cancel_generation) {
+                                                    debug!("Transcription operation cancelled before paste");
+                                                    return;
+                                                }
+                                                match utils::paste(final_text, ah_for_paste.clone()) {
+                                                    Ok(()) => debug!(
+                                                        "Text pasted successfully in {:?}",
+                                                        paste_time.elapsed()
+                                                    ),
+                                                    Err(e) => {
+                                                        error!("Failed to paste transcription: {}", e);
+                                                        let _ = ah_for_paste.emit("paste-error", ());
+                                                    }
+                                                }
+                                            });
+                                        });
+                                        return;
+                                    }
+                                }
+
+                                // For all other scenarios (Windows, macOS, and Linux without IBus/Overlay),
+                                // immediately paste on the main thread without spawning threads or sleeping!
+                                let ah_clone = ah.clone();
                                 ah.run_on_main_thread(move || {
                                     if rm_for_paste.was_cancelled_since(cancel_generation) {
                                         debug!("Transcription operation cancelled before paste");
-                                        utils::hide_recording_overlay(&ah_clone);
-                                        set_tray_state(&ah_clone, TrayIconState::Idle);
                                         return;
                                     }
-
                                     match utils::paste(final_text, ah_clone.clone()) {
                                         Ok(()) => debug!(
                                             "Text pasted successfully in {:?}",
@@ -832,8 +895,6 @@ impl ShortcutAction for TranscribeAction {
                                             let _ = ah_clone.emit("paste-error", ());
                                         }
                                     }
-                                    utils::hide_recording_overlay(&ah_clone);
-                                    set_tray_state(&ah_clone, TrayIconState::Idle);
                                 })
                                 .unwrap_or_else(|e| {
                                     error!("Failed to run paste on main thread: {:?}", e);

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -60,4 +60,8 @@ pub struct CliArgs {
     /// Emit --transcribe-file results as JSON.
     #[arg(long)]
     pub json: bool,
+
+    /// Start as IBus Input Method Engine (Linux only)
+    #[arg(long)]
+    pub ibus_engine: bool,
 }

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -124,6 +124,11 @@ fn try_direct_typing_linux(text: &str, preferred_tool: TypingTool) -> Result<boo
     // If user specified a tool, try only that one
     if preferred_tool != TypingTool::Auto {
         return match preferred_tool {
+            TypingTool::Ibus if is_ibus_available() => {
+                info!("Using user-specified IBus");
+                type_text_via_ibus_engine(text)?;
+                Ok(true)
+            }
             TypingTool::Wtype if is_wtype_available() => {
                 info!("Using user-specified wtype");
                 type_text_via_wtype(text)?;
@@ -154,6 +159,15 @@ fn try_direct_typing_linux(text: &str, preferred_tool: TypingTool) -> Result<boo
                 preferred_tool
             )),
         };
+    }
+
+    // Auto mode - prefer IBus on both Wayland and X11 if available
+    if is_ibus_available() {
+        if type_text_via_ibus_engine(text).is_ok() {
+            info!("Using IBus for direct text input in Auto mode");
+            return Ok(true);
+        }
+        info!("IBus typing failed, falling back to other tools");
     }
 
     // Auto mode - existing fallback chain
@@ -203,6 +217,9 @@ fn try_direct_typing_linux(text: &str, preferred_tool: TypingTool) -> Result<boo
 #[cfg(target_os = "linux")]
 pub fn get_available_typing_tools() -> Vec<String> {
     let mut tools = vec!["auto".to_string()];
+    if is_ibus_available() {
+        tools.push("ibus".to_string());
+    }
     if is_wtype_available() {
         tools.push("wtype".to_string());
     }
@@ -662,6 +679,154 @@ pub fn paste(text: String, app_handle: AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+#[cfg(target_os = "linux")]
+fn get_ibus_address_from_config() -> Option<String> {
+    // Locate configuration directory
+    // Get XDG_CONFIG_HOME or fallback to $HOME/.config
+    let config_dir = std::env::var("XDG_CONFIG_HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| {
+            let home = std::env::var("HOME").unwrap_or_default();
+            std::path::Path::new(&home).join(".config")
+        });
+
+    let ibus_bus_dir = config_dir.join("ibus/bus");
+    if !ibus_bus_dir.is_dir() {
+        return None;
+    }
+
+    let wayland_display = std::env::var("WAYLAND_DISPLAY").ok();
+    let display = std::env::var("DISPLAY").ok();
+
+    // Determine the exact suffix we are looking for based on current session type
+    let target_suffix = if let Some(ref wl) = wayland_display {
+        format!("unix-{}", wl)
+    } else if let Some(ref disp) = display {
+        let disp_num = disp
+            .trim_start_matches(':')
+            .split('.')
+            .next()
+            .unwrap_or("0");
+        format!("unix-{}", disp_num)
+    } else {
+        return None;
+    };
+
+    // Read the directory to find the appropriate config file
+    let mut files = std::fs::read_dir(ibus_bus_dir).ok()?;
+    let mut best_file = None;
+    let mut best_time = std::time::SystemTime::UNIX_EPOCH;
+
+    while let Some(Ok(entry)) = files.next() {
+        let path = entry.path();
+        if path.is_file() {
+            if let Some(filename) = path.file_name().and_then(|f| f.to_str()) {
+                let matches = if wayland_display.is_some() {
+                    filename.contains(&target_suffix)
+                } else {
+                    filename.contains(&target_suffix) && !filename.contains("-wayland-")
+                };
+
+                if matches {
+                    let modified = entry
+                        .metadata()
+                        .ok()
+                        .and_then(|m| m.modified().ok())
+                        .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+
+                    // If multiple files match (unlikely, but possible with stale entries),
+                    // pick the most recently modified one.
+                    if modified > best_time {
+                        best_time = modified;
+                        best_file = Some(path.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    let target_file = best_file?;
+    let content = std::fs::read_to_string(target_file).ok()?;
+
+    // Parse IBUS_ADDRESS=...
+    for line in content.lines() {
+        let line = line.trim();
+        if line.starts_with("IBUS_ADDRESS=") {
+            let addr = line.trim_start_matches("IBUS_ADDRESS=");
+            // Strip quotes if present
+            let addr = addr.trim_matches(|c| c == '\'' || c == '"');
+            if !addr.is_empty() {
+                let clean_addr = addr.split(',').next().unwrap_or(addr);
+                return Some(clean_addr.to_string());
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn get_ibus_address() -> Option<String> {
+    // 1. Try to read from display-aware config file first (most reliable and immune to stale environment variables)
+    if let Some(addr) = get_ibus_address_from_config() {
+        return Some(addr);
+    }
+
+    // 2. Fallback to env var `IBUS_ADDRESS`
+    if let Ok(addr) = std::env::var("IBUS_ADDRESS") {
+        if !addr.is_empty() {
+            let clean_addr = addr.split(',').next().unwrap_or(&addr);
+            return Some(clean_addr.to_string());
+        }
+    }
+
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn is_ibus_available() -> bool {
+    use zbus::blocking::Connection;
+    Connection::session()
+        .and_then(|conn| {
+            conn.call_method(
+                Some("org.freedesktop.DBus"),
+                "/org/freedesktop/DBus",
+                Some("org.freedesktop.DBus"),
+                "NameHasOwner",
+                &("org.freedesktop.IBus",),
+            )
+        })
+        .map(|reply| {
+            let has_owner: bool = reply.body().deserialize().unwrap_or(false);
+            has_owner
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "linux")]
+pub fn will_use_ibus(app_handle: &AppHandle) -> bool {
+    let settings = get_settings(app_handle);
+    if settings.paste_method != PasteMethod::Direct {
+        return false;
+    }
+    match settings.typing_tool {
+        TypingTool::Ibus => is_ibus_available(),
+        TypingTool::Auto => is_ibus_available(),
+        _ => false,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn type_text_via_ibus_engine(text: &str) -> Result<(), String> {
+    if !crate::ibus_engine::is_engine_active() {
+        info!("Handy IBus engine service is not active. Starting it on demand...");
+        if let Err(e) = crate::ibus_engine::start_ibus_engine_service() {
+            return Err(format!("Failed to start Handy IBus engine service: {}", e));
+        }
+    }
+    crate::ibus_engine::commit_text_via_engine(text)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -683,5 +848,56 @@ mod tests {
         assert!(should_send_auto_submit(true, PasteMethod::Direct));
         assert!(should_send_auto_submit(true, PasteMethod::CtrlShiftV));
         assert!(should_send_auto_submit(true, PasteMethod::ShiftInsert));
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_ibus_detection_and_typing_if_available() {
+        // This test runs conditionally if IBus is running on the host system.
+        // It provides a perfect way to test the D-Bus interface locally.
+        if is_ibus_available() {
+            println!("IBus is available, testing text injection...");
+            let res = type_text_via_ibus_engine("Handy IBus integration test");
+            // Note: If no input field is focused, this might return an Err,
+            // but the D-Bus connection and context lookup itself should not panic.
+            match res {
+                Ok(_) => println!("IBus injection succeeded!"),
+                Err(e) => println!(
+                    "IBus injection returned error (normal if no focused field): {}",
+                    e
+                ),
+            }
+        } else {
+            println!("IBus is not running on this host, skipping integration test.");
+        }
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_get_available_typing_tools_includes_ibus_if_running() {
+        let tools = get_available_typing_tools();
+        assert!(tools.contains(&"auto".to_string()));
+        if is_ibus_available() {
+            assert!(tools.contains(&"ibus".to_string()));
+        }
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_get_ibus_address_resolution() {
+        let addr = get_ibus_address();
+        println!("Resolved IBus address: {:?}", addr);
+        if is_ibus_available() {
+            assert!(
+                addr.is_some(),
+                "IBus is running, but get_ibus_address() failed to resolve its D-Bus address"
+            );
+            let address = addr.unwrap();
+            assert!(
+                address.starts_with("unix:"),
+                "IBus address should start with 'unix:', got: {}",
+                address
+            );
+        }
     }
 }

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -165,6 +165,11 @@ fn try_direct_typing_linux(text: &str, preferred_tool: TypingTool) -> Result<boo
     // If user specified a tool, try only that one
     if preferred_tool != TypingTool::Auto {
         return match preferred_tool {
+            TypingTool::Ibus if is_ibus_available() => {
+                info!("Using user-specified IBus");
+                type_text_via_ibus_engine(text)?;
+                Ok(true)
+            }
             TypingTool::Wtype if is_wtype_available() => {
                 info!("Using user-specified wtype");
                 type_text_via_wtype(text)?;
@@ -195,6 +200,15 @@ fn try_direct_typing_linux(text: &str, preferred_tool: TypingTool) -> Result<boo
                 preferred_tool
             )),
         };
+    }
+
+    // Auto mode - prefer IBus on both Wayland and X11 if available
+    if is_ibus_available() {
+        if type_text_via_ibus_engine(text).is_ok() {
+            info!("Using IBus for direct text input in Auto mode");
+            return Ok(true);
+        }
+        info!("IBus typing failed, falling back to other tools");
     }
 
     // Auto mode - existing fallback chain
@@ -246,6 +260,9 @@ fn try_direct_typing_linux(text: &str, preferred_tool: TypingTool) -> Result<boo
 #[cfg(target_os = "linux")]
 pub fn get_available_typing_tools() -> Vec<String> {
     let mut tools = vec!["auto".to_string()];
+    if is_ibus_available() {
+        tools.push("ibus".to_string());
+    }
     if is_wtype_available() {
         tools.push("wtype".to_string());
     }
@@ -863,6 +880,154 @@ pub fn paste(text: String, app_handle: AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+#[cfg(target_os = "linux")]
+fn get_ibus_address_from_config() -> Option<String> {
+    // Locate configuration directory
+    // Get XDG_CONFIG_HOME or fallback to $HOME/.config
+    let config_dir = std::env::var("XDG_CONFIG_HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| {
+            let home = std::env::var("HOME").unwrap_or_default();
+            std::path::Path::new(&home).join(".config")
+        });
+
+    let ibus_bus_dir = config_dir.join("ibus/bus");
+    if !ibus_bus_dir.is_dir() {
+        return None;
+    }
+
+    let wayland_display = std::env::var("WAYLAND_DISPLAY").ok();
+    let display = std::env::var("DISPLAY").ok();
+
+    // Determine the exact suffix we are looking for based on current session type
+    let target_suffix = if let Some(ref wl) = wayland_display {
+        format!("unix-{}", wl)
+    } else if let Some(ref disp) = display {
+        let disp_num = disp
+            .trim_start_matches(':')
+            .split('.')
+            .next()
+            .unwrap_or("0");
+        format!("unix-{}", disp_num)
+    } else {
+        return None;
+    };
+
+    // Read the directory to find the appropriate config file
+    let mut files = std::fs::read_dir(ibus_bus_dir).ok()?;
+    let mut best_file = None;
+    let mut best_time = std::time::SystemTime::UNIX_EPOCH;
+
+    while let Some(Ok(entry)) = files.next() {
+        let path = entry.path();
+        if path.is_file() {
+            if let Some(filename) = path.file_name().and_then(|f| f.to_str()) {
+                let matches = if wayland_display.is_some() {
+                    filename.contains(&target_suffix)
+                } else {
+                    filename.contains(&target_suffix) && !filename.contains("-wayland-")
+                };
+
+                if matches {
+                    let modified = entry
+                        .metadata()
+                        .ok()
+                        .and_then(|m| m.modified().ok())
+                        .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+
+                    // If multiple files match (unlikely, but possible with stale entries),
+                    // pick the most recently modified one.
+                    if modified > best_time {
+                        best_time = modified;
+                        best_file = Some(path.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    let target_file = best_file?;
+    let content = std::fs::read_to_string(target_file).ok()?;
+
+    // Parse IBUS_ADDRESS=...
+    for line in content.lines() {
+        let line = line.trim();
+        if line.starts_with("IBUS_ADDRESS=") {
+            let addr = line.trim_start_matches("IBUS_ADDRESS=");
+            // Strip quotes if present
+            let addr = addr.trim_matches(|c| c == '\'' || c == '"');
+            if !addr.is_empty() {
+                let clean_addr = addr.split(',').next().unwrap_or(addr);
+                return Some(clean_addr.to_string());
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn get_ibus_address() -> Option<String> {
+    // 1. Try to read from display-aware config file first (most reliable and immune to stale environment variables)
+    if let Some(addr) = get_ibus_address_from_config() {
+        return Some(addr);
+    }
+
+    // 2. Fallback to env var `IBUS_ADDRESS`
+    if let Ok(addr) = std::env::var("IBUS_ADDRESS") {
+        if !addr.is_empty() {
+            let clean_addr = addr.split(',').next().unwrap_or(&addr);
+            return Some(clean_addr.to_string());
+        }
+    }
+
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn is_ibus_available() -> bool {
+    use zbus::blocking::Connection;
+    Connection::session()
+        .and_then(|conn| {
+            conn.call_method(
+                Some("org.freedesktop.DBus"),
+                "/org/freedesktop/DBus",
+                Some("org.freedesktop.DBus"),
+                "NameHasOwner",
+                &("org.freedesktop.IBus",),
+            )
+        })
+        .map(|reply| {
+            let has_owner: bool = reply.body().deserialize().unwrap_or(false);
+            has_owner
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "linux")]
+pub fn will_use_ibus(app_handle: &AppHandle) -> bool {
+    let settings = get_settings(app_handle);
+    if settings.paste_method != PasteMethod::Direct {
+        return false;
+    }
+    match settings.typing_tool {
+        TypingTool::Ibus => is_ibus_available(),
+        TypingTool::Auto => is_ibus_available(),
+        _ => false,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn type_text_via_ibus_engine(text: &str) -> Result<(), String> {
+    if !crate::ibus_engine::is_engine_active() {
+        info!("Handy IBus engine service is not active. Starting it on demand...");
+        if let Err(e) = crate::ibus_engine::start_ibus_engine_service() {
+            return Err(format!("Failed to start Handy IBus engine service: {}", e));
+        }
+    }
+    crate::ibus_engine::commit_text_via_engine(text)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1011,5 +1176,56 @@ e.g. 28:1 28:0 means pressing on the Enter button on a standard US keyboard.
             .expect("external script should return without waiting for its child");
         fs::remove_file(script_path).expect("remove external script");
         assert!(result.is_ok());
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_ibus_detection_and_typing_if_available() {
+        // This test runs conditionally if IBus is running on the host system.
+        // It provides a perfect way to test the D-Bus interface locally.
+        if is_ibus_available() {
+            println!("IBus is available, testing text injection...");
+            let res = type_text_via_ibus_engine("Handy IBus integration test");
+            // Note: If no input field is focused, this might return an Err,
+            // but the D-Bus connection and context lookup itself should not panic.
+            match res {
+                Ok(_) => println!("IBus injection succeeded!"),
+                Err(e) => println!(
+                    "IBus injection returned error (normal if no focused field): {}",
+                    e
+                ),
+            }
+        } else {
+            println!("IBus is not running on this host, skipping integration test.");
+        }
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_get_available_typing_tools_includes_ibus_if_running() {
+        let tools = get_available_typing_tools();
+        assert!(tools.contains(&"auto".to_string()));
+        if is_ibus_available() {
+            assert!(tools.contains(&"ibus".to_string()));
+        }
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_get_ibus_address_resolution() {
+        let addr = get_ibus_address();
+        println!("Resolved IBus address: {:?}", addr);
+        if is_ibus_available() {
+            assert!(
+                addr.is_some(),
+                "IBus is running, but get_ibus_address() failed to resolve its D-Bus address"
+            );
+            let address = addr.unwrap();
+            assert!(
+                address.starts_with("unix:"),
+                "IBus address should start with 'unix:', got: {}",
+                address
+            );
+        }
     }
 }

--- a/src-tauri/src/ibus_engine.rs
+++ b/src-tauri/src/ibus_engine.rs
@@ -1,0 +1,350 @@
+use log::{debug, info};
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+use zbus::object_server::SignalContext;
+use zbus::zvariant::{OwnedObjectPath, OwnedValue, Value};
+use zbus::{blocking::Connection, interface, Result};
+
+static IBUS_CONN: Lazy<Mutex<Option<Connection>>> = Lazy::new(|| Mutex::new(None));
+static ENGINE_ENABLED: AtomicBool = AtomicBool::new(false);
+static ENGINE_FOCUSED: AtomicBool = AtomicBool::new(false);
+static ACTIVE_ENGINE_PATH: Lazy<Mutex<Option<String>>> = Lazy::new(|| Mutex::new(None));
+
+pub struct HandyIBusEngine;
+
+#[interface(name = "org.freedesktop.IBus.Engine")]
+impl HandyIBusEngine {
+    fn process_key_event(&self, _keyval: u32, _keycode: u32, _modifiers: u32) -> bool {
+        // Let all keypresses pass through transparently
+        false
+    }
+
+    fn focus_in(&self) {
+        debug!("Handy IBus Engine focused");
+        ENGINE_FOCUSED.store(true, Ordering::SeqCst);
+    }
+
+    fn focus_out(&self) {
+        debug!("Handy IBus Engine lost focus");
+        ENGINE_FOCUSED.store(false, Ordering::SeqCst);
+    }
+
+    fn enable(&self) {
+        debug!("Handy IBus Engine enabled");
+        ENGINE_ENABLED.store(true, Ordering::SeqCst);
+    }
+
+    fn disable(&self) {
+        debug!("Handy IBus Engine disabled");
+        ENGINE_ENABLED.store(false, Ordering::SeqCst);
+    }
+
+    #[zbus(signal)]
+    pub async fn commit_text(signal_ctxt: &SignalContext<'_>, text: Value<'_>) -> Result<()>;
+}
+
+pub struct HandyIBusFactory {
+    connection: Connection,
+}
+
+#[interface(name = "org.freedesktop.IBus.Factory")]
+impl HandyIBusFactory {
+    fn create_engine(&self, name: &str) -> zbus::fdo::Result<OwnedObjectPath> {
+        debug!("IBus Factory CreateEngine called for: {}", name);
+        if name == "handy" {
+            let engine = HandyIBusEngine;
+            static INSTANCE_COUNTER: std::sync::atomic::AtomicUsize =
+                std::sync::atomic::AtomicUsize::new(1);
+            let instance_id = INSTANCE_COUNTER.fetch_add(1, Ordering::SeqCst);
+            let path = format!("/org/freedesktop/IBus/Engine/Handy/{}", instance_id);
+
+            self.connection
+                .object_server()
+                .at(path.as_str(), engine)
+                .map_err(|e| {
+                    zbus::fdo::Error::Failed(format!("Failed to register engine: {}", e))
+                })?;
+            debug!("Handy IBus Engine successfully created at {}", path);
+
+            let mut active_path = ACTIVE_ENGINE_PATH.lock().unwrap();
+            *active_path = Some(path.clone());
+
+            OwnedObjectPath::try_from(path).map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        } else {
+            Err(zbus::fdo::Error::Failed("Unsupported engine".to_string()))
+        }
+    }
+}
+
+pub fn is_engine_active() -> bool {
+    IBUS_CONN.lock().unwrap().is_some()
+}
+
+pub fn start_ibus_engine_service() -> std::result::Result<(), String> {
+    if is_engine_active() {
+        info!("Handy IBus Engine service is already active. Skipping initialization.");
+        return Ok(());
+    }
+
+    info!("Starting Handy IBus Input Method Engine D-Bus service...");
+
+    let addr = crate::clipboard::get_ibus_address()
+        .ok_or_else(|| "Failed to locate active IBus private socket address.".to_string())?;
+
+    info!("Connecting to IBus private bus at {}", addr);
+    let conn = zbus::blocking::connection::Builder::address(addr.as_str())
+        .map_err(|e| format!("Invalid address: {}", e))?
+        .build()
+        .map_err(|e| format!("Failed to connect to IBus private bus: {}", e))?;
+
+    info!("Requesting well-known name org.freedesktop.IBus.Handy");
+    conn.request_name("org.freedesktop.IBus.Handy")
+        .map_err(|e| {
+            format!(
+                "Failed to request D-Bus name org.freedesktop.IBus.Handy: {}",
+                e
+            )
+        })?;
+
+    info!("Registering IBus Factory at /org/freedesktop/IBus/Factory");
+    let factory = HandyIBusFactory {
+        connection: conn.clone(),
+    };
+    conn.object_server()
+        .at("/org/freedesktop/IBus/Factory", factory)
+        .map_err(|e| format!("Failed to register IBus factory: {}", e))?;
+
+    // Store the connection globally for future CommitText signal emissions
+    let mut global_conn = IBUS_CONN.lock().unwrap();
+    *global_conn = Some(conn);
+
+    info!("Handy IBus Input Method Engine D-Bus service successfully initialized!");
+    Ok(())
+}
+
+fn get_current_global_engine(conn: &Connection) -> std::result::Result<String, String> {
+    let reply = conn
+        .call_method(
+            Some("org.freedesktop.IBus"),
+            "/org/freedesktop/IBus",
+            Some("org.freedesktop.DBus.Properties"),
+            "Get",
+            &("org.freedesktop.IBus", "GlobalEngine"),
+        )
+        .map_err(|e| format!("Failed to get GlobalEngine property: {}", e))?;
+
+    let val: OwnedValue = reply
+        .body()
+        .deserialize()
+        .map_err(|e| format!("Failed to parse GlobalEngine reply: {}", e))?;
+
+    // The property is a Variant containing a struct (sa{sv}ssssssssussssssss)
+    let val_ref: &Value<'_> = &*val;
+    if let Value::Value(inner_val) = val_ref {
+        if let Value::Structure(structure) = inner_val.as_ref() {
+            let fields = structure.fields();
+            if fields.len() >= 3 {
+                if let Value::Str(engine_name) = &fields[2] {
+                    return Ok(engine_name.to_string());
+                }
+            }
+        }
+    }
+
+    Err("Failed to extract engine name from GlobalEngine structure".to_string())
+}
+
+fn set_global_engine(conn: &Connection, engine_name: &str) -> std::result::Result<(), String> {
+    conn.call_method(
+        Some("org.freedesktop.IBus"),
+        "/org/freedesktop/IBus",
+        Some("org.freedesktop.IBus"),
+        "SetGlobalEngine",
+        &(engine_name,),
+    )
+    .map_err(|e| format!("Failed to set GlobalEngine to {}: {}", engine_name, e))?;
+    Ok(())
+}
+
+pub fn commit_text_via_engine(text: &str) -> std::result::Result<(), String> {
+    debug!("Attempting to commit text via IBus Engine: {}", text);
+
+    let conn_guard = IBUS_CONN.lock().unwrap();
+    let conn = conn_guard
+        .as_ref()
+        .ok_or_else(|| "IBus Engine D-Bus connection is not initialized.".to_string())?;
+
+    // 1. Get original global engine so we can restore it later
+    let original_engine = match get_current_global_engine(conn) {
+        Ok(eng) => {
+            debug!("Current global active IBus engine is: {}", eng);
+            Some(eng)
+        }
+        Err(e) => {
+            log::warn!(
+                "Failed to retrieve current active IBus engine: {}. Skipping auto-restore.",
+                e
+            );
+            None
+        }
+    };
+
+    // 2. Temporarily switch global engine to 'handy'
+    let switch_success = if let Some(ref orig) = original_engine {
+        if orig != "handy" {
+            debug!("Switching IBus active engine to 'handy'");
+
+            // Reset atomic flags before switching
+            ENGINE_ENABLED.store(false, Ordering::SeqCst);
+            ENGINE_FOCUSED.store(false, Ordering::SeqCst);
+
+            if let Err(e) = set_global_engine(conn, "handy") {
+                log::warn!(
+                    "Failed to switch to handy engine: {}. Trying to commit anyway.",
+                    e
+                );
+                false
+            } else {
+                // Wait for the engine to be enabled and focused
+                let start = std::time::Instant::now();
+                let mut focused = false;
+                let mut enabled = false;
+                while start.elapsed() < std::time::Duration::from_millis(1500) {
+                    focused = ENGINE_FOCUSED.load(Ordering::SeqCst);
+                    enabled = ENGINE_ENABLED.load(Ordering::SeqCst);
+                    if focused && enabled {
+                        break;
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+                if !focused || !enabled {
+                    log::warn!("Timed out waiting for Handy IBus Engine to be focused/enabled (focused: {}, enabled: {}). Proceeding anyway.", focused, enabled);
+                } else {
+                    debug!("Handy IBus Engine is active and focused. Sleeping 500ms for client context switch...");
+                    std::thread::sleep(std::time::Duration::from_millis(500));
+                    debug!("Ready to commit text!");
+                }
+                true
+            }
+        } else {
+            false
+        }
+    } else {
+        false
+    };
+
+    // 3. Emit CommitText signal
+    // Construct empty IBusAttrList: ("IBusAttrList", {}, [])
+    let empty_properties = HashMap::<String, Value>::new();
+    let empty_attributes = Vec::<Value>::new();
+    let attr_list_struct = ("IBusAttrList", empty_properties, empty_attributes);
+    let attr_list_variant = Value::new(attr_list_struct);
+
+    // Construct IBusText: ("IBusText", {}, text, attr_list_variant)
+    let empty_properties2 = HashMap::<String, Value>::new();
+    let ibus_text_struct = (
+        "IBusText",
+        empty_properties2,
+        text.to_string(),
+        attr_list_variant,
+    );
+
+    // Wrap in Value so zbus serializes it as a Variant containing the (sa{sv}sv) struct
+    let val = Value::new(ibus_text_struct);
+
+    let engine_path = {
+        let active_path = ACTIVE_ENGINE_PATH.lock().unwrap();
+        active_path
+            .clone()
+            .unwrap_or_else(|| "/org/freedesktop/IBus/Engine/Handy".to_string())
+    };
+
+    debug!(
+        "Emitting CommitText signal from active engine path: {}",
+        engine_path
+    );
+
+    conn.emit_signal(
+        None::<&str>,
+        engine_path.as_str(),
+        "org.freedesktop.IBus.Engine",
+        "CommitText",
+        &(val,),
+    )
+    .map_err(|e| format!("Failed to emit CommitText signal from Engine: {}", e))?;
+
+    debug!("Successfully committed text via IBus Engine!");
+
+    // 4. Restore original active engine if we switched it
+    if switch_success {
+        if let Some(ref orig) = original_engine {
+            // Sleep 1000ms to ensure the signal is processed before switching back
+            std::thread::sleep(std::time::Duration::from_millis(1000));
+            debug!("Restoring IBus active engine to '{}'", orig);
+            let _ = set_global_engine(conn, orig);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_debug_get_current_global_engine() {
+        let addr = crate::clipboard::get_ibus_address().expect("IBus address");
+        let conn = zbus::blocking::connection::Builder::address(addr.as_str())
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let reply = conn
+            .call_method(
+                Some("org.freedesktop.IBus"),
+                "/org/freedesktop/IBus",
+                Some("org.freedesktop.DBus.Properties"),
+                "Get",
+                &("org.freedesktop.IBus", "GlobalEngine"),
+            )
+            .unwrap();
+
+        let val: zbus::zvariant::OwnedValue = reply.body().deserialize().unwrap();
+        println!("Full zvariant value: {:?}", val);
+
+        let eng = get_current_global_engine(&conn).unwrap();
+        println!("Resolved engine name: {:?}", eng);
+    }
+
+    #[test]
+    fn test_construct_correct_ibus_text_signature() {
+        use std::collections::HashMap;
+        use zbus::zvariant::Value;
+
+        let text = "Hello IBus!";
+
+        // 1. Construct empty IBusAttrList: ("IBusAttrList", {}, [])
+        let empty_properties = HashMap::<String, Value>::new();
+        let empty_attributes = Vec::<Value>::new();
+        let attr_list_struct = ("IBusAttrList", empty_properties, empty_attributes);
+        let attr_list_variant = Value::new(attr_list_struct);
+
+        // 2. Construct IBusText: ("IBusText", {}, text, attr_list_variant)
+        let empty_properties2 = HashMap::<String, Value>::new();
+        let ibus_text_struct = (
+            "IBusText",
+            empty_properties2,
+            text.to_string(),
+            attr_list_variant,
+        );
+        let val = Value::new(ibus_text_struct);
+
+        println!("Rust constructed Value: {:?}", val);
+        let signature = val.value_signature();
+        println!("Signature: {:?}", signature);
+        assert_eq!(signature.as_str(), "(sa{sv}sv)");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,8 @@ pub mod cli;
 mod clipboard;
 mod commands;
 mod helpers;
+#[cfg(target_os = "linux")]
+pub mod ibus_engine;
 mod input;
 mod llm_client;
 mod managers;
@@ -729,6 +731,14 @@ pub fn run(cli_args: CliArgs) {
                 signal_handle::send_transcription_input(app, "transcribe_with_post_process", "CLI");
             } else if args.iter().any(|a| a == "--cancel") {
                 crate::utils::cancel_current_operation(app);
+            } else if args.iter().any(|a| a == "--ibus-engine") {
+                #[cfg(target_os = "linux")]
+                {
+                    log::info!("Received --ibus-engine via single instance");
+                    if let Err(e) = crate::ibus_engine::start_ibus_engine_service() {
+                        log::error!("Failed to start IBus engine service: {}", e);
+                    }
+                }
             } else {
                 show_main_window(app);
             }
@@ -841,6 +851,14 @@ pub fn run(cli_args: CliArgs) {
                 settings.overlay_style != settings::OverlayStyle::None,
             );
 
+            #[cfg(target_os = "linux")]
+            {
+                log::info!("Automatically starting IBus engine service on Linux startup...");
+                if let Err(e) = crate::ibus_engine::start_ibus_engine_service() {
+                    log::warn!("IBus engine service could not be started on startup: {}. (This is expected if not running under IBus).", e);
+                }
+            }
+
             // Pre-warm GPU/accelerator enumeration on a background thread. The first
             // get_available_accelerators call enumerates ORT execution providers and
             // transcribe-cpp compute devices, which can take a moment; without this
@@ -858,7 +876,7 @@ pub fn run(cli_args: CliArgs) {
             // Show main window only if not starting hidden.
             // CLI --start-hidden flag overrides the setting.
             // But if permission onboarding is required, always show the window.
-            let should_hide = settings.start_hidden || cli_args.start_hidden;
+            let should_hide = settings.start_hidden || cli_args.start_hidden || cli_args.ibus_engine;
             let should_force_show = should_force_show_permissions_window(&app_handle);
 
             // If start_hidden but tray is disabled, we must show the window

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,8 @@ pub mod cli;
 mod clipboard;
 mod commands;
 mod helpers;
+#[cfg(target_os = "linux")]
+pub mod ibus_engine;
 mod input;
 mod llm_client;
 mod managers;
@@ -855,6 +857,14 @@ pub fn run(cli_args: CliArgs) {
                 signal_handle::send_transcription_input(app, "transcribe_with_post_process", "CLI");
             } else if args.iter().any(|a| a == "--cancel") {
                 crate::utils::cancel_current_operation(app);
+            } else if args.iter().any(|a| a == "--ibus-engine") {
+                #[cfg(target_os = "linux")]
+                {
+                    log::info!("Received --ibus-engine via single instance");
+                    if let Err(e) = crate::ibus_engine::start_ibus_engine_service() {
+                        log::error!("Failed to start IBus engine service: {}", e);
+                    }
+                }
             } else {
                 // A second process was launched without remote-control flags
                 // (e.g. the binary run from a shell). On macOS, relaunching the
@@ -988,6 +998,14 @@ pub fn run(cli_args: CliArgs) {
                 settings.overlay_style != settings::OverlayStyle::None,
             );
 
+            #[cfg(target_os = "linux")]
+            {
+                log::info!("Automatically starting IBus engine service on Linux startup...");
+                if let Err(e) = crate::ibus_engine::start_ibus_engine_service() {
+                    log::warn!("IBus engine service could not be started on startup: {}. (This is expected if not running under IBus).", e);
+                }
+            }
+
             // Pre-warm GPU/accelerator enumeration on a background thread. The first
             // get_available_accelerators call enumerates ORT execution providers and
             // transcribe-cpp compute devices, which can take a moment; without this
@@ -1005,7 +1023,7 @@ pub fn run(cli_args: CliArgs) {
             // Show main window only if not starting hidden.
             // CLI --start-hidden flag overrides the setting.
             // But if permission onboarding is required, always show the window.
-            let should_hide = settings.start_hidden || cli_args.start_hidden;
+            let should_hide = settings.start_hidden || cli_args.start_hidden || cli_args.ibus_engine;
             let should_force_show = should_force_show_permissions_window(&app_handle);
 
             // If start_hidden but tray is disabled, we must show the window

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -268,6 +268,7 @@ pub enum TypingTool {
     Dotool,
     Ydotool,
     Xdotool,
+    Ibus,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Type, Default)]

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -294,6 +294,7 @@ pub enum TypingTool {
     Dotool,
     Ydotool,
     Xdotool,
+    Ibus,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Type, Default)]

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -797,6 +797,7 @@ pub fn change_typing_tool_setting(app: AppHandle, tool: String) -> Result<(), St
         "dotool" => TypingTool::Dotool,
         "ydotool" => TypingTool::Ydotool,
         "xdotool" => TypingTool::Xdotool,
+        "ibus" => TypingTool::Ibus,
         other => {
             warn!("Invalid typing tool '{}', defaulting to auto", other);
             TypingTool::Auto

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -929,6 +929,7 @@ pub fn change_typing_tool_setting(app: AppHandle, tool: String) -> Result<(), St
         "dotool" => TypingTool::Dotool,
         "ydotool" => TypingTool::Ydotool,
         "xdotool" => TypingTool::Xdotool,
+        "ibus" => TypingTool::Ibus,
         other => {
             warn!("Invalid typing tool '{}', defaulting to auto", other);
             TypingTool::Auto

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -988,7 +988,7 @@ export type StreamTextEvent = { committed: string; tentative: string }
  */
 export type StreamWorkKind = "transcribing" | "polishing"
 export type TranscribeAcceleratorSetting = "auto" | "cpu" | "gpu"
-export type TypingTool = "auto" | "wtype" | "kwtype" | "dotool" | "ydotool" | "xdotool"
+export type TypingTool = "auto" | "wtype" | "kwtype" | "dotool" | "ydotool" | "xdotool" | "ibus"
 export type WindowsMicrophonePermissionStatus = { supported: boolean; overall_access: PermissionAccess; device_access: PermissionAccess; app_access: PermissionAccess; desktop_app_access: PermissionAccess }
 
 /** tauri-specta globals **/

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1169,7 +1169,7 @@ export type StreamWorkKind = "transcribing" | "polishing"
  */
 export type Theme = "system" | "light" | "dark"
 export type TranscribeAcceleratorSetting = "auto" | "cpu" | "gpu"
-export type TypingTool = "auto" | "wtype" | "kwtype" | "dotool" | "ydotool" | "xdotool"
+export type TypingTool = "auto" | "wtype" | "kwtype" | "dotool" | "ydotool" | "xdotool" | "ibus"
 export type VadBackend = "silero" | "earshot"
 export type WindowsMicrophonePermissionStatus = { supported: boolean; overall_access: PermissionAccess; device_access: PermissionAccess; app_access: PermissionAccess; desktop_app_access: PermissionAccess }
 

--- a/src/components/settings/TypingTool.tsx
+++ b/src/components/settings/TypingTool.tsx
@@ -13,6 +13,7 @@ interface TypingToolProps {
 }
 
 const allToolLabels: Record<string, string> = {
+  ibus: "IBus",
   wtype: "wtype",
   kwtype: "kwtype",
   dotool: "dotool",


### PR DESCRIPTION
# feat(ibus): implement robust native IBus direct input engine and silent startup

 - Solves issues with Wayland client focus loss during overlay fadeout by introducing a targeted 400ms hybrid delay only when overlay is visible under IBus.
 - Avoids deadlocks by running blocking zbus session lookups in a dedicated std thread rather than the Tokio async worker pool.
 - Allows silent startup when launched via ibus-daemon by hiding settings GUI if the --ibus-engine flag is present.
 - Registers the Handy engine with language category 'other' to make it neutral and selectable by all locale configurations.

## Before Submitting This PR

**Please confirm you have done the following:**

 - [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to
ensure this isn't a duplicate
 - [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

 **If this is a feature or change that was previously closed/rejected:**

 - [x] I have explained in the description below why this should be reconsidered
 - [ ] I have gathered community feedback (link to discussion below)

 I found that the current direct method on Linux interacts directly with the underlying input layer, meaning it cannot input Chinese and requires specific low-level privileges. Since I am currently using the ibus IME framework, I considered implementing handy as an ibus input method engine.

Given that voice input is not the primary desktop input method, an internal IME switching logic was introduced. The purpose of this logic is to automatically revert to the original system input method once the intended text is rendered on the screen.
  ## Related Issues/Discussions

  Fixes 
  Discussion:

  ## Community Feedback

  This PR resolves Wayland/Linux direct typing stability and clipboard pollution issues frequently encountered by Linux users, providing a robust integration with standard
IBus input frameworks (like Rime etc.).

  ## Testing

  I have extensively tested these changes locally on Arch Linux (GNOME Shell on Wayland):
  - **Direct Input Verification**: Focused multiple targets (VS Code, Chrome inputs, Terminal), pressed `Ctrl+Space` for dictation, and verified that recognized text is
committed via `CommitText` signal instantly and 100% reliably.
  - **Hybrid Focus Delay**: Verified that when the layer-shell recording overlay is active, the 400ms delay in a spawned background thread allows the overlay to fade out
cleanly and restore physical window focus to the editor before sending IBus signals.
  - **Deadlock Mitigation**: Confirmed that moving blocking `zbus` connection lookups to a native OS thread entirely prevents Tokio runtime worker thread pool
starvation/deadlocks.
  - **Silent Startup**: Tested manual switching to Handy engine and verified that it launches silently via `ibus-daemon` as `/usr/bin/handy --ibus-engine` without showing
the main settings window.
  - **Unit Tests**: Ran `cargo test` in `src-tauri` to verify IBus D-Bus connectivity, address resolution, and `(sa{sv}sv)` GVariant payload schema correctness.

  ## Screenshots/Videos (if applicable)

  <!-- Add screenshots or videos demonstrating the change -->

  ## AI Assistance

  - [ ] No AI was used in this PR
  - [x] AI was used (please describe below)

  **If AI was used:**

  - **Tools used**: Antigravity.
  - **How extensively**: Co-authored the core D-Bus signal serialization mapping `(sa{sv}sv)` inside `src-tauri/src/ibus_engine.rs`, designed the async deadlock mitigation
threading architecture in `actions.rs`, and assisted in refining command-line parsing for silent launcher support in `lib.rs` and local AUR `PKGBUILD` validation.
  ```***
