### PR TITLE
fix(windows): refresh shortcuts after sleep and unlock

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -94,6 +94,7 @@ windows = { version = "0.61.3", features = [
   "Win32_System_Com_StructuredStorage",
   "Win32_System_Variant",
   "Win32_Foundation",
+  "Win32_System_RemoteDesktop",
   "Win32_UI_WindowsAndMessaging",
 ] }
 winreg = "0.55"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ mod llm_client;
 mod managers;
 mod overlay;
 pub mod portable;
+mod session;
 mod settings;
 mod shortcut;
 mod signal_handle;
@@ -292,6 +293,8 @@ fn initialize_core_logic(app_handle: &AppHandle) {
 
     // Create the recording overlay window (hidden by default)
     utils::create_recording_overlay(app_handle);
+
+    session::setup_session_notifications(app_handle.clone());
 }
 
 #[tauri::command]
@@ -609,6 +612,14 @@ pub fn run(cli_args: CliArgs) {
             #[cfg(target_os = "macos")]
             if let tauri::RunEvent::Reopen { .. } = &event {
                 show_main_window(app);
+            }
+            if let tauri::RunEvent::Resumed = &event {
+                log::info!("Application resumed; refreshing shortcuts");
+                if app.try_state::<commands::ShortcutsInitialized>().is_some() {
+                    shortcut::refresh_shortcuts_after_resume(app);
+                } else {
+                    log::debug!("Skipping resume shortcut refresh; shortcuts are not initialized");
+                }
             }
             let _ = (app, event); // suppress unused warnings on non-macOS
         });

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -1,0 +1,107 @@
+#[cfg(target_os = "windows")]
+mod windows_session {
+    use once_cell::sync::OnceCell;
+    use tauri::{AppHandle, Manager};
+    use windows::core::w;
+    use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
+    use windows::Win32::System::RemoteDesktop::{
+        WTSRegisterSessionNotification, WTSUnRegisterSessionNotification, NOTIFY_FOR_THIS_SESSION,
+    };
+    use windows::Win32::UI::WindowsAndMessaging::{
+        CreateWindowExW, DefWindowProcW, DispatchMessageW, GetMessageW, RegisterClassW,
+        TranslateMessage, HWND_MESSAGE, MSG, WINDOW_EX_STYLE, WINDOW_STYLE, WM_DESTROY,
+        WM_WTSSESSION_CHANGE, WNDCLASSW, WTS_SESSION_UNLOCK,
+    };
+
+    static APP_HANDLE: OnceCell<AppHandle> = OnceCell::new();
+
+    pub fn setup_session_notifications(app: AppHandle) {
+        if APP_HANDLE.set(app).is_err() {
+            log::debug!("Windows session notifications already initialized");
+            return;
+        }
+
+        std::thread::spawn(|| {
+            if let Err(e) = run_message_loop() {
+                log::warn!("Windows session notification listener stopped: {}", e);
+            }
+        });
+    }
+
+    fn run_message_loop() -> windows::core::Result<()> {
+        let class_name = w!("HandySessionNotificationWindow");
+        let window_name = w!("Handy Session Notifications");
+
+        let wnd_class = WNDCLASSW {
+            lpfnWndProc: Some(window_proc),
+            lpszClassName: class_name,
+            ..Default::default()
+        };
+
+        unsafe {
+            RegisterClassW(&wnd_class);
+
+            let hwnd = CreateWindowExW(
+                WINDOW_EX_STYLE::default(),
+                class_name,
+                window_name,
+                WINDOW_STYLE::default(),
+                0,
+                0,
+                0,
+                0,
+                Some(HWND_MESSAGE),
+                None,
+                None,
+                None,
+            )?;
+
+            WTSRegisterSessionNotification(hwnd, NOTIFY_FOR_THIS_SESSION)?;
+            log::info!("Windows session unlock notifications registered");
+
+            let mut msg = MSG::default();
+            while GetMessageW(&mut msg, None, 0, 0).as_bool() {
+                let _ = TranslateMessage(&msg);
+                DispatchMessageW(&msg);
+            }
+
+            let _ = WTSUnRegisterSessionNotification(hwnd);
+        }
+
+        Ok(())
+    }
+
+    unsafe extern "system" fn window_proc(
+        hwnd: HWND,
+        msg: u32,
+        wparam: WPARAM,
+        lparam: LPARAM,
+    ) -> LRESULT {
+        match msg {
+            WM_WTSSESSION_CHANGE if wparam.0 as u32 == WTS_SESSION_UNLOCK => {
+                log::info!("Windows session unlocked; refreshing shortcuts");
+                if let Some(app) = APP_HANDLE.get() {
+                    if app
+                        .try_state::<crate::commands::ShortcutsInitialized>()
+                        .is_some()
+                    {
+                        crate::shortcut::refresh_shortcuts_after_resume(app);
+                    } else {
+                        log::debug!(
+                            "Skipping session-unlock shortcut refresh; shortcuts are not initialized"
+                        );
+                    }
+                }
+                LRESULT(0)
+            }
+            WM_DESTROY => LRESULT(0),
+            _ => unsafe { DefWindowProcW(hwnd, msg, wparam, lparam) },
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+pub use windows_session::setup_session_notifications;
+
+#[cfg(not(target_os = "windows"))]
+pub fn setup_session_notifications(_app: tauri::AppHandle) {}

--- a/src-tauri/src/shortcut/handy_keys.rs
+++ b/src-tauri/src/shortcut/handy_keys.rs
@@ -53,6 +53,10 @@ enum ManagerCommand {
         binding_id: String,
         response: Sender<Result<(), String>>,
     },
+    Refresh {
+        bindings: Vec<(String, String)>,
+        response: Sender<Result<(), String>>,
+    },
     Shutdown,
 }
 
@@ -111,7 +115,7 @@ impl HandyKeysState {
         info!("handy-keys manager thread started");
 
         // Create the HotkeyManager in this thread
-        let manager = match HotkeyManager::new_with_blocking() {
+        let mut manager = match HotkeyManager::new_with_blocking() {
             Ok(m) => m,
             Err(e) => {
                 error!("Failed to create HotkeyManager: {}", e);
@@ -164,6 +168,41 @@ impl HandyKeysState {
                             &binding_id,
                         );
                         let _ = response.send(result);
+                    }
+                    ManagerCommand::Refresh { bindings, response } => {
+                        info!("Refreshing handy-keys shortcuts after system resume");
+
+                        let new_manager = match HotkeyManager::new_with_blocking() {
+                            Ok(manager) => manager,
+                            Err(e) => {
+                                let _ = response
+                                    .send(Err(format!("Failed to recreate HotkeyManager: {}", e)));
+                                continue;
+                            }
+                        };
+
+                        manager = new_manager;
+                        binding_to_hotkey.clear();
+                        hotkey_to_binding.clear();
+
+                        let mut errors = Vec::new();
+                        for (binding_id, hotkey_string) in bindings {
+                            if let Err(e) = Self::do_register(
+                                &manager,
+                                &mut binding_to_hotkey,
+                                &mut hotkey_to_binding,
+                                &binding_id,
+                                &hotkey_string,
+                            ) {
+                                errors.push(format!("{}: {}", binding_id, e));
+                            }
+                        }
+
+                        if errors.is_empty() {
+                            let _ = response.send(Ok(()));
+                        } else {
+                            let _ = response.send(Err(errors.join("; ")));
+                        }
                     }
                     ManagerCommand::Shutdown => {
                         info!("handy-keys manager thread shutting down");
@@ -257,6 +296,27 @@ impl HandyKeysState {
 
         rx.recv()
             .map_err(|_| "Failed to receive unregister response")?
+    }
+
+    /// Recreate the keyboard listener and re-register all active shortcuts.
+    pub fn refresh(&self, bindings: Vec<ShortcutBinding>) -> Result<(), String> {
+        let (tx, rx) = mpsc::channel();
+        let bindings = bindings
+            .into_iter()
+            .map(|binding| (binding.id, binding.current_binding))
+            .collect();
+
+        self.command_sender
+            .lock()
+            .map_err(|_| "Failed to lock command_sender")?
+            .send(ManagerCommand::Refresh {
+                bindings,
+                response: tx,
+            })
+            .map_err(|_| "Failed to send refresh command")?;
+
+        rx.recv()
+            .map_err(|_| "Failed to receive refresh response")?
     }
 
     /// Start recording mode for a specific binding
@@ -516,6 +576,35 @@ pub fn unregister_shortcut(app: &AppHandle, binding: ShortcutBinding) -> Result<
         .try_state::<HandyKeysState>()
         .ok_or("HandyKeysState not initialized")?;
     state.unregister(&binding)
+}
+
+/// Refresh active handy-keys shortcuts after the OS resumes from sleep.
+pub fn refresh_shortcuts(app: &AppHandle) -> Result<(), String> {
+    let settings = get_settings(app);
+    let default_bindings = settings::get_default_settings().bindings;
+    let mut bindings = Vec::new();
+
+    for (id, default_binding) in default_bindings {
+        if id == "cancel" {
+            continue;
+        }
+        if id == "transcribe_with_post_process" && !settings.post_process_enabled {
+            continue;
+        }
+
+        bindings.push(
+            settings
+                .bindings
+                .get(&id)
+                .cloned()
+                .unwrap_or(default_binding),
+        );
+    }
+
+    let state = app
+        .try_state::<HandyKeysState>()
+        .ok_or("HandyKeysState not initialized")?;
+    state.refresh(bindings)
 }
 
 /// Start key recording mode

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -92,6 +92,25 @@ pub fn unregister_shortcut(app: &AppHandle, binding: ShortcutBinding) -> Result<
     }
 }
 
+/// Refresh active shortcuts after the OS resumes from sleep.
+pub fn refresh_shortcuts_after_resume(app: &AppHandle) {
+    let app = app.clone();
+    std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_secs(2));
+
+        let settings = get_settings(&app);
+        let result = match settings.keyboard_implementation {
+            KeyboardImplementation::Tauri => tauri_impl::refresh_shortcuts(&app),
+            KeyboardImplementation::HandyKeys => handy_keys::refresh_shortcuts(&app),
+        };
+
+        match result {
+            Ok(()) => info!("Shortcuts refreshed after system resume"),
+            Err(e) => error!("Failed to refresh shortcuts after system resume: {}", e),
+        }
+    });
+}
+
 // ============================================================================
 // Binding Management Commands
 // ============================================================================

--- a/src-tauri/src/shortcut/tauri_impl.rs
+++ b/src-tauri/src/shortcut/tauri_impl.rs
@@ -3,7 +3,7 @@
 //! This module provides shortcut functionality using Tauri's built-in
 //! global-shortcut plugin.
 
-use log::{error, warn};
+use log::{error, info, warn};
 use tauri::AppHandle;
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutState};
 
@@ -151,6 +151,18 @@ pub fn unregister_shortcut(app: &AppHandle, binding: ShortcutBinding) -> Result<
         error_msg
     })?;
 
+    Ok(())
+}
+
+/// Refresh active Tauri global shortcuts after the OS resumes from sleep.
+pub fn refresh_shortcuts(app: &AppHandle) -> Result<(), String> {
+    info!("Refreshing Tauri global shortcuts after system resume");
+
+    if let Err(e) = app.global_shortcut().unregister_all() {
+        warn!("Failed to unregister all shortcuts during refresh: {}", e);
+    }
+
+    init_shortcuts(app);
     Ok(())
 }
 


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
  - Search covered Windows shortcut/hotkey failures after sleep, wake, lock, and unlock.
  - Related reports found: #1213, #1327, #1341, #1238.
  - Related PR found: draft PR #1301.
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [x] N/A - this is a Windows bug fix, not a new feature or a previously rejected feature request.
- [x] N/A - community discussion is not required for this bug fix, but related bug reports/PRs are linked below.

## Human Written Description

Handy shortcuts stopped responding after Windows sleep/wake and after Win+L lock/unlock. Restarting the entire app was the workaround. This fix was tested in Win 10/11.

## Related Issues/Discussions

Fixes Bug report #1213 (https://github.com/cjpais/Handy/issues/1213) and 1327/1341/1238 which are all related.

## Testing

- Ran `cargo fmt --manifest-path src-tauri/Cargo.toml`.
- Ran `cargo check --manifest-path src-tauri/Cargo.toml` with `CARGO_TARGET_DIR=H:\target` to avoid Windows path-depth/CMake issues.
- Manually tested Windows sleep/wake: after wake, shortcuts refreshed and `Ctrl+Space` opened recording again.
- Manually tested Windows `Win+L` lock/unlock: after unlock, shortcuts refreshed and `Ctrl+Space` opened recording again.
- Built an unsigned local NSIS installer with `bun run tauri build --no-sign --bundles nsis` and installed/tested the resulting Windows setup executable locally.

## Screenshots/Videos (if applicable)

N/A - this is background shortcut/session handling with no UI changes.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: AI helped inspect the shortcut/session code paths, implement the Rust changes, run local formatting/check/build commands, prepare the draft PR, and summarize related issues/PRs. Manual behavior testing was performed locally on Windows.
