### PR TITLE
fix(linux): improve GNOME Wayland overlay behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,25 @@ On some GPU/driver combinations the WebKitGTK DMA-BUF renderer can cause the win
 WEBKIT_DISABLE_DMABUF_RENDERER=1 handy
 ```
 
+**4. Keep Handy on native Wayland under GNOME (`HANDY_NO_GNOME_XWAYLAND`)**
+
+GNOME's Mutter compositor does not allow regular Wayland windows to choose
+their screen position. When a working XWayland display is available, Handy
+therefore uses GTK's X11 backend so the recording overlay can remain at its
+configured top or bottom position. This applies to the entire Handy process
+and may affect fractional scaling, accessibility integration, or clipboard
+behavior.
+
+To keep Handy on the native Wayland backend instead, set:
+
+```bash
+HANDY_NO_GNOME_XWAYLAND=1 handy
+```
+
+With this opt-out, GNOME chooses the overlay position and it may appear in the
+top-left corner. An explicitly configured `GDK_BACKEND` also takes precedence
+over Handy's automatic selection.
+
 **Making a workaround permanent**
 
 Once you've found a flag that helps, export it from your shell profile (`~/.bashrc`, `~/.zshenv`, …) or from the desktop autostart entry that launches Handy. If you launch Handy from a `.desktop` file, you can prefix the `Exec=` line, e.g.:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2470,6 +2470,7 @@ dependencies = [
  "vad-rs",
  "windows 0.61.3",
  "winreg 0.55.0",
+ "x11-dl",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -106,6 +106,7 @@ transcribe-rs = { version = "0.3.3", features = ["whisper-metal"] }
 gtk-layer-shell = { version = "0.8", features = ["v0_6"] }
 gtk = "0.18"
 transcribe-rs = { version = "0.3.3", features = ["whisper-vulkan"] }
+x11-dl = "2.21"
 
 [patch.crates-io]
 tauri-runtime = { git = "https://github.com/cjpais/tauri.git", branch = "handy-2.10.2" }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,6 +4,93 @@
 use clap::Parser;
 use handy_app_lib::CliArgs;
 
+#[cfg(target_os = "linux")]
+use std::ffi::CString;
+
+#[cfg(target_os = "linux")]
+fn env_value_is_truthy(value: Option<&str>) -> bool {
+    value.map(str::trim).is_some_and(|value| {
+        !value.is_empty()
+            && !matches!(
+                value.to_ascii_lowercase().as_str(),
+                "0" | "false" | "no" | "off"
+            )
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn x11_display_is_usable_with(
+    display: Option<&str>,
+    open_display: impl FnOnce(&str) -> bool,
+) -> bool {
+    let Some(display) = display.map(str::trim).filter(|display| !display.is_empty()) else {
+        return false;
+    };
+
+    open_display(display)
+}
+
+#[cfg(target_os = "linux")]
+fn x11_display_is_usable(display: Option<&str>) -> bool {
+    x11_display_is_usable_with(display, |display| {
+        let Ok(display) = CString::new(display) else {
+            return false;
+        };
+        let Ok(xlib) = x11_dl::xlib::Xlib::open() else {
+            return false;
+        };
+
+        unsafe {
+            // XOpenDisplay performs the X11 setup and authorization handshake.
+            // A live socket alone is insufficient because GTK would still fail
+            // to start when XAUTHORITY is stale or mismatched.
+            let connection = (xlib.XOpenDisplay)(display.as_ptr());
+            if connection.is_null() {
+                return false;
+            }
+            (xlib.XCloseDisplay)(connection);
+        }
+
+        true
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn should_probe_gnome_xwayland(
+    current_desktop: Option<&str>,
+    wayland_display: Option<&str>,
+    session_type: Option<&str>,
+    gtk_backend: Option<&str>,
+    disabled: Option<&str>,
+) -> bool {
+    let is_gnome =
+        current_desktop.is_some_and(|desktop| desktop.to_ascii_lowercase().contains("gnome"));
+    let is_wayland = wayland_display.is_some_and(|display| !display.trim().is_empty())
+        || session_type.is_some_and(|kind| kind.eq_ignore_ascii_case("wayland"));
+    let backend_is_unset = gtk_backend.is_none_or(|backend| backend.trim().is_empty());
+
+    is_gnome && is_wayland && backend_is_unset && !env_value_is_truthy(disabled)
+}
+
+#[cfg(target_os = "linux")]
+fn should_use_gnome_xwayland_with(
+    current_desktop: Option<&str>,
+    wayland_display: Option<&str>,
+    session_type: Option<&str>,
+    x11_display: Option<&str>,
+    gtk_backend: Option<&str>,
+    disabled: Option<&str>,
+    probe_x11: impl FnOnce(Option<&str>) -> bool,
+) -> bool {
+    should_probe_gnome_xwayland(
+        current_desktop,
+        wayland_display,
+        session_type,
+        gtk_backend,
+        disabled,
+    ) && probe_x11(x11_display)
+}
+
 fn main() {
     let cli_args = CliArgs::parse();
 
@@ -12,7 +99,171 @@ fn main() {
         // DMABUF renderer causes crashes on various GPU/display server configurations
         // See: https://github.com/tauri-apps/tauri/issues/9394
         std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+
+        // Mutter does not let regular Wayland windows choose their position.
+        // Using GTK's X11 backend restores overlay placement, at the cost of
+        // running Handy through XWayland. Set HANDY_NO_GNOME_XWAYLAND=1 to
+        // retain the native Wayland backend and its compositor-selected position.
+        let current_desktop = std::env::var("XDG_CURRENT_DESKTOP").ok();
+        let wayland_display = std::env::var("WAYLAND_DISPLAY").ok();
+        let session_type = std::env::var("XDG_SESSION_TYPE").ok();
+        let x11_display = std::env::var("DISPLAY").ok();
+        let gtk_backend = std::env::var("GDK_BACKEND").ok();
+        let disabled = std::env::var("HANDY_NO_GNOME_XWAYLAND").ok();
+        if should_use_gnome_xwayland_with(
+            current_desktop.as_deref(),
+            wayland_display.as_deref(),
+            session_type.as_deref(),
+            x11_display.as_deref(),
+            gtk_backend.as_deref(),
+            disabled.as_deref(),
+            x11_display_is_usable,
+        ) {
+            std::env::set_var("GDK_BACKEND", "x11");
+        }
     }
 
     handy_app_lib::run(cli_args)
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    fn gnome_wayland_decision(x11_display_usable: bool) -> bool {
+        should_use_gnome_xwayland_with(
+            Some("ubuntu:GNOME"),
+            Some("wayland-0"),
+            Some("wayland"),
+            Some(":0"),
+            None,
+            None,
+            |_| x11_display_usable,
+        )
+    }
+
+    #[test]
+    fn enables_xwayland_for_gnome_wayland_when_available() {
+        assert!(gnome_wayland_decision(true));
+    }
+
+    #[test]
+    fn accepts_session_type_when_wayland_display_is_missing() {
+        assert!(should_use_gnome_xwayland_with(
+            Some("GNOME"),
+            None,
+            Some("WAYLAND"),
+            Some(":0"),
+            None,
+            None,
+            |_| true,
+        ));
+    }
+
+    #[test]
+    fn preserves_native_wayland_when_xwayland_is_unavailable() {
+        assert!(!gnome_wayland_decision(false));
+    }
+
+    #[test]
+    fn preserves_user_selected_gtk_backend() {
+        assert!(!should_use_gnome_xwayland_with(
+            Some("GNOME"),
+            Some("wayland-0"),
+            Some("wayland"),
+            Some(":0"),
+            Some("wayland"),
+            None,
+            |_| panic!("X11 probe should be skipped for an explicit GTK backend"),
+        ));
+    }
+
+    #[test]
+    fn treats_empty_gtk_backend_as_unset() {
+        assert!(should_use_gnome_xwayland_with(
+            Some("GNOME"),
+            Some("wayland-0"),
+            Some("wayland"),
+            Some(":0"),
+            Some(""),
+            None,
+            |_| true,
+        ));
+    }
+
+    #[test]
+    fn supports_truthy_opt_out_values() {
+        for value in ["1", "true", "YES", "on"] {
+            assert!(!should_use_gnome_xwayland_with(
+                Some("GNOME"),
+                Some("wayland-0"),
+                Some("wayland"),
+                Some(":0"),
+                None,
+                Some(value),
+                |_| panic!("X11 probe should be skipped when the workaround is disabled"),
+            ));
+        }
+    }
+
+    #[test]
+    fn ignores_false_opt_out_values() {
+        for value in ["", "0", "false", "NO", "off"] {
+            assert!(should_use_gnome_xwayland_with(
+                Some("GNOME"),
+                Some("wayland-0"),
+                Some("wayland"),
+                Some(":0"),
+                None,
+                Some(value),
+                |_| true,
+            ));
+        }
+    }
+
+    #[test]
+    fn does_not_affect_other_desktops_or_x11_sessions() {
+        assert!(!should_use_gnome_xwayland_with(
+            Some("KDE"),
+            Some("wayland-0"),
+            Some("wayland"),
+            Some("remote.invalid:0"),
+            None,
+            None,
+            |_| panic!("X11 probe should be skipped outside GNOME"),
+        ));
+        assert!(!should_use_gnome_xwayland_with(
+            Some("GNOME"),
+            None,
+            Some("x11"),
+            Some("remote.invalid:0"),
+            None,
+            None,
+            |_| panic!("X11 probe should be skipped outside Wayland"),
+        ));
+    }
+
+    #[test]
+    fn accepts_authenticated_x11_display() {
+        assert!(x11_display_is_usable_with(Some(":0"), |display| display == ":0"));
+    }
+
+    #[test]
+    fn rejects_x11_display_when_authenticated_open_fails() {
+        assert!(!x11_display_is_usable_with(Some(":0"), |_| false));
+    }
+
+    #[test]
+    fn rejects_missing_or_empty_x11_display() {
+        assert!(!x11_display_is_usable_with(None, |_| true));
+        assert!(!x11_display_is_usable_with(Some("  "), |_| true));
+    }
+
+    #[test]
+    fn passes_protocol_qualified_local_display_to_xlib() {
+        assert!(x11_display_is_usable_with(
+            Some("hostname/unix:0"),
+            |display| display == "hostname/unix:0",
+        ));
+    }
 }

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -19,6 +19,9 @@ use tauri_nspanel::{tauri_panel, CollectionBehavior, PanelBuilder, PanelLevel};
 use gtk_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
 
 #[cfg(target_os = "linux")]
+use gtk::prelude::GtkWindowExt;
+
+#[cfg(target_os = "linux")]
 use std::env;
 
 #[cfg(target_os = "macos")]
@@ -224,19 +227,20 @@ fn calculate_overlay_position(app_handle: &AppHandle) -> Option<(f64, f64)> {
 /// Creates the recording overlay window and keeps it hidden by default
 #[cfg(not(target_os = "macos"))]
 pub fn create_recording_overlay(app_handle: &AppHandle) {
+    let position = calculate_overlay_position(app_handle);
+
     // On Linux (Wayland), monitor detection often fails, but we don't need exact coordinates
     // for Layer Shell as we use anchors. On other platforms, we require a monitor.
     #[cfg(not(target_os = "linux"))]
     {
-        let position = calculate_overlay_position(app_handle);
         if position.is_none() {
             debug!("Failed to determine overlay position, not creating overlay window");
             return;
         }
     }
 
-    // Position starts unset — update_overlay_position() sets the correct
-    // LogicalPosition before the overlay is shown.
+    // Set an initial position for regular windows. update_overlay_position()
+    // refreshes it before each show, including after monitor changes.
     let mut builder = WebviewWindowBuilder::new(
         app_handle,
         "recording_overlay",
@@ -257,6 +261,12 @@ pub fn create_recording_overlay(app_handle: &AppHandle) {
     .focused(false)
     .visible(false);
 
+    // GNOME Wayland does not support layer-shell and ignores position changes
+    // after a window is mapped, so provide the fallback position at creation.
+    if let Some((x, y)) = position {
+        builder = builder.position(x, y);
+    }
+
     if let Some(data_dir) = crate::portable::data_dir() {
         builder = builder.data_directory(data_dir.join("webview"));
     }
@@ -266,6 +276,11 @@ pub fn create_recording_overlay(app_handle: &AppHandle) {
         Ok(window) => {
             #[cfg(target_os = "linux")]
             {
+                if let Ok(gtk_window) = window.gtk_window() {
+                    gtk_window.set_accept_focus(false);
+                    gtk_window.set_focus_on_map(false);
+                }
+
                 // Try to initialize GTK layer shell, ignore errors if compositor doesn't support it
                 if init_gtk_layer_shell(&window) {
                     debug!("GTK layer shell initialized for overlay window");


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched existing issues and pull requests, including closed ones, to ensure this is not a duplicate
- [x] I have read CONTRIBUTING.md

## Human Written Description

On Ubuntu GNOME Wayland, Handy’s recording overlay appeared in the top-left and could steal focus from the application receiving the transcription. This change uses XWayland only when an authenticated X11 connection is available and prevents the overlay from accepting focus, improving overlay positioning and paste reliability.

## Related Issues/Discussions

Related: #379, #994, #1239
Related PR: #1388

## Community Feedback

The linked issues contain reports from Linux users experiencing overlay and paste problems. I also reproduced the problem locally on Ubuntu GNOME Wayland.

## Testing

- Confirmed the overlay appears bottom-center.
- Confirmed the overlay does not steal focus.
- Confirmed transcription is pasted into the previously focused application.
- Ran `cargo test --bin handy`: 12 tests passed.
- Ran `cargo check`.
- Ran `cargo fmt -- --check`.
- Ran `git diff --check`.

## Screenshots/Videos (if applicable)

Not included.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used to inspect the codebase, help implement the Linux overlay and XWayland compatibility changes, add tests, review edge cases, and run validation.
