### PR TITLE
docs: add Intel Mac (x86_64) build instructions

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -17,6 +17,21 @@ This guide covers how to set up the development environment and build Handy from
 - Xcode Command Line Tools
 - Install with: `xcode-select --install`
 
+##### Intel Mac (x86_64)
+
+Prebuilt ONNX Runtime binaries are not available for Intel Macs. Install ONNX Runtime via Homebrew and link dynamically:
+
+```bash
+brew install onnxruntime
+ORT_LIB_LOCATION=$(brew --prefix onnxruntime)/lib ORT_PREFER_DYNAMIC_LINK=1 bun run tauri dev
+```
+
+The same environment variables apply for production builds:
+
+```bash
+ORT_LIB_LOCATION=$(brew --prefix onnxruntime)/lib ORT_PREFER_DYNAMIC_LINK=1 bun run tauri build
+```
+
 #### Windows
 
 - Microsoft C++ Build Tools


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Description

When building Handy on an Intel Mac, the build fails because `ort-sys` does not ship prebuilt ONNX Runtime binaries for `x86_64-apple-darwin`. This PR adds documentation to `BUILD.md` explaining that Intel Mac users need to install `onnxruntime` via Homebrew and set `ORT_LIB_LOCATION` / `ORT_PREFER_DYNAMIC_LINK` environment variables before building.

## Related Issues/Discussions

Issue #1470

## Community Feedback

Bug report filed: #1470

## Testing

- Verified the markdown renders correctly in the updated BUILD.md
- The documented workaround (`ORT_LIB_LOCATION=$(brew --prefix onnxruntime)/lib ORT_PREFER_DYNAMIC_LINK=1 bun run tauri dev`) was tested and resolves the build failure on an Intel Mac

## Screenshots/Videos (if applicable)

N/A — documentation-only change.

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: AI helped draft the documentation and create the issue/PR structure following project templates
