### PR TITLE
feat: add VAD chunked live transcription mode

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -4,8 +4,11 @@ use crate::audio_feedback::{play_feedback_sound, play_feedback_sound_blocking, S
 use crate::audio_toolkit::{is_microphone_access_denied, is_no_input_device_error};
 use crate::managers::audio::AudioRecordingManager;
 use crate::managers::history::HistoryManager;
+use crate::managers::streaming::StreamingSession;
 use crate::managers::transcription::TranscriptionManager;
-use crate::settings::{get_settings, AppSettings, APPLE_INTELLIGENCE_PROVIDER_ID};
+use crate::settings::{
+    get_settings, AppSettings, TranscriptionMode, APPLE_INTELLIGENCE_PROVIDER_ID,
+};
 use crate::shortcut;
 use crate::tray::{change_tray_icon, TrayIconState};
 use crate::utils::{
@@ -13,10 +16,10 @@ use crate::utils::{
 };
 use crate::TranscriptionCoordinator;
 use ferrous_opencc::{config::BuiltinConfig, OpenCC};
-use log::{debug, error, warn};
+use log::{debug, error, info, warn};
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tauri::Manager;
 use tauri::{AppHandle, Emitter};
@@ -37,6 +40,8 @@ impl Drop for FinishGuard {
         }
     }
 }
+
+static STREAMING_SESSION: Lazy<Mutex<Option<StreamingSession>>> = Lazy::new(|| Mutex::new(None));
 
 // Shortcut Action Trait
 pub trait ShortcutAction: Send + Sync {
@@ -400,6 +405,99 @@ pub(crate) async fn process_transcription_output(
     }
 }
 
+async fn save_wav_and_history(
+    hm: &Arc<HistoryManager>,
+    audio: Vec<f32>,
+    transcription: String,
+    post_process: bool,
+    post_processed_text: Option<String>,
+    post_process_prompt: Option<String>,
+) {
+    if audio.is_empty() {
+        debug!("No audio to save for history");
+        return;
+    }
+
+    let sample_count = audio.len();
+    let file_name = format!("handy-{}.wav", chrono::Utc::now().timestamp());
+    let wav_path = hm.recordings_dir().join(&file_name);
+    let wav_path_for_verify = wav_path.clone();
+
+    let wav_saved = match tauri::async_runtime::spawn_blocking(move || {
+        crate::audio_toolkit::save_wav_file(&wav_path, &audio)
+    })
+    .await
+    {
+        Ok(Ok(())) => {
+            match crate::audio_toolkit::verify_wav_file(&wav_path_for_verify, sample_count) {
+                Ok(()) => true,
+                Err(err) => {
+                    error!("WAV verification failed: {err}");
+                    false
+                }
+            }
+        }
+        Ok(Err(err)) => {
+            error!("Failed to save WAV file: {err}");
+            false
+        }
+        Err(err) => {
+            error!("WAV save task panicked: {err}");
+            false
+        }
+    };
+
+    if wav_saved {
+        if let Err(err) = hm.save_entry(
+            file_name,
+            transcription,
+            post_process,
+            post_processed_text,
+            post_process_prompt,
+        ) {
+            error!("Failed to save history entry: {err}");
+        }
+    }
+}
+
+pub fn cancel_streaming_session() {
+    if let Some(session) = STREAMING_SESSION.lock().unwrap().take() {
+        info!("Cancelling active VAD chunked streaming session");
+        session.cancel();
+    }
+}
+
+fn start_streaming_session(
+    app: &AppHandle,
+    tm: Arc<TranscriptionManager>,
+    chunk_rx: std::sync::mpsc::Receiver<Vec<f32>>,
+    live_paste: bool,
+) -> Result<(), String> {
+    let vad_path = app
+        .path()
+        .resolve(
+            "resources/models/silero_vad_v4.onnx",
+            tauri::path::BaseDirectory::Resource,
+        )
+        .map_err(|err| format!("Failed to resolve streaming VAD path: {err}"))?;
+
+    info!(
+        "Starting VAD chunked streaming session (live_paste: {}, vad_model: {})",
+        live_paste,
+        vad_path.display()
+    );
+
+    let session = StreamingSession::start(
+        tm,
+        app.clone(),
+        chunk_rx,
+        vad_path.to_string_lossy().to_string(),
+        live_paste,
+    );
+    *STREAMING_SESSION.lock().unwrap() = Some(session);
+    Ok(())
+}
+
 impl ShortcutAction for TranscribeAction {
     fn start(&self, app: &AppHandle, binding_id: &str, _shortcut_str: &str) {
         let start_time = Instant::now();
@@ -425,9 +523,22 @@ impl ShortcutAction for TranscribeAction {
         // Get the microphone mode to determine audio feedback timing
         let settings = get_settings(app);
         let is_always_on = settings.always_on_microphone;
+        let is_streaming = matches!(settings.transcription_mode, TranscriptionMode::VadChunked);
+        info!(
+            "Starting transcription recording (binding: {}, mode: {:?}, always_on: {}, post_process: {}, live_paste: {})",
+            binding_id,
+            settings.transcription_mode,
+            is_always_on,
+            self.post_process,
+            is_streaming && !self.post_process
+        );
         debug!("Microphone mode - always_on: {}", is_always_on);
 
         let mut recording_error: Option<String> = None;
+        if is_streaming {
+            *STREAMING_SESSION.lock().unwrap() = None;
+        }
+
         if is_always_on {
             // Always-on mode: Play audio feedback immediately, then apply mute after sound finishes
             debug!("Always-on mode: Playing audio feedback immediately");
@@ -440,7 +551,16 @@ impl ShortcutAction for TranscribeAction {
                 rm_clone.apply_mute();
             });
 
-            if let Err(e) = rm.try_start_recording(&binding_id) {
+            let start_result = if is_streaming {
+                rm.try_start_streaming_recording(&binding_id)
+                    .and_then(|chunk_rx| {
+                        start_streaming_session(app, Arc::clone(&tm), chunk_rx, !self.post_process)
+                    })
+            } else {
+                rm.try_start_recording(&binding_id)
+            };
+
+            if let Err(e) = start_result {
                 debug!("Recording failed: {}", e);
                 recording_error = Some(e);
             }
@@ -449,7 +569,16 @@ impl ShortcutAction for TranscribeAction {
             // This allows the microphone to be activated before playing the sound
             debug!("On-demand mode: Starting recording first, then audio feedback");
             let recording_start_time = Instant::now();
-            match rm.try_start_recording(&binding_id) {
+            let start_result = if is_streaming {
+                rm.try_start_streaming_recording(&binding_id)
+                    .and_then(|chunk_rx| {
+                        start_streaming_session(app, Arc::clone(&tm), chunk_rx, !self.post_process)
+                    })
+            } else {
+                rm.try_start_recording(&binding_id)
+            };
+
+            match start_result {
                 Ok(()) => {
                     debug!("Recording started in {:?}", recording_start_time.elapsed());
                     // Small delay to ensure microphone stream is active
@@ -475,6 +604,8 @@ impl ShortcutAction for TranscribeAction {
             // Dynamically register the cancel shortcut in a separate task to avoid deadlock
             shortcut::register_cancel_shortcut(app);
         } else {
+            rm.cancel_recording();
+            cancel_streaming_session();
             // Starting failed (for example due to blocked microphone permissions).
             // Revert UI state so we don't stay stuck in the recording overlay.
             utils::hide_recording_overlay(app);
@@ -514,6 +645,12 @@ impl ShortcutAction for TranscribeAction {
         let rm = Arc::clone(&app.state::<Arc<AudioRecordingManager>>());
         let tm = Arc::clone(&app.state::<Arc<TranscriptionManager>>());
         let hm = Arc::clone(&app.state::<Arc<HistoryManager>>());
+        let settings = get_settings(app);
+        let is_streaming = matches!(settings.transcription_mode, TranscriptionMode::VadChunked);
+        info!(
+            "Stopping transcription recording (binding: {}, mode: {:?}, post_process: {})",
+            binding_id, settings.transcription_mode, self.post_process
+        );
 
         change_tray_icon(app, TrayIconState::Transcribing);
         show_transcribing_overlay(app);
@@ -535,7 +672,75 @@ impl ShortcutAction for TranscribeAction {
             );
 
             let stop_recording_time = Instant::now();
-            if let Some(samples) = rm.stop_recording(&binding_id) {
+            let samples = rm.stop_recording(&binding_id);
+
+            if is_streaming {
+                debug!(
+                    "Streaming recording stopped in {:?}",
+                    stop_recording_time.elapsed()
+                );
+
+                let session = STREAMING_SESSION.lock().unwrap().take();
+                if let Some(session) = session {
+                    let result = session.finish();
+                    let transcription = result.combined_text;
+
+                    if transcription.trim().is_empty() {
+                        debug!("Streaming transcription produced no text");
+                        utils::hide_recording_overlay(&ah);
+                        change_tray_icon(&ah, TrayIconState::Idle);
+                        return;
+                    }
+
+                    if post_process {
+                        show_processing_overlay(&ah);
+                        let processed =
+                            process_transcription_output(&ah, &transcription, post_process).await;
+                        save_wav_and_history(
+                            &hm,
+                            result.audio,
+                            transcription,
+                            post_process,
+                            processed.post_processed_text.clone(),
+                            processed.post_process_prompt.clone(),
+                        )
+                        .await;
+
+                        if processed.final_text.is_empty() {
+                            utils::hide_recording_overlay(&ah);
+                            change_tray_icon(&ah, TrayIconState::Idle);
+                        } else {
+                            let ah_clone = ah.clone();
+                            let final_text = processed.final_text;
+                            ah.run_on_main_thread(move || {
+                                if let Err(e) = utils::paste(final_text, ah_clone.clone()) {
+                                    error!("Failed to paste transcription: {}", e);
+                                    let _ = ah_clone.emit("paste-error", ());
+                                }
+                                utils::hide_recording_overlay(&ah_clone);
+                                change_tray_icon(&ah_clone, TrayIconState::Idle);
+                            })
+                            .unwrap_or_else(|e| {
+                                error!("Failed to run paste on main thread: {:?}", e);
+                                utils::hide_recording_overlay(&ah);
+                                change_tray_icon(&ah, TrayIconState::Idle);
+                            });
+                        }
+                    } else {
+                        save_wav_and_history(&hm, result.audio, transcription, false, None, None)
+                            .await;
+                        utils::hide_recording_overlay(&ah);
+                        change_tray_icon(&ah, TrayIconState::Idle);
+                    }
+                } else {
+                    debug!("Streaming mode stopped without an active session");
+                    utils::hide_recording_overlay(&ah);
+                    change_tray_icon(&ah, TrayIconState::Idle);
+                }
+                return;
+            }
+
+            if let Some(samples) = samples {
                 debug!(
                     "Recording stopped and samples retrieved in {:?}, sample count: {}",
                     stop_recording_time.elapsed(),

--- a/src-tauri/src/audio_toolkit/audio/recorder.rs
+++ b/src-tauri/src/audio_toolkit/audio/recorder.rs
@@ -4,7 +4,7 @@ use std::{
         atomic::{AtomicBool, Ordering},
         mpsc, Arc, Mutex,
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use cpal::{
@@ -21,6 +21,7 @@ use crate::audio_toolkit::{
 
 enum Cmd {
     Start,
+    StartStreaming(mpsc::Sender<Vec<f32>>),
     Stop(mpsc::Sender<Vec<f32>>),
     Shutdown,
 }
@@ -200,6 +201,14 @@ impl AudioRecorder {
             tx.send(Cmd::Start)?;
         }
         Ok(())
+    }
+
+    pub fn start_streaming(&self) -> Result<mpsc::Receiver<Vec<f32>>, Box<dyn std::error::Error>> {
+        let (stream_tx, stream_rx) = mpsc::channel();
+        if let Some(tx) = &self.cmd_tx {
+            tx.send(Cmd::StartStreaming(stream_tx))?;
+        }
+        Ok(stream_rx)
     }
 
     pub fn stop(&self) -> Result<Vec<f32>, Box<dyn std::error::Error>> {
@@ -408,6 +417,10 @@ fn run_consumer(
 
     let mut processed_samples = Vec::<f32>::new();
     let mut recording = false;
+    let mut stream_tx: Option<mpsc::Sender<Vec<f32>>> = None;
+    let mut streaming_frames_sent = 0usize;
+    let mut streaming_samples_sent = 0usize;
+    let mut last_streaming_log = Instant::now();
 
     // ---------- spectrum visualisation setup ---------------------------- //
     const BUCKETS: usize = 16;
@@ -471,7 +484,28 @@ fn run_consumer(
 
         // ---------- existing pipeline ------------------------------------ //
         frame_resampler.push(&raw, &mut |frame: &[f32]| {
-            handle_frame(frame, recording, &vad, &mut processed_samples)
+            if !recording {
+                return;
+            }
+
+            if let Some(tx) = &stream_tx {
+                if tx.send(frame.to_vec()).is_err() {
+                    log::warn!("Streaming transcription channel closed");
+                } else {
+                    streaming_frames_sent += 1;
+                    streaming_samples_sent += frame.len();
+                    if last_streaming_log.elapsed() >= Duration::from_secs(3) {
+                        log::info!(
+                            "Audio recorder forwarded streaming frames: {} ({:.2}s audio)",
+                            streaming_frames_sent,
+                            streaming_samples_sent as f32 / constants::WHISPER_SAMPLE_RATE as f32
+                        );
+                        last_streaming_log = Instant::now();
+                    }
+                }
+            } else {
+                handle_frame(frame, recording, &vad, &mut processed_samples)
+            }
         });
 
         // non-blocking check for a command
@@ -480,13 +514,34 @@ fn run_consumer(
                 Cmd::Start => {
                     stop_flag.store(false, Ordering::Relaxed);
                     processed_samples.clear();
+                    stream_tx = None;
                     recording = true;
                     visualizer.reset();
                     if let Some(v) = &vad {
                         v.lock().unwrap().reset();
                     }
                 }
+                Cmd::StartStreaming(tx) => {
+                    stop_flag.store(false, Ordering::Relaxed);
+                    processed_samples.clear();
+                    streaming_frames_sent = 0;
+                    streaming_samples_sent = 0;
+                    last_streaming_log = Instant::now();
+                    stream_tx = Some(tx);
+                    recording = true;
+                    visualizer.reset();
+                    if let Some(v) = &vad {
+                        v.lock().unwrap().reset();
+                    }
+                    log::info!("Audio recorder entered VAD chunked streaming mode");
+                }
                 Cmd::Stop(reply_tx) => {
+                    log::info!(
+                        "Audio recorder stopping recording (streaming: {}, forwarded_frames: {}, forwarded_audio: {:.2}s)",
+                        stream_tx.is_some(),
+                        streaming_frames_sent,
+                        streaming_samples_sent as f32 / constants::WHISPER_SAMPLE_RATE as f32
+                    );
                     recording = false;
                     stop_flag.store(true, Ordering::Relaxed);
 
@@ -498,7 +553,14 @@ fn run_consumer(
                         match sample_rx.recv_timeout(Duration::from_secs(2)) {
                             Ok(AudioChunk::Samples(remaining)) => {
                                 frame_resampler.push(&remaining, &mut |frame: &[f32]| {
-                                    handle_frame(frame, true, &vad, &mut processed_samples)
+                                    if let Some(tx) = &stream_tx {
+                                        if tx.send(frame.to_vec()).is_ok() {
+                                            streaming_frames_sent += 1;
+                                            streaming_samples_sent += frame.len();
+                                        }
+                                    } else {
+                                        handle_frame(frame, true, &vad, &mut processed_samples)
+                                    }
                                 });
                             }
                             Ok(AudioChunk::EndOfStream) => break,
@@ -510,9 +572,24 @@ fn run_consumer(
                     }
 
                     frame_resampler.finish(&mut |frame: &[f32]| {
-                        handle_frame(frame, true, &vad, &mut processed_samples)
+                        if let Some(tx) = &stream_tx {
+                            if tx.send(frame.to_vec()).is_ok() {
+                                streaming_frames_sent += 1;
+                                streaming_samples_sent += frame.len();
+                            }
+                        } else {
+                            handle_frame(frame, true, &vad, &mut processed_samples)
+                        }
                     });
 
+                    if stream_tx.is_some() {
+                        log::info!(
+                            "Audio recorder closed VAD chunked stream after forwarding {} frames ({:.2}s audio)",
+                            streaming_frames_sent,
+                            streaming_samples_sent as f32 / constants::WHISPER_SAMPLE_RATE as f32
+                        );
+                    }
+                    stream_tx = None;
                     let _ = reply_tx.send(std::mem::take(&mut processed_samples));
 
                     // Resume the audio callback so the consumer loop can continue

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -507,6 +507,7 @@ pub fn run(cli_args: CliArgs) {
             shortcut::change_extra_recording_buffer_setting,
             shortcut::change_paste_delay_ms_setting,
             shortcut::change_paste_method_setting,
+            shortcut::change_transcription_mode_setting,
             shortcut::get_available_typing_tools,
             shortcut::change_typing_tool_setting,
             shortcut::change_external_script_path_setting,

--- a/src-tauri/src/managers/audio.rs
+++ b/src-tauri/src/managers/audio.rs
@@ -4,7 +4,7 @@ use crate::settings::{get_settings, AppSettings};
 use crate::utils;
 use log::{debug, error, info};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{mpsc, Arc, Mutex};
 use std::time::{Duration, Instant};
 use tauri::Manager;
 
@@ -482,6 +482,43 @@ impl AudioRecordingManager {
             _ => None,
         }
     }
+
+    pub fn try_start_streaming_recording(
+        &self,
+        binding_id: &str,
+    ) -> Result<mpsc::Receiver<Vec<f32>>, String> {
+        let mut state = self.state.lock().unwrap();
+
+        if let RecordingState::Idle = *state {
+            if matches!(*self.mode.lock().unwrap(), MicrophoneMode::OnDemand) {
+                self.close_generation.fetch_add(1, Ordering::SeqCst);
+                if let Err(e) = self.start_microphone_stream() {
+                    let msg = format!("{e}");
+                    error!("Failed to open microphone stream: {msg}");
+                    return Err(msg);
+                }
+            }
+
+            if let Some(rec) = self.recorder.lock().unwrap().as_ref() {
+                return match rec.start_streaming() {
+                    Ok(rx) => {
+                        *self.is_recording.lock().unwrap() = true;
+                        *state = RecordingState::Recording {
+                            binding_id: binding_id.to_string(),
+                        };
+                        info!("VAD chunked streaming recording started for binding {binding_id}");
+                        Ok(rx)
+                    }
+                    Err(e) => Err(format!("Failed to start streaming recorder: {e}")),
+                };
+            }
+
+            Err("Recorder not available".to_string())
+        } else {
+            Err("Already recording".to_string())
+        }
+    }
+
     pub fn is_recording(&self) -> bool {
         matches!(
             *self.state.lock().unwrap(),

--- a/src-tauri/src/managers/mod.rs
+++ b/src-tauri/src/managers/mod.rs
@@ -1,4 +1,5 @@
 pub mod audio;
 pub mod history;
 pub mod model;
+pub mod streaming;
 pub mod transcription;

--- a/src-tauri/src/managers/streaming.rs
+++ b/src-tauri/src/managers/streaming.rs
@@ -1,0 +1,380 @@
+use crate::audio_toolkit::vad::{SmoothedVad, VadFrame};
+use crate::audio_toolkit::{SileroVad, VoiceActivityDetector};
+use crate::managers::transcription::TranscriptionManager;
+use crate::utils;
+use log::{debug, error, info, warn};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread;
+use tauri::{AppHandle, Emitter};
+
+const SAMPLE_RATE: usize = 16_000;
+const MIN_CHUNK_SECS: f32 = 1.0;
+const MAX_CHUNK_SECS: f32 = 15.0;
+const MIN_FINAL_SECS: f32 = 0.35;
+
+pub struct StreamingFinishResult {
+    pub audio: Vec<f32>,
+    pub combined_text: String,
+}
+
+pub struct StreamingSession {
+    tm: Arc<TranscriptionManager>,
+    text_buf: Arc<Mutex<Vec<String>>>,
+    audio_buf: Arc<Mutex<Vec<f32>>>,
+    cancelled: Arc<AtomicBool>,
+    worker_handle: Option<thread::JoinHandle<()>>,
+    active: bool,
+}
+
+impl StreamingSession {
+    pub fn start(
+        tm: Arc<TranscriptionManager>,
+        app: AppHandle,
+        chunk_rx: mpsc::Receiver<Vec<f32>>,
+        vad_model_path: String,
+        live_paste: bool,
+    ) -> Self {
+        let text_buf = Arc::new(Mutex::new(Vec::new()));
+        let audio_buf = Arc::new(Mutex::new(Vec::new()));
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let text_buf_worker = Arc::clone(&text_buf);
+        let audio_buf_worker = Arc::clone(&audio_buf);
+        let cancelled_worker = Arc::clone(&cancelled);
+        let tm_worker = Arc::clone(&tm);
+
+        tm.begin_streaming();
+
+        let worker_handle = thread::spawn(move || {
+            info!(
+                "VAD chunked streaming worker starting (live_paste: {})",
+                live_paste
+            );
+            let mut chunker = match VadChunker::from_model(&vad_model_path) {
+                Ok(chunker) => chunker,
+                Err(err) => {
+                    error!("Failed to initialize streaming VAD: {err}");
+                    return;
+                }
+            };
+
+            for frame in chunk_rx {
+                if cancelled_worker.load(Ordering::Relaxed) {
+                    break;
+                }
+
+                if let Some(chunk) = chunker.push_frame(&frame) {
+                    transcribe_chunk(
+                        &tm_worker,
+                        &app,
+                        &text_buf_worker,
+                        &audio_buf_worker,
+                        &cancelled_worker,
+                        chunk,
+                        live_paste,
+                    );
+                }
+            }
+
+            if !cancelled_worker.load(Ordering::Relaxed) {
+                info!("VAD chunked streaming input ended; flushing final chunk");
+                if let Some(chunk) = chunker.finish() {
+                    transcribe_chunk(
+                        &tm_worker,
+                        &app,
+                        &text_buf_worker,
+                        &audio_buf_worker,
+                        &cancelled_worker,
+                        chunk,
+                        live_paste,
+                    );
+                }
+            }
+
+            debug!("Streaming transcription worker finished");
+        });
+
+        Self {
+            tm,
+            text_buf,
+            audio_buf,
+            cancelled,
+            worker_handle: Some(worker_handle),
+            active: true,
+        }
+    }
+
+    pub fn finish(mut self) -> StreamingFinishResult {
+        if let Some(handle) = self.worker_handle.take() {
+            if let Err(err) = handle.join() {
+                error!("Streaming transcription worker panicked: {err:?}");
+            }
+        }
+
+        self.active = false;
+        self.tm.end_streaming();
+
+        StreamingFinishResult {
+            audio: std::mem::take(&mut *self.audio_buf.lock().unwrap()),
+            combined_text: self.text_buf.lock().unwrap().join(" "),
+        }
+    }
+
+    pub fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Relaxed);
+    }
+}
+
+impl Drop for StreamingSession {
+    fn drop(&mut self) {
+        if self.active {
+            self.cancel();
+            self.tm.end_streaming();
+        }
+    }
+}
+
+struct VadChunker {
+    vad: Box<dyn VoiceActivityDetector>,
+    current_chunk: Vec<f32>,
+    min_chunk_samples: usize,
+    max_chunk_samples: usize,
+    min_final_samples: usize,
+    frames_seen: usize,
+    speech_frames: usize,
+    noise_frames: usize,
+    chunks_emitted: usize,
+    short_pause_logged: bool,
+}
+
+impl VadChunker {
+    fn from_model(vad_model_path: &str) -> Result<Self, anyhow::Error> {
+        let silero = SileroVad::new(vad_model_path, 0.3)
+            .map_err(|e| anyhow::anyhow!("Failed to create SileroVad: {}", e))?;
+        let smoothed_vad = SmoothedVad::new(Box::new(silero), 15, 15, 2);
+        Ok(Self::new(Box::new(smoothed_vad)))
+    }
+
+    fn new(vad: Box<dyn VoiceActivityDetector>) -> Self {
+        Self {
+            vad,
+            current_chunk: Vec::new(),
+            min_chunk_samples: (SAMPLE_RATE as f32 * MIN_CHUNK_SECS) as usize,
+            max_chunk_samples: (SAMPLE_RATE as f32 * MAX_CHUNK_SECS) as usize,
+            min_final_samples: (SAMPLE_RATE as f32 * MIN_FINAL_SECS) as usize,
+            frames_seen: 0,
+            speech_frames: 0,
+            noise_frames: 0,
+            chunks_emitted: 0,
+            short_pause_logged: false,
+        }
+    }
+
+    fn push_frame(&mut self, frame: &[f32]) -> Option<Vec<f32>> {
+        self.frames_seen += 1;
+        match self.vad.push_frame(frame) {
+            Ok(VadFrame::Speech(samples)) => {
+                self.speech_frames += 1;
+                if self.current_chunk.is_empty() {
+                    info!(
+                        "VAD chunked streaming detected speech start at frame {}",
+                        self.frames_seen
+                    );
+                }
+                self.short_pause_logged = false;
+                self.current_chunk.extend_from_slice(samples);
+                if self.current_chunk.len() >= self.max_chunk_samples {
+                    return self.take_current_chunk("max_duration");
+                }
+            }
+            Ok(VadFrame::Noise) => {
+                self.noise_frames += 1;
+                if self.current_chunk.len() >= self.min_chunk_samples {
+                    return self.take_current_chunk("speech_pause");
+                } else if !self.current_chunk.is_empty() && !self.short_pause_logged {
+                    info!(
+                        "VAD chunked streaming saw pause but current chunk is below minimum ({:.2}s < {:.2}s)",
+                        samples_to_secs(self.current_chunk.len()),
+                        MIN_CHUNK_SECS
+                    );
+                    self.short_pause_logged = true;
+                }
+            }
+            Err(err) => warn!("Streaming VAD failed for frame: {err}"),
+        }
+        if self.frames_seen % 100 == 0 {
+            info!(
+                "VAD chunked streaming stats: frames={}, speech={}, noise={}, buffered={:.2}s, chunks={}",
+                self.frames_seen,
+                self.speech_frames,
+                self.noise_frames,
+                samples_to_secs(self.current_chunk.len()),
+                self.chunks_emitted
+            );
+        }
+        None
+    }
+
+    fn finish(&mut self) -> Option<Vec<f32>> {
+        info!(
+            "VAD chunked streaming finish: frames={}, speech={}, noise={}, buffered={:.2}s, chunks={}",
+            self.frames_seen,
+            self.speech_frames,
+            self.noise_frames,
+            samples_to_secs(self.current_chunk.len()),
+            self.chunks_emitted
+        );
+        if self.current_chunk.len() >= self.min_final_samples {
+            self.take_current_chunk("final_flush")
+        } else {
+            if !self.current_chunk.is_empty() {
+                info!(
+                    "VAD chunked streaming dropped final buffered audio below minimum ({:.2}s < {:.2}s)",
+                    samples_to_secs(self.current_chunk.len()),
+                    MIN_FINAL_SECS
+                );
+            }
+            self.current_chunk.clear();
+            None
+        }
+    }
+
+    fn take_current_chunk(&mut self, reason: &str) -> Option<Vec<f32>> {
+        if self.current_chunk.is_empty() {
+            None
+        } else {
+            self.chunks_emitted += 1;
+            info!(
+                "VAD chunked streaming emitting chunk #{} ({:.2}s, reason: {})",
+                self.chunks_emitted,
+                samples_to_secs(self.current_chunk.len()),
+                reason
+            );
+            Some(std::mem::take(&mut self.current_chunk))
+        }
+    }
+}
+
+fn samples_to_secs(samples: usize) -> f32 {
+    samples as f32 / SAMPLE_RATE as f32
+}
+
+fn transcribe_chunk(
+    tm: &TranscriptionManager,
+    app: &AppHandle,
+    text_buf: &Arc<Mutex<Vec<String>>>,
+    audio_buf: &Arc<Mutex<Vec<f32>>>,
+    cancelled: &Arc<AtomicBool>,
+    audio: Vec<f32>,
+    live_paste: bool,
+) {
+    if cancelled.load(Ordering::Relaxed) {
+        return;
+    }
+
+    let sample_count = audio.len();
+    info!(
+        "Transcribing VAD chunk ({:.2}s, live_paste: {})",
+        samples_to_secs(sample_count),
+        live_paste
+    );
+    audio_buf.lock().unwrap().extend_from_slice(&audio);
+
+    match tm.transcribe(audio) {
+        Ok(text) => {
+            if cancelled.load(Ordering::Relaxed) {
+                return;
+            }
+
+            let text = text.trim();
+            if text.is_empty() {
+                debug!("Streaming chunk produced empty text ({sample_count} samples)");
+                return;
+            }
+
+            debug!("Streaming chunk transcribed: '{text}'");
+            text_buf.lock().unwrap().push(text.to_string());
+
+            if live_paste {
+                paste_on_main_thread(app, format_live_chunk_for_paste(text));
+            }
+        }
+        Err(err) => error!("Streaming chunk transcription failed: {err}"),
+    }
+}
+
+fn format_live_chunk_for_paste(text: &str) -> String {
+    let text = text.trim();
+    if text.is_empty() {
+        return String::new();
+    }
+
+    if text.ends_with(['.', '!', '?']) {
+        format!("{text} ")
+    } else {
+        let text = text
+            .trim_end_matches(|c: char| matches!(c, ',' | ';' | ':'))
+            .trim_end();
+        format!("{text}. ")
+    }
+}
+
+fn paste_on_main_thread(app: &AppHandle, text: String) {
+    let app_clone = app.clone();
+    let _ = app.run_on_main_thread(move || {
+        if let Err(err) = utils::paste(text, app_clone.clone()) {
+            error!("Failed to paste streamed transcription chunk: {err}");
+            let _ = app_clone.emit("paste-error", ());
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{format_live_chunk_for_paste, VadChunker, MAX_CHUNK_SECS, SAMPLE_RATE};
+    use crate::audio_toolkit::vad::VadFrame;
+    use crate::audio_toolkit::VoiceActivityDetector;
+    use anyhow::Result;
+
+    struct AlwaysSpeechVad;
+
+    impl VoiceActivityDetector for AlwaysSpeechVad {
+        fn push_frame<'a>(&'a mut self, frame: &'a [f32]) -> Result<VadFrame<'a>> {
+            Ok(VadFrame::Speech(frame))
+        }
+    }
+
+    #[test]
+    fn format_live_chunk_preserves_or_adds_sentence_separator() {
+        assert_eq!(
+            format_live_chunk_for_paste("hello, world!?  "),
+            "hello, world!? "
+        );
+        assert_eq!(format_live_chunk_for_paste("hello world"), "hello world. ");
+        assert_eq!(
+            format_live_chunk_for_paste("hello world, "),
+            "hello world. "
+        );
+        assert_eq!(
+            format_live_chunk_for_paste("hello, world"),
+            "hello, world. "
+        );
+    }
+
+    #[test]
+    fn chunker_flushes_at_hard_max_duration() {
+        let mut chunker = VadChunker::new(Box::new(AlwaysSpeechVad));
+        let frame = vec![0.1; 480];
+        let frame_count = ((MAX_CHUNK_SECS * SAMPLE_RATE as f32) as usize / frame.len()) + 1;
+        let mut flushed = None;
+
+        for _ in 0..frame_count {
+            flushed = chunker.push_frame(&frame);
+            if flushed.is_some() {
+                break;
+            }
+        }
+
+        assert!(flushed.is_some());
+    }
+}

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -9,7 +9,7 @@ use log::{debug, error, info, warn};
 use serde::Serialize;
 use specta::Type;
 use std::panic::{catch_unwind, AssertUnwindSafe};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard, OnceLock};
 use std::thread;
 use std::time::{Duration, SystemTime};
@@ -73,6 +73,7 @@ pub struct TranscriptionManager {
     watcher_handle: Arc<Mutex<Option<thread::JoinHandle<()>>>>,
     is_loading: Arc<Mutex<bool>>,
     loading_condvar: Arc<Condvar>,
+    streaming_sessions: Arc<AtomicUsize>,
 }
 
 impl TranscriptionManager {
@@ -87,6 +88,7 @@ impl TranscriptionManager {
             watcher_handle: Arc::new(Mutex::new(None)),
             is_loading: Arc::new(Mutex::new(false)),
             loading_condvar: Arc::new(Condvar::new()),
+            streaming_sessions: Arc::new(AtomicUsize::new(0)),
         };
 
         // Start the idle watcher
@@ -111,6 +113,11 @@ impl TranscriptionManager {
                     // maybe_unload_immediately() after each transcription.
                     // Treating it as 0s here would unload the model mid-recording.
                     if timeout == ModelUnloadTimeout::Immediately {
+                        continue;
+                    }
+
+                    if manager_cloned.streaming_sessions.load(Ordering::Relaxed) > 0 {
+                        manager_cloned.touch_activity();
                         continue;
                     }
 
@@ -239,6 +246,11 @@ impl TranscriptionManager {
 
     /// Unloads the model immediately if the setting is enabled and the model is loaded
     pub fn maybe_unload_immediately(&self, context: &str) {
+        if self.streaming_sessions.load(Ordering::Relaxed) > 0 {
+            debug!("Skipping immediate model unload during active streaming session");
+            return;
+        }
+
         let settings = get_settings(&self.app_handle);
         if settings.model_unload_timeout == ModelUnloadTimeout::Immediately
             && self.is_model_loaded()
@@ -248,6 +260,20 @@ impl TranscriptionManager {
                 warn!("Failed to immediately unload model: {}", e);
             }
         }
+    }
+
+    pub fn begin_streaming(&self) {
+        self.streaming_sessions.fetch_add(1, Ordering::Relaxed);
+        self.touch_activity();
+    }
+
+    pub fn end_streaming(&self) {
+        let _ =
+            self.streaming_sessions
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |count| {
+                    Some(count.saturating_sub(1))
+                });
+        self.touch_activity();
     }
 
     pub fn load_model(&self, model_id: &str) -> Result<()> {

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -147,6 +147,13 @@ pub enum ClipboardHandling {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Type)]
 #[serde(rename_all = "snake_case")]
+pub enum TranscriptionMode {
+    Standard,
+    VadChunked,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Type)]
+#[serde(rename_all = "snake_case")]
 pub enum AutoSubmitKey {
     Enter,
     CtrlEnter,
@@ -198,6 +205,12 @@ impl Default for PasteMethod {
 impl Default for ClipboardHandling {
     fn default() -> Self {
         ClipboardHandling::DontModify
+    }
+}
+
+impl Default for TranscriptionMode {
+    fn default() -> Self {
+        TranscriptionMode::Standard
     }
 }
 
@@ -383,6 +396,8 @@ pub struct AppSettings {
     pub paste_method: PasteMethod,
     #[serde(default)]
     pub clipboard_handling: ClipboardHandling,
+    #[serde(default)]
+    pub transcription_mode: TranscriptionMode,
     #[serde(default = "default_auto_submit")]
     pub auto_submit: bool,
     #[serde(default)]
@@ -790,6 +805,7 @@ pub fn get_default_settings() -> AppSettings {
         recording_retention_period: default_recording_retention_period(),
         paste_method: PasteMethod::default(),
         clipboard_handling: ClipboardHandling::default(),
+        transcription_mode: TranscriptionMode::default(),
         auto_submit: default_auto_submit(),
         auto_submit_key: AutoSubmitKey::default(),
         post_process_enabled: default_post_process_enabled(),

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -23,7 +23,7 @@ use tauri_plugin_autostart::ManagerExt;
 use crate::settings::APPLE_INTELLIGENCE_DEFAULT_MODEL_ID;
 use crate::settings::{
     self, get_settings, AutoSubmitKey, ClipboardHandling, KeyboardImplementation, LLMPrompt,
-    OverlayPosition, PasteMethod, ShortcutBinding, SoundTheme, TypingTool,
+    OverlayPosition, PasteMethod, ShortcutBinding, SoundTheme, TranscriptionMode, TypingTool,
     APPLE_INTELLIGENCE_PROVIDER_ID,
 };
 use crate::tray;
@@ -703,6 +703,27 @@ pub fn change_paste_method_setting(app: AppHandle, method: String) -> Result<(),
         }
     };
     settings.paste_method = parsed;
+    settings::write_settings(&app, settings);
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn change_transcription_mode_setting(app: AppHandle, mode: String) -> Result<(), String> {
+    let mut settings = settings::get_settings(&app);
+    let parsed = match mode.as_str() {
+        "standard" => TranscriptionMode::Standard,
+        "vad_chunked" => TranscriptionMode::VadChunked,
+        other => {
+            warn!(
+                "Invalid transcription mode '{}', defaulting to standard",
+                other
+            );
+            TranscriptionMode::Standard
+        }
+    };
+    settings.transcription_mode = parsed;
+    info!("Transcription mode setting changed to {:?}", parsed);
     settings::write_settings(&app, settings);
     Ok(())
 }

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -24,6 +24,7 @@ pub fn cancel_current_operation(app: &AppHandle) {
     let audio_manager = app.state::<Arc<AudioRecordingManager>>();
     let recording_was_active = audio_manager.is_recording();
     audio_manager.cancel_recording();
+    crate::actions::cancel_streaming_session();
 
     // Update tray icon and hide overlay
     change_tray_icon(app, crate::tray::TrayIconState::Idle);

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -133,6 +133,14 @@ async changePasteMethodSetting(method: string) : Promise<Result<null, string>> {
     else return { status: "error", error: e  as any };
 }
 },
+async changeTranscriptionModeSetting(mode: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("change_transcription_mode_setting", { mode }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async getAvailableTypingTools() : Promise<string[]> {
     return await TAURI_INVOKE("get_available_typing_tools");
 },
@@ -802,10 +810,8 @@ async updateRecordingRetentionPeriod(period: string) : Promise<Result<null, stri
 }
 },
 /**
- * Checks if the Mac is a laptop by detecting battery presence
- * 
- * This uses pmset to check for battery information.
- * Returns true if a battery is detected (laptop), false otherwise (desktop)
+ * Stub implementation for non-macOS platforms
+ * Always returns false since laptop detection is macOS-specific
  */
 async isLaptop() : Promise<Result<boolean, string>> {
     try {
@@ -832,7 +838,7 @@ historyUpdatePayload: "history-update-payload"
 
 /** user-defined types **/
 
-export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk: boolean; audio_feedback: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; selected_model?: string; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: SecretMap; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; experimental_enabled?: boolean; lazy_stream_close?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool; external_script_path: string | null; custom_filler_words?: string[] | null; whisper_accelerator?: WhisperAcceleratorSetting; ort_accelerator?: OrtAcceleratorSetting; whisper_gpu_device?: number; extra_recording_buffer_ms?: number }
+export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk: boolean; audio_feedback: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; selected_model?: string; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; transcription_mode?: TranscriptionMode; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: SecretMap; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; experimental_enabled?: boolean; lazy_stream_close?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool; external_script_path: string | null; custom_filler_words?: string[] | null; whisper_accelerator?: WhisperAcceleratorSetting; ort_accelerator?: OrtAcceleratorSetting; whisper_gpu_device?: number; extra_recording_buffer_ms?: number }
 export type AudioDevice = { index: string; name: string; is_default: boolean }
 export type AutoSubmitKey = "enter" | "ctrl_enter" | "cmd_enter"
 export type AvailableAccelerators = { whisper: string[]; ort: string[]; gpu_devices: GpuDeviceOption[] }
@@ -867,6 +873,7 @@ export type RecordingRetentionPeriod = "never" | "preserve_limit" | "days_3" | "
 export type SecretMap = Partial<{ [key in string]: string }>
 export type ShortcutBinding = { id: string; name: string; description: string; default_binding: string; current_binding: string }
 export type SoundTheme = "marimba" | "pop" | "custom"
+export type TranscriptionMode = "standard" | "vad_chunked"
 export type TypingTool = "auto" | "wtype" | "kwtype" | "dotool" | "ydotool" | "xdotool"
 export type WhisperAcceleratorSetting = "auto" | "cpu" | "gpu"
 export type WindowsMicrophonePermissionStatus = { supported: boolean; overall_access: PermissionAccess; device_access: PermissionAccess; app_access: PermissionAccess; desktop_app_access: PermissionAccess }

--- a/src/components/settings/TranscriptionModeSetting.tsx
+++ b/src/components/settings/TranscriptionModeSetting.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import type { TranscriptionMode } from "@/bindings";
+import { useSettings } from "../../hooks/useSettings";
+import { Dropdown } from "../ui/Dropdown";
+import { SettingContainer } from "../ui/SettingContainer";
+
+interface TranscriptionModeSettingProps {
+  descriptionMode?: "inline" | "tooltip";
+  grouped?: boolean;
+}
+
+export const TranscriptionModeSetting: React.FC<TranscriptionModeSettingProps> =
+  React.memo(({ descriptionMode = "tooltip", grouped = false }) => {
+    const { t } = useTranslation();
+    const { getSetting, updateSetting, isUpdating } = useSettings();
+    const selectedMode = (getSetting("transcription_mode") ||
+      "standard") as TranscriptionMode;
+
+    return (
+      <SettingContainer
+        title={t("settings.advanced.transcriptionMode.title")}
+        description={t("settings.advanced.transcriptionMode.description")}
+        descriptionMode={descriptionMode}
+        grouped={grouped}
+      >
+        <Dropdown
+          options={[
+            {
+              value: "standard",
+              label: t(
+                "settings.advanced.transcriptionMode.options.standard",
+              ),
+            },
+            {
+              value: "vad_chunked",
+              label: t(
+                "settings.advanced.transcriptionMode.options.vadChunked",
+              ),
+            },
+          ]}
+          selectedValue={selectedMode}
+          onSelect={(value) =>
+            updateSetting("transcription_mode", value as TranscriptionMode)
+          }
+          disabled={isUpdating("transcription_mode")}
+        />
+      </SettingContainer>
+    );
+  });

--- a/src/components/settings/advanced/AdvancedSettings.tsx
+++ b/src/components/settings/advanced/AdvancedSettings.tsx
@@ -20,6 +20,7 @@ import { useSettings } from "../../../hooks/useSettings";
 import { KeyboardImplementationSelector } from "../debug/KeyboardImplementationSelector";
 import { AccelerationSelector } from "../AccelerationSelector";
 import { LazyStreamClose } from "../LazyStreamClose";
+import { TranscriptionModeSetting } from "../TranscriptionModeSetting";
 
 export const AdvancedSettings: React.FC = () => {
   const { t } = useTranslation();
@@ -47,6 +48,7 @@ export const AdvancedSettings: React.FC = () => {
       <SettingsGroup title={t("settings.advanced.groups.transcription")}>
         <CustomWords descriptionMode="tooltip" grouped />
         <AppendTrailingSpace descriptionMode="tooltip" grouped={true} />
+        <TranscriptionModeSetting descriptionMode="tooltip" grouped={true} />
       </SettingsGroup>
 
       <SettingsGroup title={t("settings.advanced.groups.history")}>

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -255,6 +255,14 @@
         "label": "Keep Mic Open Between Transcriptions",
         "description": "Keeps the microphone stream open for 30 seconds after recording stops, reducing latency for back-to-back transcriptions. May degrade Bluetooth audio quality while active."
       },
+      "transcriptionMode": {
+        "title": "Transcription Mode",
+        "description": "Standard transcribes after recording stops. VAD Chunked transcribes pause-bounded chunks while recording and pastes finalized chunks live.",
+        "options": {
+          "standard": "Standard",
+          "vadChunked": "VAD Chunked"
+        }
+      },
       "acceleration": {
         "whisper": {
           "title": "Whisper Acceleration",

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -120,6 +120,8 @@ const settingUpdaters: {
   paste_delay_ms: (value) =>
     commands.changePasteDelayMsSetting(value as number),
   paste_method: (value) => commands.changePasteMethodSetting(value as string),
+  transcription_mode: (value) =>
+    commands.changeTranscriptionModeSetting(value as string),
   typing_tool: (value) => commands.changeTypingToolSetting(value as string),
   external_script_path: (value) =>
     commands.changeExternalScriptPathSetting(value as string | null),
@@ -155,6 +157,19 @@ const settingUpdaters: {
     commands.changeWhisperGpuDevice(value as number),
   extra_recording_buffer_ms: (value) =>
     commands.changeExtraRecordingBufferSetting(value as number),
+};
+
+const throwIfCommandError = (result: unknown) => {
+  if (
+    result &&
+    typeof result === "object" &&
+    "status" in result &&
+    result.status === "error"
+  ) {
+    const error =
+      "error" in result ? String(result.error) : "Command returned an error";
+    throw new Error(error);
+  }
 };
 
 export const useSettingsStore = create<SettingsStore>()(
@@ -287,7 +302,8 @@ export const useSettingsStore = create<SettingsStore>()(
 
         const updater = settingUpdaters[key];
         if (updater) {
-          await updater(value);
+          const result = await updater(value);
+          throwIfCommandError(result);
         } else if (key !== "bindings" && key !== "selected_model") {
           console.warn(`No handler for setting: ${String(key)}`);
         }


### PR DESCRIPTION
## Before Submitting This PR

<!--
HANDY IS UNDERGOING A FEATURE FREEZE. IF YOU ARE SUBMITTING A PR WHICH IS A NEW FEATURE THAT THE COMMUNITY HAS NOT ASKED FOR: PREPARE TO BE REJECTED. IF THE COMMUNITY HAS ASKED FOR IT, OR YOU HAVE EXPLICITLY GATHERED SUPPORT IT MAY STILL BE CONSIDERED.

BUG FIXES ARE THE TOP PRIORITY. THERE ARE 60+ ISSUES TO FIX.
-->

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [x] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

This PR started as an idea to use live streaming, but this strategy sounded much easier and less intrusive. From my tests this is indeed the case. It improves response time without consequent increase in complexity ( as live stream would entail). I am on a Cosmic  24 / Wayland system. I am not certain how this will behave in other systems. Mine works perfectly. 

## Related Issues/Discussions

<!-- Link to related issues, discussions, or previous PRs -->
<!-- If reopening something previously closed, explain why this should be reconsidered -->

Fixes #
Discussion:

Related prior/parallel work:

- Inspired by #1173
- Related to open eager segmented transcription work in #1515
- Related to older closed live/streaming transcription PRs including #550, #832, and #864

This version is intentionally narrower than previous attempts: standard transcription remains the default, and the new behavior is an opt-in VAD chunked mode. It reuses Handy's existing recorder, Silero VAD, transcription manager, paste path, and history storage instead of introducing a separate streaming engine.

## Community Feedback

No discussion link yet. This is an experimental implementation prepared from local COSMIC 24.04 Wayland testing and prior PR context.

## Testing

- [x] `bun run lint`
- [x] `bun run build`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml`
- [x] `git diff --check`
- [x] Manual test on Pop!_OS/COSMIC 24.04 Wayland: VAD Chunked mode starts streaming, emits pause-bounded chunks, and pastes live chunks.

## Screenshots/Videos (if applicable)

N/A

## AI Assistance

<!-- AI-assisted PRs are welcome! Just let us know so we can review appropriately. -->

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: Assisted with implementation, debugging, logging, local verification, and PR preparation.
