### PR TITLE
fix: skip post-processing when transcription is empty

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -63,7 +63,21 @@ fn build_system_prompt(prompt_template: &str) -> String {
     prompt_template.replace("${output}", "").trim().to_string()
 }
 
+/// Returns `true` when a transcription has no meaningful content to
+/// post-process (empty or whitespace-only). Used to skip the post-processing
+/// LLM call when nothing was actually transcribed, which would otherwise make
+/// the model reply with an error message such as "you need to provide the
+/// transcription".
+fn is_blank_transcription(transcription: &str) -> bool {
+    transcription.trim().is_empty()
+}
+
 async fn post_process_transcription(settings: &AppSettings, transcription: &str) -> Option<String> {
+    if is_blank_transcription(transcription) {
+        debug!("Post-processing skipped because the transcription is empty");
+        return None;
+    }
+
     let provider = match settings.active_post_process_provider().cloned() {
         Some(provider) => provider,
         None => {
@@ -719,3 +733,21 @@ pub static ACTION_MAP: Lazy<HashMap<String, Arc<dyn ShortcutAction>>> = Lazy::ne
     );
     map
 });
+
+#[cfg(test)]
+mod tests {
+    use super::is_blank_transcription;
+
+    #[test]
+    fn blank_transcription_is_detected() {
+        assert!(is_blank_transcription(""));
+        assert!(is_blank_transcription("   "));
+        assert!(is_blank_transcription("\t\n  \r\n"));
+    }
+
+    #[test]
+    fn non_blank_transcription_is_kept() {
+        assert!(!is_blank_transcription("hello"));
+        assert!(!is_blank_transcription("  hello  "));
+    }
+}


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched existing issues and pull requests (including closed ones) to ensure this isn't a duplicate
- [x] I have read CONTRIBUTING.md

## Human Written Description

I was looking through Handy's open bug reports for something small to pick up, and this one stood out. It's a bit of a papercut. If you tap the hotkey but don't actually end up saying anything, instead of just doing nothing it still fires off the post-processing model, which then types out a confusing error like "you need to provide the transcription." That felt wrong for a no-op, so the fix just skips post-processing when there's nothing to process. Seemed like a clean, contained change to start with.

## Related Issues/Discussions

Fixes #1409

## Community Feedback

The bug is confirmed by the maintainer in #1409: "Yeah, we should not post-process if there's an empty transcription."

## Testing

Added unit tests for the new `is_blank_transcription` helper covering empty and whitespace-only input. The fix is a minimal early-return guard at the top of `post_process_transcription()`, which is the single function all post-processing paths route through, mirroring its existing "no provider" and "empty prompt" early-returns. I did not run the full app locally, so CI covers fmt/clippy/tests.

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Claude Code found the issue, wrote the guard plus unit tests, and drafted this PR. I reviewed the change and wrote the description above.
