### PR TITLE
Use handy-keys mouse blocking fix

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2488,8 +2488,7 @@ dependencies = [
 [[package]]
 name = "handy-keys"
 version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c1bb519fbead4e7344bf0fe32718c4cea30fc05e03fc65c242df064f515b03"
+source = "git+https://github.com/Perdolique/handy-keys?branch=codex%2Fblock-mouse-hotkeys#3b6239c23d3814343e7a8a26c5ae058223a4451c"
 dependencies = [
  "bitflags 2.11.0",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -147,6 +147,7 @@ transcribe-cpp = { version = "0.1.0", default-features = false, features = [
 ] }
 
 [patch.crates-io]
+handy-keys = { git = "https://github.com/Perdolique/handy-keys", branch = "codex/block-mouse-hotkeys" }
 tauri-runtime = { git = "https://github.com/cjpais/tauri.git", branch = "handy-2.10.2" }
 tauri-runtime-wry = { git = "https://github.com/cjpais/tauri.git", branch = "handy-2.10.2" }
 tauri-utils = { git = "https://github.com/cjpais/tauri.git", branch = "handy-2.10.2" }


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

I'm using advanced mouse buttons as hotkeys (MouseX1), but the app doesn't block click propagation, which makes it unusable in some apps like browsers (this button navigates back to history). It's so annoying to configure every app because I never use this mouse button in other apps.

## Related Issues/Discussions

Upstream dependency fix: https://github.com/handy-computer/handy-keys/pull/22

## Community Feedback

This is a bug-fix draft tied to the upstream `handy-keys` mouse blocking PR 🐛🖱️ Once that dependency fix lands or is otherwise accepted, this PR can switch from the fork branch to the released crate/version.

## Testing

- `git diff --check`
- `rustfmt --check src/platform/windows/listener.rs` in `handy-keys`
- `cargo check --target x86_64-pc-windows-gnu --tests` in `handy-keys`
- `cargo check --manifest-path src-tauri/Cargo.toml -p handy-keys --target x86_64-pc-windows-gnu --tests`
- `bun install`
- `bun run lint`
- `bun run build`

Full backend `cargo check --manifest-path src-tauri/Cargo.toml --target x86_64-pc-windows-gnu` currently stops in this local WSL environment because `openssl-sys` cannot find system OpenSSL headers (`libssl-dev`).

## Screenshots/Videos (if applicable)

Not applicable.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: Used to inspect the dependency behaviour, prepare the dependency patch, and draft this PR.



