### PR TITLE
fix(visualizer): scale FFT window to device sample rate

### DIFF
--- a/src-tauri/src/audio_toolkit/audio/recorder.rs
+++ b/src-tauri/src/audio_toolkit/audio/recorder.rs
@@ -417,10 +417,10 @@ fn run_consumer(
     // buckets onto a single bin at 48 kHz (e.g. built-in laptop mics), and
     // would stutter at ~4-8 updates/sec on an 8-16 kHz Bluetooth headset.
     // Targets: 48 kHz -> 2048, 16 kHz -> 512, 8 kHz -> 256.
-    let target_window = (in_sample_rate as f32 / 30.0) as usize;
+    let target_window = (f64::from(in_sample_rate) / 30.0).round() as usize;
     let window_size = [256usize, 512, 1024, 2048]
         .into_iter()
-        .min_by_key(|w| (*w as i64 - target_window as i64).abs())
+        .min_by_key(|w| w.abs_diff(target_window))
         .unwrap();
     let mut visualizer = AudioVisualiser::new(
         in_sample_rate,

--- a/src-tauri/src/audio_toolkit/audio/recorder.rs
+++ b/src-tauri/src/audio_toolkit/audio/recorder.rs
@@ -411,10 +411,20 @@ fn run_consumer(
 
     // ---------- spectrum visualisation setup ---------------------------- //
     const BUCKETS: usize = 16;
-    const WINDOW_SIZE: usize = 512;
+    // Scale the FFT window to the device sample rate so the analysis window
+    // (~33 ms) and frequency resolution (~30 Hz/bin) stay roughly constant
+    // across devices. A fixed 512-sample window collapses the low vocal
+    // buckets onto a single bin at 48 kHz (e.g. built-in laptop mics), and
+    // would stutter at ~4-8 updates/sec on an 8-16 kHz Bluetooth headset.
+    // Targets: 48 kHz -> 2048, 16 kHz -> 512, 8 kHz -> 256.
+    let target_window = (in_sample_rate as f32 / 30.0) as usize;
+    let window_size = [256usize, 512, 1024, 2048]
+        .into_iter()
+        .min_by_key(|w| (*w as i64 - target_window as i64).abs())
+        .unwrap();
     let mut visualizer = AudioVisualiser::new(
         in_sample_rate,
-        WINDOW_SIZE,
+        window_size,
         BUCKETS,
         400.0,  // vocal_min_hz
         4000.0, // vocal_max_hz


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Human Written Description

Split out from #1478 per maintainer request. I noticed the audio visualizer barely reacted while speaking when using my MacBook's built-in microphone. The built-in mic captures at 48 kHz, and the fixed 512-sample FFT window assumes 16 kHz input, so the low vocal buckets collapse onto a single FFT bin. This change scales the window to the device sample rate; the vocal band (400-4000 Hz) is unchanged from upstream.

## Related Issues/Discussions

Split out from #1478 at the maintainer's request.

## Community Feedback

N/A (bug fix split out of an existing PR during review)

## Testing

Tested on macOS with the MacBook built-in mic (48 kHz): visualizer buckets now respond across the vocal range while speaking. Behavior at 16 kHz input is unchanged (window stays 512). `cargo check` passes.

## Screenshots/Videos (if applicable)

N/A

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: AI wrote the implementation under my direction; I identified the bug (visualizer unresponsive with the built-in mic), tested on-device, and reviewed the change.
