### PR TITLE
feat: add Whisper large-v3 full precision model option

### DIFF
--- a/src-tauri/src/managers/model.rs
+++ b/src-tauri/src/managers/model.rs
@@ -232,6 +232,36 @@ impl ModelManager {
             },
         );
 
+        // Whisper large-v3 full precision (no quantization) — highest accuracy
+        available_models.insert(
+            "large-v3-full".to_string(),
+            ModelInfo {
+                id: "large-v3-full".to_string(),
+                name: "Whisper Large v3 (Full)".to_string(),
+                description: "Best accuracy, but very slow. Full precision, no quantization."
+                    .to_string(),
+                filename: "ggml-large-v3.bin".to_string(),
+                url: Some(
+                    "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3.bin"
+                        .to_string(),
+                ),
+                sha256: None, // Full-precision model from HuggingFace — verify after download
+                size_mb: 2965,
+                is_downloaded: false,
+                is_downloading: false,
+                partial_size: 0,
+                is_directory: false,
+                engine_type: EngineType::Whisper,
+                accuracy_score: 0.95,
+                speed_score: 0.15,
+                supports_translation: true,
+                is_recommended: false,
+                supported_languages: whisper_languages.clone(),
+                supports_language_selection: true,
+                is_custom: false,
+            },
+        );
+
         available_models.insert(
             "breeze-asr".to_string(),
             ModelInfo {

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -45,6 +45,10 @@
         "name": "Whisper Large",
         "description": "Good accuracy, but slow."
       },
+      "large-v3-full": {
+        "name": "Whisper Large v3 (Full)",
+        "description": "Best accuracy, but very slow. Full precision, no quantization."
+      },
       "parakeet-tdt-0.6b-v2": {
         "name": "Parakeet V2",
         "description": "English only. The best model for English speakers."

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -45,6 +45,10 @@
         "name": "Whisper Large",
         "description": "Хорошая точность, но медленная."
       },
+      "large-v3-full": {
+        "name": "Whisper Large v3 (полная)",
+        "description": "Лучшая точность, но очень медленная. Без квантизации."
+      },
       "parakeet-tdt-0.6b-v2": {
         "name": "Parakeet V2",
         "description": "Только английский. Лучшая модель для англоговорящих."


### PR DESCRIPTION
## Summary

Adds an **unquantized (FP16) Whisper large-v3** model option alongside the existing Q5_0-quantized variant.

### What changed

- **`src-tauri/src/managers/model.rs`** — new model entry `"large-v3-full"` (id, filename `ggml-large-v3.bin`, download URL from HuggingFace, accuracy/speed scores)
- **`src/i18n/locales/en/translation.json`** — English name + description
- **`src/i18n/locales/ru/translation.json`** — Russian name + description

### Details

| Property | Existing `large` | New `large-v3-full` |
|---|---|---|
| File | `ggml-large-v3-q5_0.bin` | `ggml-large-v3.bin` |
| Size | ~1.1 GiB | ~2.9 GiB |
| Quantization | Q5_0 | None (FP16) |
| Accuracy | 0.85 | 0.95 |
| Speed | 0.30 | 0.15 |

- Uses the same GGML format and `WhisperEngine` loader — **no changes to the transcription pipeline**
- Model sourced from [`ggerganov/whisper.cpp`](https://huggingface.co/ggerganov/whisper.cpp/tree/main) on HuggingFace
- `sha256` set to `None` since the hash is not yet published at the HF source; can be added after first verified download
- Supports translation to English (same as existing large-v3)

### Testing

- Verify the model appears in the Models settings page
- Download completes successfully (~2.9 GiB)
- Transcription works with the full-precision model
- Translation to English works