### PR TITLE
fix: stop 'Mute While Recording' from stranding system audio muted

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -419,11 +419,12 @@ impl ShortcutAction for TranscribeAction {
             debug!("Always-on mode: Playing audio feedback immediately");
             let rm_clone = Arc::clone(&rm);
             let app_clone = app.clone();
+            let mute_generation = rm.mute_generation();
             // The blocking helper exits immediately if audio feedback is disabled,
             // so we can always reuse this thread to ensure mute happens right after playback.
             std::thread::spawn(move || {
                 play_feedback_sound_blocking(&app_clone, SoundType::Start);
-                rm_clone.apply_mute();
+                rm_clone.apply_mute(mute_generation);
             });
 
             if let Err(e) = rm.try_start_recording(&binding_id) {
@@ -441,13 +442,14 @@ impl ShortcutAction for TranscribeAction {
                     // Small delay to ensure microphone stream is active
                     let app_clone = app.clone();
                     let rm_clone = Arc::clone(&rm);
+                    let mute_generation = rm.mute_generation();
                     std::thread::spawn(move || {
                         std::thread::sleep(std::time::Duration::from_millis(100));
                         debug!("Handling delayed audio feedback/mute sequence");
                         // Helper handles disabled audio feedback by returning early, so we reuse it
                         // to keep mute sequencing consistent in every mode.
                         play_feedback_sound_blocking(&app_clone, SoundType::Start);
-                        rm_clone.apply_mute();
+                        rm_clone.apply_mute(mute_generation);
                     });
                 }
                 Err(e) => {

--- a/src-tauri/src/managers/audio.rs
+++ b/src-tauri/src/managers/audio.rs
@@ -115,6 +115,18 @@ pub enum MicrophoneMode {
     OnDemand,
 }
 
+/// Tracks whether we muted system audio, plus a generation counter that ties
+/// each (possibly delayed) `apply_mute` to the recording session that
+/// requested it. `remove_mute` bumps the generation, so an apply that lands
+/// after the session already ended (e.g. a very quick press/release racing
+/// the delayed audio-feedback thread) becomes a no-op instead of leaving
+/// system audio muted with nothing left to restore it.
+#[derive(Debug, Default)]
+struct MuteState {
+    generation: u64,
+    did_mute: bool,
+}
+
 /* ──────────────────────────────────────────────────────────────── */
 
 fn create_audio_recorder(
@@ -151,7 +163,7 @@ pub struct AudioRecordingManager {
     recorder: Arc<Mutex<Option<AudioRecorder>>>,
     is_open: Arc<Mutex<bool>>,
     is_recording: Arc<Mutex<bool>>,
-    did_mute: Arc<Mutex<bool>>,
+    mute_state: Arc<Mutex<MuteState>>,
     close_generation: Arc<AtomicU64>,
 }
 
@@ -174,7 +186,7 @@ impl AudioRecordingManager {
             recorder: Arc::new(Mutex::new(None)),
             is_open: Arc::new(Mutex::new(false)),
             is_recording: Arc::new(Mutex::new(false)),
-            did_mute: Arc::new(Mutex::new(false)),
+            mute_state: Arc::new(Mutex::new(MuteState::default())),
             close_generation: Arc::new(AtomicU64::new(0)),
         };
 
@@ -241,24 +253,41 @@ impl AudioRecordingManager {
 
     /* ---------- microphone life-cycle -------------------------------------- */
 
-    /// Applies mute if mute_while_recording is enabled and stream is open
-    pub fn apply_mute(&self) {
-        let settings = get_settings(&self.app_handle);
-        let mut did_mute_guard = self.did_mute.lock().unwrap();
-
-        if settings.mute_while_recording && *self.is_open.lock().unwrap() {
-            set_mute(true);
-            *did_mute_guard = true;
-            debug!("Mute applied");
-        }
+    /// Snapshot of the current mute generation. Callers that defer
+    /// `apply_mute` (e.g. until after the start sound finished playing) must
+    /// take this before spawning the delayed work, so the apply is skipped if
+    /// the recording session ends first.
+    pub fn mute_generation(&self) -> u64 {
+        self.mute_state.lock().unwrap().generation
     }
 
-    /// Removes mute if it was applied
+    /// Applies mute if mute_while_recording is enabled, the stream is open and
+    /// the session identified by `generation` is still the active one
+    pub fn apply_mute(&self, generation: u64) {
+        let settings = get_settings(&self.app_handle);
+        if !settings.mute_while_recording {
+            return;
+        }
+
+        // Lock order: is_open before mute_state (same as stop_microphone_stream)
+        let is_open = self.is_open.lock().unwrap();
+        let mut mute_state = self.mute_state.lock().unwrap();
+        if !*is_open || mute_state.generation != generation {
+            debug!("Skipping mute: stream closed or session already ended");
+            return;
+        }
+        set_mute(true);
+        mute_state.did_mute = true;
+        debug!("Mute applied");
+    }
+
+    /// Removes mute if it was applied and invalidates any pending delayed apply
     pub fn remove_mute(&self) {
-        let mut did_mute_guard = self.did_mute.lock().unwrap();
-        if *did_mute_guard {
+        let mut mute_state = self.mute_state.lock().unwrap();
+        mute_state.generation += 1;
+        if mute_state.did_mute {
             set_mute(false);
-            *did_mute_guard = false;
+            mute_state.did_mute = false;
             debug!("Mute removed");
         }
     }
@@ -291,9 +320,17 @@ impl AudioRecordingManager {
 
         let start_time = Instant::now();
 
-        // Don't mute immediately - caller will handle muting after audio feedback
-        let mut did_mute_guard = self.did_mute.lock().unwrap();
-        *did_mute_guard = false;
+        // Don't mute immediately - caller will handle muting after audio feedback.
+        // The previous stream restores audio on close, so did_mute should already
+        // be false here; if it somehow isn't, restore instead of just clearing the
+        // flag, which would strand system audio in the muted state.
+        {
+            let mut mute_state = self.mute_state.lock().unwrap();
+            if mute_state.did_mute {
+                set_mute(false);
+                mute_state.did_mute = false;
+            }
+        }
 
         // Get the selected device from settings, considering clamshell mode
         let settings = get_settings(&self.app_handle);
@@ -339,11 +376,15 @@ impl AudioRecordingManager {
             return;
         }
 
-        let mut did_mute_guard = self.did_mute.lock().unwrap();
-        if *did_mute_guard {
-            set_mute(false);
+        {
+            let mut mute_state = self.mute_state.lock().unwrap();
+            // Invalidate any pending delayed apply for the closing stream
+            mute_state.generation += 1;
+            if mute_state.did_mute {
+                set_mute(false);
+                mute_state.did_mute = false;
+            }
         }
-        *did_mute_guard = false;
 
         if let Some(rec) = self.recorder.lock().unwrap().as_mut() {
             // If still recording, stop first.
@@ -496,6 +537,10 @@ impl AudioRecordingManager {
         if let RecordingState::Recording { .. } = *state {
             *state = RecordingState::Idle;
             drop(state);
+
+            // Restore system audio right away; in always-on mode (or with lazy
+            // stream close) nothing else would unmute after a cancellation
+            self.remove_mute();
 
             if let Some(rec) = self.recorder.lock().unwrap().as_ref() {
                 let _ = rec.stop(); // Discard the result


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

I listen to music a lot while I work, so I've been messing with the mute-while-recording behavior in Handy on my Mac. While testing it we found the audio could get stuck muted if you cancel a recording or tap the shortcut really quickly — this PR fixes those two cases so your audio always comes back.

## Related Issues/Discussions

Related (closed) report of the same symptom family: #660 — mute state not restored correctly after recording.

Fixes #
Discussion:

## Community Feedback

These are pre-existing bugs rather than a feature; happy to open a discussion if preferred.

## Testing

Tested on macOS 26 (Apple Silicon), both microphone modes (always-on and on-demand), with "Mute While Recording" enabled:

- **Cancel path**: start a recording with music playing, press the cancel shortcut → audio now unmutes immediately. Before this fix, in always-on mode (or with lazy stream close) audio stayed muted until the *next* completed recording, because only `TranscribeAction::stop()` called `remove_mute()`.
- **Quick press/release race**: tap the transcribe shortcut for <100ms. The delayed audio-feedback thread used to apply the mute *after* `remove_mute()` had already run, leaving the system muted on a dead session. With the generation counter, the stale apply is skipped (debug log: "Skipping mute: stream closed or session already ended").
- Normal recordings: mute applies after the start sound and is removed on key release, unchanged.
- `cargo fmt --check`, `cargo clippy`, `cargo test`, `bun run lint`, `bun run format:check` all pass.

## Screenshots/Videos (if applicable)

N/A (audio behavior).

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Fable 5)
- How extensively: Wrote most of the code under my direction; I identified the symptoms, tested the behavior on real hardware, and reviewed the changes.
