### PR TITLE
perf: use tmpfs (/tmp) for recordings when available to reduce disk I/O

### DIFF
--- a/src-tauri/src/managers/history.rs
+++ b/src-tauri/src/managers/history.rs
@@ -73,9 +73,32 @@ pub struct HistoryManager {
 
 impl HistoryManager {
     pub fn new(app_handle: &AppHandle) -> Result<Self> {
-        // Create recordings directory in app data dir
+        // Create recordings directory — prefer tmpfs (/tmp) if available to avoid
+        // unnecessary writes to slow HDD or flash storage wear.
         let app_data_dir = crate::portable::app_data_dir(app_handle)?;
-        let recordings_dir = app_data_dir.join("recordings");
+        let recordings_dir = {
+            let tmp_dir = std::path::Path::new("/tmp/handy-recordings");
+            // Check if /tmp is tmpfs by reading /proc/mounts
+            let is_tmpfs = std::fs::read_to_string("/proc/mounts")
+                .map(|mounts| mounts.lines().any(|line| {
+                    let parts: Vec<&str> = line.split_whitespace().collect();
+                    parts.len() >= 3 && parts[1] == "/tmp" && parts[2] == "tmpfs"
+                }))
+                .unwrap_or(false);
+            let tmpfs_writable = is_tmpfs && {
+                std::fs::create_dir_all(tmp_dir).is_ok() &&
+                std::fs::metadata(tmp_dir)
+                    .map(|m| !m.permissions().readonly())
+                    .unwrap_or(false)
+            };
+            if tmpfs_writable {
+                debug!("Using tmpfs for recordings: {:?}", tmp_dir);
+                std::path::PathBuf::from(tmp_dir)
+            } else {
+                debug!("tmpfs not available or not writable, using app data dir for recordings");
+                app_data_dir.join("recordings")
+            }
+        };
         let db_path = app_data_dir.join("history.db");
 
         // Ensure recordings directory exists


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched existing issues and pull requests
- [x] I have read CONTRIBUTING.md

## Human Written Description

On systems with slow HDDs or flash storage (eMMC, SD cards), writing temporary WAV recordings to the app data directory causes unnecessary disk wear and latency. Since these files are short-lived (deleted after transcription), tmpfs is a much better location. This change checks if `/tmp` is mounted as tmpfs via `/proc/mounts` and uses `/tmp/handy-recordings/` if available, falling back to the original app data directory otherwise.

## Testing

- Fedora 43, `/tmp` mounted as tmpfs (16GB)
- WAV files confirmed written to `/tmp/handy-recordings/`
- Fallback to app data dir works when tmpfs unavailable

## AI Assistance

- [x] AI was used
- Tools used: Claude (Anthropic)
- How extensively: helped write the Rust code. Testing and decision made by me.