### PR TITLE
fix(transcription): chunk long GigaAM audio to prevent crash on recordings over ~3 min

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -69,7 +69,7 @@ rusqlite = { version = "0.37", features = ["bundled"] }
 tar = "0.4.44"
 flate2 = "1.0"
 sha2 = "0.10"
-transcribe-rs = { version = "0.3.8", features = ["whisper-cpp", "onnx"] }
+transcribe-rs = { version = "0.3.8", features = ["whisper-cpp", "onnx", "vad-silero"] }
 handy-keys = "0.2.4"
 ferrous-opencc = "0.2.3"
 clap = { version = "4", features = ["derive"] }

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -502,6 +502,19 @@ impl TranscriptionManager {
             }
         };
 
+        // Resolved once here so it can be moved into the panic-guarded closure.
+        // Used by GigaAM to VAD-chunk long audio that would otherwise exceed the
+        // model's encoder limit.
+        let vad_path = self
+            .app_handle
+            .path()
+            .resolve(
+                "resources/models/silero_vad_v4.onnx",
+                tauri::path::BaseDirectory::Resource,
+            )
+            .ok();
+        let vad_path = vad_path.as_ref().and_then(|p| p.to_str());
+
         // Perform transcription with the appropriate engine.
         // We use catch_unwind to prevent engine panics from poisoning the mutex,
         // which would make the app hang indefinitely on subsequent operations.
@@ -593,9 +606,10 @@ impl TranscriptionManager {
                                     anyhow::anyhow!("SenseVoice transcription failed: {}", e)
                                 })
                         }
-                        LoadedEngine::GigaAM(gigaam_engine) => gigaam_engine
-                            .transcribe(&audio, &TranscribeOptions::default())
-                            .map_err(|e| anyhow::anyhow!("GigaAM transcription failed: {}", e)),
+                        LoadedEngine::GigaAM(gigaam_engine) => {
+                            transcribe_gigaam(gigaam_engine, &audio, vad_path)
+                                .map_err(|e| anyhow::anyhow!("GigaAM transcription failed: {}", e))
+                        }
                         LoadedEngine::Canary(canary_engine) => {
                             let lang = if validated_language == "auto" {
                                 None
@@ -851,4 +865,57 @@ impl Drop for TranscriptionManager {
             }
         }
     }
+}
+
+// GigaAM's exported ONNX encoder caps positional encoding at 5000 frames
+// (~200 s); longer audio crashes outright, and quality degrades well before
+// that. The model is documented for <=25 s per pass, so audio above this
+// threshold is segmented at silence boundaries (mirroring GigaAM's official
+// transcribe_longform). Shorter audio fits in a single pass and is left
+// untouched — identical output, no chunking overhead.
+const GIGAAM_CHUNK_THRESHOLD_SECS: f32 = 40.0;
+
+fn transcribe_gigaam(
+    model: &mut GigaAMModel,
+    audio: &[f32],
+    vad_path: Option<&str>,
+) -> Result<transcribe_rs::TranscriptionResult> {
+    let duration_secs = audio.len() as f32 / 16_000.0;
+
+    match vad_path {
+        Some(path) if duration_secs > GIGAAM_CHUNK_THRESHOLD_SECS => {
+            info!(
+                "GigaAM: audio {:.0}s exceeds {:.0}s limit, using VAD-chunked transcription",
+                duration_secs, GIGAAM_CHUNK_THRESHOLD_SECS
+            );
+            transcribe_gigaam_chunked(model, audio, path)
+        }
+        _ => model
+            .transcribe(audio, &TranscribeOptions::default())
+            .map_err(|e| anyhow::anyhow!("{}", e)),
+    }
+}
+
+fn transcribe_gigaam_chunked(
+    model: &mut GigaAMModel,
+    audio: &[f32],
+    vad_path: &str,
+) -> Result<transcribe_rs::TranscriptionResult> {
+    use transcribe_rs::transcriber::{Transcriber, VadChunked, VadChunkedConfig};
+    use transcribe_rs::vad::{SileroVad, SmoothedVad};
+
+    let silero = SileroVad::new(vad_path, 0.3)
+        .map_err(|e| anyhow::anyhow!("failed to load Silero VAD for chunking: {}", e))?;
+    let vad = SmoothedVad::new(Box::new(silero), 15, 15, 2);
+    let config = VadChunkedConfig {
+        min_chunk_secs: 10.0,
+        max_chunk_secs: 24.0,
+        padding_secs: 0.0,
+        smart_split_search_secs: Some(3.0),
+        merge_separator: " ".into(),
+    };
+    let mut chunker = VadChunked::new(Box::new(vad), config, TranscribeOptions::default());
+    chunker
+        .transcribe(model, audio)
+        .map_err(|e| anyhow::anyhow!("{}", e))
 }


### PR DESCRIPTION
## Before Submitting This PR

- [x] I searched existing issues and pull requests to make sure this isn't a duplicate
- [x] I read CONTRIBUTING.md

## Human Written Description

I use the GigaAM v3 model and noticed that any recording longer than a few minutes just gave me no text at all, while short ones worked fine. Losing several minutes of speech with nothing to show for it is the worst case, and long dictations are exactly when I need it most, so I looked into why it happens and fixed it.

## Related Issues/Discussions

Fixes the GigaAM case of #1332 (Handy silently drops long audio recordings around 5 min). The same cause probably affects other ONNX models like Parakeet (#1483), but I only changed and tested the GigaAM path. There is also an unmerged `chunking` branch in the repo doing a broader streaming version; this is a smaller targeted fix that reuses the same transcribe-rs VadChunked.

## Community Feedback

#1332 is open with 10 comments from people hitting the same lost long recordings.

## What was wrong

GigaAM crashes on recordings longer than about 3 minutes. The ONNX model has a fixed limit of 5000 encoder frames, which is roughly 200 seconds of audio. Past that it errors out in the attention layer ("5000 by N"). Quality also drops well before that. GigaAM's own README says the model is only meant for audio up to 25 seconds, and for longer audio you are supposed to split it with a VAD first (their transcribe_longform does exactly this).

## The fix

If the audio is longer than 40 seconds, split it into chunks of up to 24 seconds at silent points using the Silero VAD that already ships with Handy, transcribe each chunk, and join the text. Audio under 40 seconds goes through the same code as before, so short recordings are untouched.

Changes:
transcription.rs, route long GigaAM audio through VadChunked.
Cargo.toml, enable the vad-silero feature (Cargo.lock is unchanged).

## Testing

Built it on a Mac (M4, GigaAM v3 int8) and recorded 3.6 minutes. Before the fix this length crashed. After the fix it split into 17 chunks, transcribed the whole thing, and pasted the text. No errors.

Then I ran a benchmark comparing the old behavior (whole audio in one pass) against the fix (chunked), both against a known transcript, measuring word error rate (lower is better). Test files were built from the open GOLOS Russian dataset at fixed lengths, three files each.

Results, old vs new, WER %:
30 sec: old 25.0 / 18.2 / 21.7, new 25.0 / 18.2 / 39.1
120 sec: old 89 / 93 / 91, new 25 / 21 / 23
180 sec: old 100 / 98 / 100, new 19 / 26 / 29
600 sec: old crashes, new 26 / 33 / 27

Clips that fit a single chunk come out identical (25.0 vs 25.0, 18.2 vs 18.2), so there is no quality loss on audio the model can already handle. Past 2 minutes the old path returns near garbage before it crashes after about 200 seconds. The one 30 sec file that differs is actually 34 seconds, so it gets split.

How to reproduce: the dataset builder and the benchmark tool are here: https://gist.github.com/thriw/24dc2059790532b7fddd7421d89fc58a . No audio is committed, the script regenerates it from GOLOS.
