### PR TITLE
[codex] Add custom post-processing request body

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -351,6 +351,7 @@ pub fn run(cli_args: CliArgs) {
             shortcut::change_post_process_base_url_setting,
             shortcut::change_post_process_api_key_setting,
             shortcut::change_post_process_model_setting,
+            shortcut::change_post_process_custom_body_setting,
             shortcut::set_post_process_provider,
             shortcut::fetch_post_process_models,
             shortcut::add_post_process_prompt,

--- a/src-tauri/src/llm_client.rs
+++ b/src-tauri/src/llm_client.rs
@@ -2,7 +2,7 @@ use crate::settings::PostProcessProvider;
 use log::debug;
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE, REFERER, USER_AGENT};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 #[derive(Debug, Serialize)]
 struct ChatMessage {
@@ -57,6 +57,52 @@ struct ChatChoice {
 #[derive(Debug, Deserialize)]
 struct ChatMessageResponse {
     content: Option<String>,
+}
+
+fn parse_custom_body(provider: &PostProcessProvider) -> Result<Option<Map<String, Value>>, String> {
+    let Some(custom_body) = provider.custom_body.as_deref() else {
+        return Ok(None);
+    };
+
+    let trimmed = custom_body.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+
+    let value: Value = serde_json::from_str(trimmed).map_err(|e| {
+        format!(
+            "Invalid custom request body for provider '{}': {}",
+            provider.id, e
+        )
+    })?;
+
+    match value {
+        Value::Object(object) => Ok(Some(object)),
+        _ => Err(format!(
+            "Invalid custom request body for provider '{}': expected a JSON object",
+            provider.id
+        )),
+    }
+}
+
+fn build_chat_request_body(
+    request_body: ChatCompletionRequest,
+    provider: &PostProcessProvider,
+) -> Result<Value, String> {
+    let mut request_value = serde_json::to_value(request_body)
+        .map_err(|e| format!("Failed to serialize chat request body: {}", e))?;
+
+    if let Some(custom_body) = parse_custom_body(provider)? {
+        let request_object = request_value
+            .as_object_mut()
+            .ok_or_else(|| "Chat request body did not serialize to a JSON object".to_string())?;
+
+        for (key, value) in custom_body {
+            request_object.insert(key, value);
+        }
+    }
+
+    Ok(request_value)
 }
 
 /// Build headers for API requests based on provider type
@@ -178,13 +224,16 @@ pub async fn send_chat_completion_with_schema(
         },
     });
 
-    let request_body = ChatCompletionRequest {
-        model: model.to_string(),
-        messages,
-        response_format,
-        reasoning_effort,
-        reasoning,
-    };
+    let request_body = build_chat_request_body(
+        ChatCompletionRequest {
+            model: model.to_string(),
+            messages,
+            response_format,
+            reasoning_effort,
+            reasoning,
+        },
+        provider,
+    )?;
 
     let response = client
         .post(&url)
@@ -274,4 +323,65 @@ pub async fn fetch_models(
     }
 
     Ok(models)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_provider(custom_body: Option<&str>) -> PostProcessProvider {
+        PostProcessProvider {
+            id: "custom".to_string(),
+            label: "Custom".to_string(),
+            base_url: "http://localhost:11434/v1".to_string(),
+            allow_base_url_edit: true,
+            models_endpoint: Some("/models".to_string()),
+            supports_structured_output: false,
+            custom_body: custom_body.map(str::to_string),
+        }
+    }
+
+    fn test_request() -> ChatCompletionRequest {
+        ChatCompletionRequest {
+            model: "gemma3:1b-it-qat".to_string(),
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: "clean this".to_string(),
+            }],
+            response_format: None,
+            reasoning_effort: Some("none".to_string()),
+            reasoning: None,
+        }
+    }
+
+    #[test]
+    fn merges_custom_body_fields_into_chat_request() {
+        let body = build_chat_request_body(
+            test_request(),
+            &test_provider(Some(r#"{"keep_alive":"1h","temperature":0}"#)),
+        )
+        .expect("custom body should merge");
+
+        assert_eq!(body["model"], "gemma3:1b-it-qat");
+        assert_eq!(body["keep_alive"], "1h");
+        assert_eq!(body["temperature"], 0);
+    }
+
+    #[test]
+    fn empty_custom_body_is_ignored() {
+        let body = build_chat_request_body(test_request(), &test_provider(Some("   ")))
+            .expect("empty custom body should be ignored");
+
+        assert!(body.get("keep_alive").is_none());
+        assert_eq!(body["reasoning_effort"], "none");
+    }
+
+    #[test]
+    fn custom_body_must_be_a_json_object() {
+        let result = build_chat_request_body(test_request(), &test_provider(Some(r#""1h""#)));
+
+        assert!(result
+            .expect_err("non-object custom body should fail")
+            .contains("expected a JSON object"));
+    }
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -104,6 +104,8 @@ pub struct PostProcessProvider {
     pub models_endpoint: Option<String>,
     #[serde(default)]
     pub supports_structured_output: bool,
+    #[serde(default)]
+    pub custom_body: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Type)]
@@ -530,6 +532,7 @@ fn default_post_process_providers() -> Vec<PostProcessProvider> {
             allow_base_url_edit: false,
             models_endpoint: Some("/models".to_string()),
             supports_structured_output: true,
+            custom_body: None,
         },
         PostProcessProvider {
             id: "zai".to_string(),
@@ -538,6 +541,7 @@ fn default_post_process_providers() -> Vec<PostProcessProvider> {
             allow_base_url_edit: false,
             models_endpoint: Some("/models".to_string()),
             supports_structured_output: true,
+            custom_body: None,
         },
         PostProcessProvider {
             id: "openrouter".to_string(),
@@ -546,6 +550,7 @@ fn default_post_process_providers() -> Vec<PostProcessProvider> {
             allow_base_url_edit: false,
             models_endpoint: Some("/models".to_string()),
             supports_structured_output: true,
+            custom_body: None,
         },
         PostProcessProvider {
             id: "anthropic".to_string(),
@@ -554,6 +559,7 @@ fn default_post_process_providers() -> Vec<PostProcessProvider> {
             allow_base_url_edit: false,
             models_endpoint: Some("/models".to_string()),
             supports_structured_output: false,
+            custom_body: None,
         },
         PostProcessProvider {
             id: "groq".to_string(),
@@ -562,6 +568,7 @@ fn default_post_process_providers() -> Vec<PostProcessProvider> {
             allow_base_url_edit: false,
             models_endpoint: Some("/models".to_string()),
             supports_structured_output: false,
+            custom_body: None,
         },
         PostProcessProvider {
             id: "cerebras".to_string(),
@@ -570,6 +577,7 @@ fn default_post_process_providers() -> Vec<PostProcessProvider> {
             allow_base_url_edit: false,
             models_endpoint: Some("/models".to_string()),
             supports_structured_output: true,
+            custom_body: None,
         },
     ];
 
@@ -586,6 +594,7 @@ fn default_post_process_providers() -> Vec<PostProcessProvider> {
             allow_base_url_edit: false,
             models_endpoint: None,
             supports_structured_output: true,
+            custom_body: None,
         });
     }
 
@@ -597,6 +606,7 @@ fn default_post_process_providers() -> Vec<PostProcessProvider> {
         allow_base_url_edit: false,
         models_endpoint: Some("/models".to_string()),
         supports_structured_output: true,
+        custom_body: None,
     });
 
     // Custom provider always comes last
@@ -607,6 +617,7 @@ fn default_post_process_providers() -> Vec<PostProcessProvider> {
         allow_base_url_edit: true,
         models_endpoint: Some("/models".to_string()),
         supports_structured_output: false,
+        custom_body: None,
     });
 
     providers

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -868,6 +868,24 @@ fn validate_provider_exists(
     Ok(())
 }
 
+fn normalize_post_process_custom_body(custom_body: String) -> Result<Option<String>, String> {
+    let trimmed = custom_body.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+
+    let value: serde_json::Value = serde_json::from_str(trimmed)
+        .map_err(|e| format!("Custom request body must be valid JSON: {}", e))?;
+
+    if !value.is_object() {
+        return Err("Custom request body must be a JSON object.".to_string());
+    }
+
+    serde_json::to_string_pretty(&value)
+        .map(Some)
+        .map_err(|e| format!("Failed to format custom request body: {}", e))
+}
+
 #[tauri::command]
 #[specta::specta]
 pub fn change_post_process_api_key_setting(
@@ -892,6 +910,26 @@ pub fn change_post_process_model_setting(
     let mut settings = settings::get_settings(&app);
     validate_provider_exists(&settings, &provider_id)?;
     settings.post_process_models.insert(provider_id, model);
+    settings::write_settings(&app, settings);
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn change_post_process_custom_body_setting(
+    app: AppHandle,
+    provider_id: String,
+    custom_body: String,
+) -> Result<(), String> {
+    let mut settings = settings::get_settings(&app);
+    validate_provider_exists(&settings, &provider_id)?;
+    let normalized = normalize_post_process_custom_body(custom_body)?;
+
+    let provider = settings
+        .post_process_provider_mut(&provider_id)
+        .ok_or_else(|| format!("Provider '{}' not found", provider_id))?;
+    provider.custom_body = normalized;
+
     settings::write_settings(&app, settings);
     Ok(())
 }

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -216,6 +216,14 @@ async changePostProcessModelSetting(providerId: string, model: string) : Promise
     else return { status: "error", error: e  as any };
 }
 },
+async changePostProcessCustomBodySetting(providerId: string, customBody: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("change_post_process_custom_body_setting", { providerId, customBody }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async setPostProcessProvider(providerId: string) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("set_post_process_provider", { providerId }) };
@@ -862,7 +870,7 @@ export type OverlayPosition = "none" | "top" | "bottom"
 export type PaginatedHistory = { entries: HistoryEntry[]; has_more: boolean }
 export type PasteMethod = "ctrl_v" | "direct" | "none" | "shift_insert" | "ctrl_shift_v" | "external_script"
 export type PermissionAccess = "allowed" | "denied" | "unknown"
-export type PostProcessProvider = { id: string; label: string; base_url: string; allow_base_url_edit?: boolean; models_endpoint?: string | null; supports_structured_output?: boolean }
+export type PostProcessProvider = { id: string; label: string; base_url: string; allow_base_url_edit?: boolean; models_endpoint?: string | null; supports_structured_output?: boolean; custom_body?: string | null }
 export type RecordingRetentionPeriod = "never" | "preserve_limit" | "days_3" | "weeks_2" | "months_3"
 export type SecretMap = Partial<{ [key in string]: string }>
 export type ShortcutBinding = { id: string; name: string; description: string; default_binding: string; current_binding: string }

--- a/src/components/settings/PostProcessingSettingsApi/usePostProcessProviderState.ts
+++ b/src/components/settings/PostProcessingSettingsApi/usePostProcessProviderState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useSettings } from "../../../hooks/useSettings";
 import { commands, type PostProcessProvider } from "@/bindings";
 import type { ModelOption } from "./types";
@@ -21,6 +21,10 @@ type PostProcessProviderState = {
   handleModelChange: (value: string) => void;
   modelOptions: ModelOption[];
   isModelUpdating: boolean;
+  customBody: string;
+  handleCustomBodyChange: (value: string) => void;
+  customBodyErrorKey: string | null;
+  isCustomBodyUpdating: boolean;
   isFetchingModels: boolean;
   handleProviderSelect: (providerId: string) => void;
   handleModelSelect: (value: string) => void;
@@ -38,6 +42,7 @@ export const usePostProcessProviderState = (): PostProcessProviderState => {
     updatePostProcessBaseUrl,
     updatePostProcessApiKey,
     updatePostProcessModel,
+    updatePostProcessCustomBody,
     fetchPostProcessModels,
     postProcessModelOptions,
   } = useSettings();
@@ -64,6 +69,14 @@ export const usePostProcessProviderState = (): PostProcessProviderState => {
   const baseUrl = selectedProvider?.base_url ?? "";
   const apiKey = settings?.post_process_api_keys?.[selectedProviderId] ?? "";
   const model = settings?.post_process_models?.[selectedProviderId] ?? "";
+  const customBody = selectedProvider?.custom_body ?? "";
+  const [customBodyErrorKey, setCustomBodyErrorKey] = useState<string | null>(
+    null,
+  );
+
+  useEffect(() => {
+    setCustomBodyErrorKey(null);
+  }, [selectedProviderId]);
 
   const providerOptions = useMemo<DropdownOption[]>(() => {
     return providers.map((provider) => ({
@@ -163,6 +176,51 @@ export const usePostProcessProviderState = (): PostProcessProviderState => {
     [selectedProviderId, updatePostProcessModel],
   );
 
+  const handleCustomBodyChange = useCallback(
+    (value: string) => {
+      if (!selectedProvider || selectedProvider.id !== "custom") {
+        return;
+      }
+
+      const trimmed = value.trim();
+      if (!trimmed) {
+        setCustomBodyErrorKey(null);
+        if (customBody.trim()) {
+          void updatePostProcessCustomBody(selectedProvider.id, "");
+        }
+        return;
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        setCustomBodyErrorKey(
+          "settings.postProcessing.api.customBody.errorInvalidJson",
+        );
+        return;
+      }
+
+      if (
+        parsed === null ||
+        typeof parsed !== "object" ||
+        Array.isArray(parsed)
+      ) {
+        setCustomBodyErrorKey(
+          "settings.postProcessing.api.customBody.errorNotObject",
+        );
+        return;
+      }
+
+      const formatted = JSON.stringify(parsed, null, 2);
+      setCustomBodyErrorKey(null);
+      if (formatted !== customBody.trim()) {
+        void updatePostProcessCustomBody(selectedProvider.id, formatted);
+      }
+    },
+    [customBody, selectedProvider, updatePostProcessCustomBody],
+  );
+
   const handleRefreshModels = useCallback(() => {
     if (isAppleProvider) return;
     void fetchPostProcessModels(selectedProviderId);
@@ -201,6 +259,9 @@ export const usePostProcessProviderState = (): PostProcessProviderState => {
   const isModelUpdating = isUpdating(
     `post_process_model:${selectedProviderId}`,
   );
+  const isCustomBodyUpdating = isUpdating(
+    `post_process_custom_body:${selectedProviderId}`,
+  );
   const isFetchingModels = isUpdating(
     `post_process_models_fetch:${selectedProviderId}`,
   );
@@ -226,6 +287,10 @@ export const usePostProcessProviderState = (): PostProcessProviderState => {
     handleModelChange,
     modelOptions,
     isModelUpdating,
+    customBody,
+    handleCustomBodyChange,
+    customBodyErrorKey,
+    isCustomBodyUpdating,
     isFetchingModels,
     handleProviderSelect,
     handleModelSelect,

--- a/src/components/settings/post-processing/PostProcessingSettings.tsx
+++ b/src/components/settings/post-processing/PostProcessingSettings.tsx
@@ -22,6 +22,38 @@ import { usePostProcessProviderState } from "../PostProcessingSettingsApi/usePos
 import { ShortcutInput } from "../ShortcutInput";
 import { useSettings } from "../../../hooks/useSettings";
 
+interface CustomBodyFieldProps {
+  value: string;
+  onBlur: (value: string) => void;
+  disabled: boolean;
+  placeholder?: string;
+}
+
+const CustomBodyField: React.FC<CustomBodyFieldProps> = React.memo(
+  ({ value, onBlur, disabled, placeholder }) => {
+    const [localValue, setLocalValue] = useState(value);
+
+    useEffect(() => {
+      setLocalValue(value);
+    }, [value]);
+
+    return (
+      <Textarea
+        value={localValue}
+        onChange={(event) => setLocalValue(event.target.value)}
+        onBlur={() => onBlur(localValue)}
+        placeholder={placeholder}
+        variant="compact"
+        disabled={disabled}
+        className="w-full font-mono"
+        spellCheck={false}
+      />
+    );
+  },
+);
+
+CustomBodyField.displayName = "CustomBodyField";
+
 const PostProcessingSettingsApiComponent: React.FC = () => {
   const { t } = useTranslation();
   const state = usePostProcessProviderState();
@@ -136,6 +168,32 @@ const PostProcessingSettingsApiComponent: React.FC = () => {
                 className={`h-4 w-4 ${state.isFetchingModels ? "animate-spin" : ""}`}
               />
             </ResetButton>
+          </div>
+        </SettingContainer>
+      )}
+
+      {state.isCustomProvider && (
+        <SettingContainer
+          title={t("settings.postProcessing.api.customBody.title")}
+          description={t("settings.postProcessing.api.customBody.description")}
+          descriptionMode="tooltip"
+          layout="stacked"
+          grouped={true}
+        >
+          <div className="space-y-2">
+            <CustomBodyField
+              value={state.customBody}
+              onBlur={state.handleCustomBodyChange}
+              disabled={state.isCustomBodyUpdating}
+              placeholder={t(
+                "settings.postProcessing.api.customBody.placeholder",
+              )}
+            />
+            {state.customBodyErrorKey && (
+              <p className="text-xs text-red-400">
+                {t(state.customBodyErrorKey)}
+              </p>
+            )}
           </div>
         </SettingContainer>
       )}

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -40,6 +40,10 @@ interface UseSettingsReturn {
     apiKey: string,
   ) => Promise<void>;
   updatePostProcessModel: (providerId: string, model: string) => Promise<void>;
+  updatePostProcessCustomBody: (
+    providerId: string,
+    customBody: string,
+  ) => Promise<void>;
   fetchPostProcessModels: (providerId: string) => Promise<string[]>;
 }
 
@@ -73,6 +77,7 @@ export const useSettings = (): UseSettingsReturn => {
     updatePostProcessBaseUrl: store.updatePostProcessBaseUrl,
     updatePostProcessApiKey: store.updatePostProcessApiKey,
     updatePostProcessModel: store.updatePostProcessModel,
+    updatePostProcessCustomBody: store.updatePostProcessCustomBody,
     fetchPostProcessModels: store.fetchPostProcessModels,
   };
 };

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -372,6 +372,13 @@
           "placeholderWithOptions": "ابحث عن نموذج أو اختره",
           "placeholderNoOptions": "اكتب اسم النموذج",
           "refreshModels": "تحديث النماذج"
+        },
+        "customBody": {
+          "title": "Custom Body",
+          "description": "JSON object merged into every chat completions request for the custom provider.",
+          "placeholder": "{\n  \"keep_alive\": \"1h\"\n}",
+          "errorInvalidJson": "Enter a valid JSON object.",
+          "errorNotObject": "Custom body must be a JSON object."
         }
       },
       "prompts": {

--- a/src/i18n/locales/bg/translation.json
+++ b/src/i18n/locales/bg/translation.json
@@ -394,6 +394,13 @@
           "placeholderWithOptions": "Търсене или избор на модел",
           "placeholderNoOptions": "Въведете име на модел",
           "refreshModels": "Опресняване на моделите"
+        },
+        "customBody": {
+          "title": "Custom Body",
+          "description": "JSON object merged into every chat completions request for the custom provider.",
+          "placeholder": "{\n  \"keep_alive\": \"1h\"\n}",
+          "errorInvalidJson": "Enter a valid JSON object.",
+          "errorNotObject": "Custom body must be a JSON object."
         }
       },
       "prompts": {

--- a/src/i18n/locales/cs/translation.json
+++ b/src/i18n/locales/cs/translation.json
@@ -394,6 +394,13 @@
           "placeholderWithOptions": "Vyhledejte nebo vyberte model",
           "placeholderNoOptions": "Zadejte název modelu",
           "refreshModels": "Obnovit modely"
+        },
+        "customBody": {
+          "title": "Custom Body",
+          "description": "JSON object merged into every chat completions request for the custom provider.",
+          "placeholder": "{\n  \"keep_alive\": \"1h\"\n}",
+          "errorInvalidJson": "Enter a valid JSON object.",
+          "errorNotObject": "Custom body must be a JSON object."
         }
       },
       "prompts": {

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -394,6 +394,13 @@
           "placeholderWithOptions": "Modell suchen oder auswählen",
           "placeholderNoOptions": "Modellnamen eingeben",
           "refreshModels": "Modelle aktualisieren"
+        },
+        "customBody": {
+          "title": "Custom Body",
+          "description": "JSON object merged into every chat completions request for the custom provider.",
+          "placeholder": "{\n  \"keep_alive\": \"1h\"\n}",
+          "errorInvalidJson": "Enter a valid JSON object.",
+          "errorNotObject": "Custom body must be a JSON object."
         }
       },
       "prompts": {

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -394,6 +394,13 @@
           "placeholderWithOptions": "Search or select a model",
           "placeholderNoOptions": "Type a model name",
           "refreshModels": "Refresh models"
+        },
+        "customBody": {
+          "title": "Custom Body",
+          "description": "JSON object merged into every chat completions request for the custom provider.",
+          "placeholder": "{\n  \"keep_alive\": \"1h\"\n}",
+          "errorInvalidJson": "Enter a valid JSON object.",
+          "errorNotObject": "Custom body must be a JSON object."
         }
       },
       "prompts": {

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -394,6 +394,13 @@
           "placeholderWithOptions": "Buscar o seleccionar un modelo",
           "placeholderNoOptions": "Escribe un nombre de modelo",
           "refreshModels": "Actualizar modelos"
+        },
+        "customBody": {
+          "title": "Custom Body",
+          "description": "JSON object merged into every chat completions request for the custom provider.",
+          "placeholder": "{\n  \"keep_alive\": \"1h\"\n}",
+          "errorInvalidJson": "Enter a valid JSON object.",
+          "errorNotObject": "Custom body must be a JSON object."
         }
       },
       "prompts": {

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -394,6 +394,13 @@
           "placeholderWithOptions": "Rechercher ou sélectionner un modèle",
           "placeholderNoOptions": "Tapez un nom de modèle",
           "refreshModels": "Actualiser les modèles"
+        },
+        "customBody": {
+          "title": "Custom Body",
+          "description": "JSON object merged into every chat completions request for the custom provider.",
+          "placeholder": "{\n  \"keep_alive\": \"1h\"\n}",
+          "errorInvalidJson": "Enter a valid JSON object.",
+          "errorNotObject": "Custom body must be a JSON object."
         }
       },
       "prompts": {

--- a/src/i18n/locales/he/translation.json
+++ b/src/i18n/locales/he/translation.json
@@ -394,6 +394,13 @@
           "placeholderWithOptions": "חפש או בחר מודל",
           "placeholderNoOptions": "הקלד שם מודל",
           "refreshModels": "רענן מודלים"
+        },
+        "customBody": {
+          "title": "Custom Body",
+          "description": "JSON object merged into every chat completions request for the custom provider.",
+          "placeholder": "{\n  \"keep_alive\": \"1h\"\n}",
+          "errorInvalidJson": "Enter a valid JSON object.",
+          "errorNotObject": "Custom body must be a JSON object."
         }
       },
       "prompts": {

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -394,6 +394,13 @@
           "placeholderWithOptions": "Cerca o scegli un modello",
           "placeholderNoOptions": "Digita il nome di un modello",
           "refreshModels": "Aggiorna modelli"
+        },
+        "customBody": {
+          "title": "Custom Body",
+          "description": "JSON object merged into every chat completions request for the custom provider.",
+          "placeholder": "{\n  \"keep_alive\": \"1h\"\n}",
+          "errorInvalidJson": "Enter a valid JSON object.",
+          "errorNotObject": "Custom body must be a JSON object."
         }
       },
       "prompts": {

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -394,6 +394,13 @@
           "placeholderWithOptions": "モデルを検索または選択",
           "placeholderNoOptions": "モデル名を入力",
           "refreshModels": "モデルを更新"
+        },
+        "customBody": {
+          "title": "Custom Body",
+          "description": "JSON object merged into every chat completions request for the custom provider.",
+          "placeholder": "{\n  \"keep_alive\": \"1h\"\n}",
+          "errorInvalidJson": "Enter a valid JSON object.",
+          "errorNotObject": "Custom body must be a JSON object."
         }
       },
       "prompts": {

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -394,6 +394,13 @@
           "placeholderWithOptions": "모델 검색 또는 선택",
           "placeholderNoOptions": "모델 이름 입력",
           "refreshModels": "모델 새로고침"
+        },
+        "customBody": {
+          "title": "Custom Body",
+          "description": "JSON object merged into every chat completions request for the custom provider.",
+          "placeholder": "{\n  \"keep_alive\": \"1h\"\n}",
+          "errorInvalidJson": "Enter a valid JSON object.",
+          "errorNotObject": "Custom body must be a JSON object."
         }
       },
       "prompts": {

--- a/src/i18n/locales/pl/translation.json
+++ b/src/i18n/locales/pl/translation.json
@@ -394,6 +394,13 @@
           "placeholderWithOptions": "Wyszukaj lub wybierz model",
           "placeholderNoOptions": "Wpisz nazwę modelu",
           "refreshModels": "Odśwież modele"
+        },
+        "customBody": {
+          "title": "Custom Body",
+          "description": "JSON object merged into every chat completions request for the custom provider.",
+          "placeholder": "{\n  \"keep_alive\": \"1h\"\n}",
+          "errorInvalidJson": "Enter a valid JSON object.",
+          "errorNotObject": "Custom body must be a JSON object."
         }
       },
       "prompts": {

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -394,6 +394,13 @@
           "placeholderWithOptions": "Buscar ou selecionar um modelo",
           "placeholderNoOptions": "Digite o nome de um modelo",
           "refreshModels": "Atualizar modelos"
+        },
+        "customBody": {
+          "title": "Custom Body",
+          "description": "JSON object merged into every chat completions request for the custom provider.",
+          "placeholder": "{\n  \"keep_alive\": \"1h\"\n}",
+          "errorInvalidJson": "Enter a valid JSON object.",
+          "errorNotObject": "Custom body must be a JSON object."
         }
       },
       "prompts": {

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -394,6 +394,13 @@
           "placeholderWithOptions": "Найдите или выберите модель",
           "placeholderNoOptions": "Введите название модели",
           "refreshModels": "Обновить модели"
+        },
+        "customBody": {
+          "title": "Custom Body",
+          "description": "JSON object merged into every chat completions request for the custom provider.",
+          "placeholder": "{\n  \"keep_alive\": \"1h\"\n}",
+          "errorInvalidJson": "Enter a valid JSON object.",
+          "errorNotObject": "Custom body must be a JSON object."
         }
       },
       "prompts": {

--- a/src/i18n/locales/sv/translation.json
+++ b/src/i18n/locales/sv/translation.json
@@ -394,6 +394,13 @@
           "placeholderWithOptions": "Sök eller välj en modell",
           "placeholderNoOptions": "Ange ett modellnamn",
           "refreshModels": "Uppdatera modeller"
+        },
+        "customBody": {
+          "title": "Custom Body",
+          "description": "JSON object merged into every chat completions request for the custom provider.",
+          "placeholder": "{\n  \"keep_alive\": \"1h\"\n}",
+          "errorInvalidJson": "Enter a valid JSON object.",
+          "errorNotObject": "Custom body must be a JSON object."
         }
       },
       "prompts": {

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -394,6 +394,13 @@
           "placeholderWithOptions": "Model ara veya seç",
           "placeholderNoOptions": "Model adı yazın",
           "refreshModels": "Modelleri Yenile"
+        },
+        "customBody": {
+          "title": "Custom Body",
+          "description": "JSON object merged into every chat completions request for the custom provider.",
+          "placeholder": "{\n  \"keep_alive\": \"1h\"\n}",
+          "errorInvalidJson": "Enter a valid JSON object.",
+          "errorNotObject": "Custom body must be a JSON object."
         }
       },
       "prompts": {

--- a/src/i18n/locales/uk/translation.json
+++ b/src/i18n/locales/uk/translation.json
@@ -394,6 +394,13 @@
           "placeholderWithOptions": "Шукайте або оберіть модель",
           "placeholderNoOptions": "Введіть назву моделі",
           "refreshModels": "Оновити моделі"
+        },
+        "customBody": {
+          "title": "Custom Body",
+          "description": "JSON object merged into every chat completions request for the custom provider.",
+          "placeholder": "{\n  \"keep_alive\": \"1h\"\n}",
+          "errorInvalidJson": "Enter a valid JSON object.",
+          "errorNotObject": "Custom body must be a JSON object."
         }
       },
       "prompts": {

--- a/src/i18n/locales/vi/translation.json
+++ b/src/i18n/locales/vi/translation.json
@@ -394,6 +394,13 @@
           "placeholderWithOptions": "Tìm kiếm hoặc chọn một mô hình",
           "placeholderNoOptions": "Nhập tên mô hình",
           "refreshModels": "Làm mới mô hình"
+        },
+        "customBody": {
+          "title": "Custom Body",
+          "description": "JSON object merged into every chat completions request for the custom provider.",
+          "placeholder": "{\n  \"keep_alive\": \"1h\"\n}",
+          "errorInvalidJson": "Enter a valid JSON object.",
+          "errorNotObject": "Custom body must be a JSON object."
         }
       },
       "prompts": {

--- a/src/i18n/locales/zh-TW/translation.json
+++ b/src/i18n/locales/zh-TW/translation.json
@@ -394,6 +394,13 @@
           "placeholderWithOptions": "搜尋或選擇模型",
           "placeholderNoOptions": "輸入模型名稱",
           "refreshModels": "重新整理模型"
+        },
+        "customBody": {
+          "title": "Custom Body",
+          "description": "JSON object merged into every chat completions request for the custom provider.",
+          "placeholder": "{\n  \"keep_alive\": \"1h\"\n}",
+          "errorInvalidJson": "Enter a valid JSON object.",
+          "errorNotObject": "Custom body must be a JSON object."
         }
       },
       "prompts": {

--- a/src/i18n/locales/zh/translation.json
+++ b/src/i18n/locales/zh/translation.json
@@ -394,6 +394,13 @@
           "placeholderWithOptions": "搜索或选择模型",
           "placeholderNoOptions": "输入模型名称",
           "refreshModels": "刷新模型"
+        },
+        "customBody": {
+          "title": "Custom Body",
+          "description": "JSON object merged into every chat completions request for the custom provider.",
+          "placeholder": "{\n  \"keep_alive\": \"1h\"\n}",
+          "errorInvalidJson": "Enter a valid JSON object.",
+          "errorNotObject": "Custom body must be a JSON object."
         }
       },
       "prompts": {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -38,7 +38,7 @@ interface SettingsStore {
   checkCustomSounds: () => Promise<void>;
   setPostProcessProvider: (providerId: string) => Promise<void>;
   updatePostProcessSetting: (
-    settingType: "base_url" | "api_key" | "model",
+    settingType: "base_url" | "api_key" | "model" | "custom_body",
     providerId: string,
     value: string,
   ) => Promise<void>;
@@ -51,6 +51,10 @@ interface SettingsStore {
     apiKey: string,
   ) => Promise<void>;
   updatePostProcessModel: (providerId: string, model: string) => Promise<void>;
+  updatePostProcessCustomBody: (
+    providerId: string,
+    customBody: string,
+  ) => Promise<void>;
   fetchPostProcessModels: (providerId: string) => Promise<string[]>;
   setPostProcessModelOptions: (providerId: string, models: string[]) => void;
 
@@ -436,7 +440,7 @@ export const useSettingsStore = create<SettingsStore>()(
 
     // Generic updater for post-processing provider settings
     updatePostProcessSetting: async (
-      settingType: "base_url" | "api_key" | "model",
+      settingType: "base_url" | "api_key" | "model" | "custom_body",
       providerId: string,
       value: string,
     ) => {
@@ -452,6 +456,8 @@ export const useSettingsStore = create<SettingsStore>()(
           await commands.changePostProcessApiKeySetting(providerId, value);
         } else if (settingType === "model") {
           await commands.changePostProcessModelSetting(providerId, value);
+        } else if (settingType === "custom_body") {
+          await commands.changePostProcessCustomBodySetting(providerId, value);
         }
         await refreshSettings();
       } catch (error) {
@@ -523,6 +529,14 @@ export const useSettingsStore = create<SettingsStore>()(
 
     updatePostProcessModel: async (providerId, model) => {
       return get().updatePostProcessSetting("model", providerId, model);
+    },
+
+    updatePostProcessCustomBody: async (providerId, customBody) => {
+      return get().updatePostProcessSetting(
+        "custom_body",
+        providerId,
+        customBody,
+      );
     },
 
     fetchPostProcessModels: async (providerId) => {


### PR DESCRIPTION
## Summary

- Add a Custom Body JSON setting for the custom post-processing provider.
- Validate and normalize the JSON object before saving it.
- Merge custom body fields into the OpenAI-compatible chat completions request so values like `{"keep_alive":"1h"}` can be passed through to compatible local providers.
- Add generated bindings, UI wiring, fallback locale keys, and Rust coverage for request-body merging.

## Validation

- `bun run format:check`
- `bun run check:translations`
- `bun run build`
- `bun run lint`
- `cargo test`
- `bun run test:playwright`