### PR TITLE
fix: skip post-processing for empty/whitespace transcriptions (#1409)

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -346,6 +346,10 @@ pub(crate) struct ProcessedTranscription {
     pub post_process_prompt: Option<String>,
 }
 
+fn should_run_post_process(post_process: bool, text: &str) -> bool {
+    post_process && !text.trim().is_empty()
+}
+
 pub(crate) async fn process_transcription_output(
     app: &AppHandle,
     transcription: &str,
@@ -360,7 +364,7 @@ pub(crate) async fn process_transcription_output(
         final_text = converted_text;
     }
 
-    if post_process {
+    if should_run_post_process(post_process, &final_text) {
         if let Some(processed_text) = post_process_transcription(&settings, &final_text).await {
             post_processed_text = Some(processed_text.clone());
             final_text = processed_text;
@@ -719,3 +723,28 @@ pub static ACTION_MAP: Lazy<HashMap<String, Arc<dyn ShortcutAction>>> = Lazy::ne
     );
     map
 });
+
+#[cfg(test)]
+mod tests {
+    use super::should_run_post_process;
+
+    #[test]
+    fn skips_post_process_for_empty_transcription() {
+        assert!(!should_run_post_process(true, ""));
+    }
+
+    #[test]
+    fn skips_post_process_for_whitespace_transcription() {
+        assert!(!should_run_post_process(true, " \n\t "));
+    }
+
+    #[test]
+    fn allows_post_process_for_non_empty_transcription() {
+        assert!(should_run_post_process(true, "hello"));
+    }
+
+    #[test]
+    fn skips_post_process_when_feature_is_disabled() {
+        assert!(!should_run_post_process(false, "hello"));
+    }
+}


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

When using Handy, I noticed that releasing the hotkey without speaking could still trigger post-processing and see a model-generated message like “you need to provide the transcription” in the History. This felt incorrect because there was no actual transcription content to process. This change adds a guard to skip post-processing when the transcription is empty or whitespace-only, so only real speech output is post-processed.

## Related Issues/Discussions

Fixes #1409  
Discussion: N/A (bug fix tracked in issue)

## Community Feedback

Issue confirmation and maintainer agreement:
- https://github.com/cjpais/Handy/issues/1409
<img width="950" height="158" alt="image" src="https://github.com/user-attachments/assets/aa708b9a-13d5-4a57-94da-31fdc2ae6298" />


## Testing

### Focused backend tests
- Command:
  ```bash
  cd src-tauri
  cargo test should_run_post_process -- --nocapture
```
## AI Assistance

<!-- AI-assisted PRs are welcome! Just let us know so we can review appropriately. -->

- [ ] No AI was used in this PR
- [x ] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex (GPT-5.5)
- How extensively: Helped trace the backend path, implement the empty/whitespace guard, and add focused Rust unit tests.
