### PR TITLE
fix: support global shortcuts and paste on GNOME/Wayland (Ubuntu 26.04)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,6 +135,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev libgtk-layer-shell0 libgtk-layer-shell-dev
 
+      - name: install dependencies (ubuntu 26.04 x64)
+        if: contains(inputs.platform, 'ubuntu-26.04') && !contains(inputs.platform, 'arm')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev libgtk-layer-shell0 libgtk-layer-shell-dev libevdev-dev xdg-utils
+
       - name: Verify gtk-layer-shell runtime dependency (Ubuntu)
         if: contains(inputs.platform, 'ubuntu')
         run: |

--- a/BUILD.md
+++ b/BUILD.md
@@ -52,9 +52,9 @@ ORT_LIB_LOCATION=$(brew --prefix onnxruntime)/lib ORT_PREFER_DYNAMIC_LINK=1 bun 
 - Install with:
 
   ```bash
-  # Ubuntu/Debian
+  # Ubuntu/Debian (22.04, 24.04, 26.04)
   sudo apt update
-  sudo apt install build-essential libasound2-dev pkg-config libssl-dev libvulkan-dev vulkan-tools glslc spirv-headers glslang-tools libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev libgtk-layer-shell0 libgtk-layer-shell-dev patchelf cmake
+  sudo apt install build-essential clang libclang-dev libasound2-dev pkg-config libssl-dev libvulkan-dev vulkan-tools glslc spirv-headers glslang-tools libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev libgtk-layer-shell0 libgtk-layer-shell-dev libevdev-dev patchelf cmake libopenblas-dev libx11-dev libxtst-dev libxrandr-dev
 
   # Fedora/RHEL
   sudo dnf groupinstall "Development Tools"

--- a/README.md
+++ b/README.md
@@ -137,7 +137,9 @@ For reliable text input on Linux, install the appropriate tool for your display 
 | Display Server | Recommended Tool | Install Command                                    |
 | -------------- | ---------------- | -------------------------------------------------- |
 | X11            | `xdotool`        | `sudo apt install xdotool`                         |
-| Wayland        | `wtype`          | `sudo apt install wtype`                           |
+| Wayland (GNOME/Ubuntu) | `ydotool` + `wl-clipboard` | `sudo apt install ydotool wl-clipboard` then `sudo systemctl enable --now ydotoold` and `sudo usermod -aG input $USER` (log out/in) |
+| Wayland (Sway/Hyprland) | `wtype`          | `sudo apt install wtype`                           |
+| Wayland (KDE)        | `ydotool` or `dotool` | `sudo apt install ydotool`                          |
 | Both           | `dotool`         | `sudo apt install dotool` (requires `input` group) |
 
 - **X11**: Install `xdotool` for both direct typing and clipboard paste shortcuts
@@ -232,7 +234,7 @@ The following are recommendations for running Handy on your own machine. If you 
 - **macOS**: M series Mac, Intel Mac
 - **Windows**: Intel, AMD, or NVIDIA GPU
 - **Linux**: Intel, AMD, or NVIDIA GPU
-  - Ubuntu 22.04, 24.04
+  - Ubuntu 22.04, 24.04, 26.04
 
 **For Parakeet V3 Model:**
 

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -4,13 +4,15 @@ use crate::settings::TypingTool;
 use crate::settings::{get_settings, AutoSubmitKey, ClipboardHandling, PasteMethod};
 use enigo::{Direction, Enigo, Key, Keyboard};
 use log::info;
+#[cfg(target_os = "linux")]
+use log::warn;
 use std::process::Command;
 use std::time::Duration;
 use tauri::{AppHandle, Manager};
 use tauri_plugin_clipboard_manager::ClipboardExt;
 
 #[cfg(target_os = "linux")]
-use crate::utils::{is_kde_wayland, is_wayland};
+use crate::utils::{is_gnome_wayland, is_kde_wayland, is_wayland};
 
 /// Pastes text using the clipboard: saves current content, writes text, sends paste keystroke, restores clipboard.
 fn paste_via_clipboard(
@@ -53,11 +55,22 @@ fn paste_via_clipboard(
 
     // Fall back to enigo if no native tool handled it
     if !key_combo_sent {
-        match paste_method {
-            PasteMethod::CtrlV => input::send_paste_ctrl_v(enigo)?,
-            PasteMethod::CtrlShiftV => input::send_paste_ctrl_shift_v(enigo)?,
-            PasteMethod::ShiftInsert => input::send_paste_shift_insert(enigo)?,
+        let enigo_result = match paste_method {
+            PasteMethod::CtrlV => input::send_paste_ctrl_v(enigo),
+            PasteMethod::CtrlShiftV => input::send_paste_ctrl_shift_v(enigo),
+            PasteMethod::ShiftInsert => input::send_paste_shift_insert(enigo),
             _ => return Err("Invalid paste method for clipboard paste".into()),
+        };
+
+        if enigo_result.is_err() {
+            #[cfg(target_os = "linux")]
+            if is_wayland() {
+                warn!("Clipboard paste key combo failed on Wayland, falling back to direct typing");
+                if try_direct_typing_linux(text, TypingTool::Auto)? {
+                    return Ok(());
+                }
+            }
+            enigo_result?;
         }
     }
 
@@ -78,38 +91,81 @@ fn paste_via_clipboard(
     Ok(())
 }
 
+/// Logs a tool failure and returns whether the attempt succeeded.
+#[cfg(target_os = "linux")]
+fn attempt_tool(name: &str, result: Result<(), String>) -> bool {
+    match result {
+        Ok(()) => {
+            info!("Using {} successfully", name);
+            true
+        }
+        Err(e) => {
+            warn!("{} failed: {}, trying next tool", name, e);
+            false
+        }
+    }
+}
+
 /// Attempts to send a key combination using Linux-native tools.
 /// Returns `Ok(true)` if a native tool handled it, `Ok(false)` to fall back to enigo.
 #[cfg(target_os = "linux")]
 fn try_send_key_combo_linux(paste_method: &PasteMethod) -> Result<bool, String> {
     if is_wayland() {
-        // Wayland: prefer wtype (but not on KDE), then dotool, then ydotool
-        // Note: wtype doesn't work on KDE (no zwp_virtual_keyboard_manager_v1 support)
-        if !is_kde_wayland() && is_wtype_available() {
-            info!("Using wtype for key combo");
-            send_key_combo_via_wtype(paste_method)?;
-            return Ok(true);
-        }
-        if is_dotool_available() {
-            info!("Using dotool for key combo");
-            send_key_combo_via_dotool(paste_method)?;
-            return Ok(true);
-        }
-        if is_ydotool_available() {
-            info!("Using ydotool for key combo");
-            send_key_combo_via_ydotool(paste_method)?;
-            return Ok(true);
+        // GNOME Wayland does not expose the virtual keyboard protocol that wtype needs.
+        // Prefer uinput-based tools (ydotool/dotool) first.
+        if is_gnome_wayland() {
+            if is_ydotool_available()
+                && attempt_tool("ydotool", send_key_combo_via_ydotool(paste_method))
+            {
+                return Ok(true);
+            }
+            if is_dotool_available()
+                && attempt_tool("dotool", send_key_combo_via_dotool(paste_method))
+            {
+                return Ok(true);
+            }
+            if is_wtype_available() && attempt_tool("wtype", send_key_combo_via_wtype(paste_method))
+            {
+                return Ok(true);
+            }
+        } else if is_kde_wayland() {
+            if is_dotool_available()
+                && attempt_tool("dotool", send_key_combo_via_dotool(paste_method))
+            {
+                return Ok(true);
+            }
+            if is_ydotool_available()
+                && attempt_tool("ydotool", send_key_combo_via_ydotool(paste_method))
+            {
+                return Ok(true);
+            }
+        } else {
+            // Other Wayland compositors: try wtype first, but fall through on failure.
+            if is_wtype_available() && attempt_tool("wtype", send_key_combo_via_wtype(paste_method))
+            {
+                return Ok(true);
+            }
+            if is_dotool_available()
+                && attempt_tool("dotool", send_key_combo_via_dotool(paste_method))
+            {
+                return Ok(true);
+            }
+            if is_ydotool_available()
+                && attempt_tool("ydotool", send_key_combo_via_ydotool(paste_method))
+            {
+                return Ok(true);
+            }
         }
     } else {
         // X11: prefer xdotool, then ydotool
-        if is_xdotool_available() {
-            info!("Using xdotool for key combo");
-            send_key_combo_via_xdotool(paste_method)?;
+        if is_xdotool_available()
+            && attempt_tool("xdotool", send_key_combo_via_xdotool(paste_method))
+        {
             return Ok(true);
         }
-        if is_ydotool_available() {
-            info!("Using ydotool for key combo");
-            send_key_combo_via_ydotool(paste_method)?;
+        if is_ydotool_available()
+            && attempt_tool("ydotool", send_key_combo_via_ydotool(paste_method))
+        {
             return Ok(true);
         }
     }
@@ -159,27 +215,42 @@ fn try_direct_typing_linux(text: &str, preferred_tool: TypingTool) -> Result<boo
     // Auto mode - existing fallback chain
     if is_wayland() {
         // KDE Wayland: prefer kwtype (uses KDE Fake Input protocol, supports umlauts)
-        if is_kde_wayland() && is_kwtype_available() {
-            info!("Using kwtype for direct text input on KDE Wayland");
-            type_text_via_kwtype(text)?;
+        if is_kde_wayland()
+            && is_kwtype_available()
+            && attempt_tool("kwtype", type_text_via_kwtype(text))
+        {
             return Ok(true);
         }
-        // Wayland: prefer wtype, then dotool, then ydotool
-        // Note: wtype doesn't work on KDE (no zwp_virtual_keyboard_manager_v1 support)
-        if !is_kde_wayland() && is_wtype_available() {
-            info!("Using wtype for direct text input");
-            type_text_via_wtype(text)?;
-            return Ok(true);
-        }
-        if is_dotool_available() {
-            info!("Using dotool for direct text input");
-            type_text_via_dotool(text)?;
-            return Ok(true);
-        }
-        if is_ydotool_available() {
-            info!("Using ydotool for direct text input");
-            type_text_via_ydotool(text)?;
-            return Ok(true);
+
+        // GNOME Wayland: wtype's virtual keyboard protocol is unavailable; use uinput tools.
+        if is_gnome_wayland() {
+            if is_ydotool_available() && attempt_tool("ydotool", type_text_via_ydotool(text)) {
+                return Ok(true);
+            }
+            if is_dotool_available() && attempt_tool("dotool", type_text_via_dotool(text)) {
+                return Ok(true);
+            }
+            if is_wtype_available() && attempt_tool("wtype", type_text_via_wtype(text)) {
+                return Ok(true);
+            }
+        } else if is_kde_wayland() {
+            if is_dotool_available() && attempt_tool("dotool", type_text_via_dotool(text)) {
+                return Ok(true);
+            }
+            if is_ydotool_available() && attempt_tool("ydotool", type_text_via_ydotool(text)) {
+                return Ok(true);
+            }
+        } else {
+            // Other Wayland compositors: try wtype first, fall through on failure.
+            if is_wtype_available() && attempt_tool("wtype", type_text_via_wtype(text)) {
+                return Ok(true);
+            }
+            if is_dotool_available() && attempt_tool("dotool", type_text_via_dotool(text)) {
+                return Ok(true);
+            }
+            if is_ydotool_available() && attempt_tool("ydotool", type_text_via_ydotool(text)) {
+                return Ok(true);
+            }
         }
     } else {
         // X11: prefer xdotool, then ydotool

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -191,8 +191,19 @@ pub enum KeyboardImplementation {
 
 impl Default for KeyboardImplementation {
     fn default() -> Self {
+        // On Linux Wayland (GNOME/KDE/etc.), the Tauri global-shortcut plugin
+        // cannot capture system-wide hotkeys because the compositor does not
+        // expose a global key-grab API. The handy-keys implementation reads
+        // input via evdev (/dev/input), which works globally on Wayland as long
+        // as the user is in the `input` group. Default to it on Wayland so the
+        // shortcut works natively out of the box. X11 keeps the Tauri backend.
         #[cfg(target_os = "linux")]
-        return KeyboardImplementation::Tauri;
+        {
+            if crate::utils::is_wayland() {
+                return KeyboardImplementation::HandyKeys;
+            }
+            return KeyboardImplementation::Tauri;
+        }
         #[cfg(not(target_os = "linux"))]
         return KeyboardImplementation::HandyKeys;
     }

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -67,3 +67,23 @@ pub fn is_kde_plasma() -> bool {
 pub fn is_kde_wayland() -> bool {
     is_wayland() && is_kde_plasma()
 }
+
+/// Check if running on GNOME desktop environment
+#[cfg(target_os = "linux")]
+pub fn is_gnome() -> bool {
+    std::env::var("XDG_CURRENT_DESKTOP")
+        .map(|v| {
+            let upper = v.to_uppercase();
+            upper.contains("GNOME") || upper.contains("UBUNTU")
+        })
+        .unwrap_or(false)
+        || std::env::var("DESKTOP_SESSION")
+            .map(|v| v.to_lowercase().contains("gnome"))
+            .unwrap_or(false)
+}
+
+/// Check if running on GNOME with Wayland
+#[cfg(target_os = "linux")]
+pub fn is_gnome_wayland() -> bool {
+    is_wayland() && is_gnome()
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -46,6 +46,7 @@
     "linux": {
       "deb": {
         "depends": ["libgtk-layer-shell0"],
+        "recommends": ["ydotool", "wl-clipboard", "wtype", "xdotool"],
         "files": {
           "/usr/lib": "transcribe-libs"
         }


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched existing issues and pull requests (including closed ones) to ensure this isn't a duplicate
- [x] I have read CONTRIBUTING.md

## Human Written Description

I run Handy on a few machines and it's been solid on macOS and Ubuntu 24.04, but on a fresh Ubuntu 26.04 install (GNOME on Wayland) it was basically unusable: the global shortcut never started a recording, and when I did get audio through, the transcribed text was never pasted into the focused app. The logs matched what others reported in #1549 — `wtype failed: Compositor does not support the virtual keyboard protocol` — even with `ydotool` installed. After digging in, both problems come down to Wayland/GNOME specifics, not the transcription pipeline itself. This fix keeps current behavior on X11/macOS/Windows and only changes what's needed on Wayland. It matters to me because 26.04 is what ships on new machines now, and the app looks broken out of the box there.

## Related Issues/Discussions

Addresses #1549 (Problem 1: GNOME Wayland keycombo paste picks `wtype`, fails, and previously had no runtime fallback)

Related to #1555 (Wayland meta tracker — text insertion and hotkeys)

Related to #429 (GNOME Wayland paste reliability; clipboard keycombo portion)

Related to #949 (Tauri global shortcuts don't work on Wayland compositors — defaulting to `HandyKeys`/evdev on Wayland)

Discussion: #1555

**Note:** #1549 Problem 2 (ExternalScript paste hanging via `wl-copy`) is **not** addressed here.

**Overlap with other PRs:** #1276 tackles the same GNOME/`wtype` paste guard; this PR goes further with runtime per-tool fallback (`attempt_tool`), explicit GNOME ordering (`ydotool` → `dotool` → `wtype`), default `HandyKeys` on Wayland for hotkeys, and packaging/docs/CI for Ubuntu 26.04. Happy to coordinate if the maintainer prefers a narrower scope.

## Community Feedback

This is a bug fix, not a feature. #1549 documents the exact failure mode (including logs) on GNOME Wayland with Handy 0.8.3. #1555 tracks Wayland paste/hotkey work across the project. #522 (closed) reported the same `wtype` error being surfaced only in logs with no fallback — the `attempt_tool` helper and GNOME tool ordering address that behavior.

## Testing

Tested on Ubuntu 26.04 (GNOME / Wayland):

- Built the `.deb` locally and installed it clean.
- Global shortcut now triggers recording on first launch. Before this change the Tauri global-shortcut backend simply never fired under Wayland.
- Transcribed text is pasted reliably. Before, `wtype` failed with "Compositor does not support the virtual keyboard protocol" and nothing landed in the field.
- Environment: `ydotool` + `wl-clipboard` installed, `ydotoold` running, user in the `input` group.

**System information:**

- App version: 0.8.3 (local build)
- OS: Ubuntu 26.04, GNOME on Wayland (`XDG_SESSION_TYPE=wayland`)
- CPU: AMD Ryzen 7 5700X
- GPU: AMD Radeon RX 6700 XT (Navi 22)

To confirm I didn't regress the other targets:

- Everything I added on the runtime side is gated behind `#[cfg(target_os = "linux")]`, so macOS and Windows compile and behave exactly as before.
- On Linux/X11 nothing changes: the keyboard backend stays `Tauri` and paste still prefers `xdotool`.
- `cargo fmt --check`, `cargo clippy`, and the lib tests pass with no new warnings.

### What changed and why

**Global shortcut.** On Wayland the compositor doesn't hand out a system-wide key-grab API, so the Tauri global-shortcut plugin can't see the hotkey (#949). The `handy-keys` backend already reads input via evdev (`/dev/input`), which works globally on Wayland as long as the user is in the `input` group. The default `KeyboardImplementation` now resolves to `HandyKeys` on Linux **Wayland** sessions and stays `Tauri` on X11.

**Paste / typing.** `wtype` depends on the virtual keyboard protocol that GNOME doesn't implement (#1549, #522). On GNOME Wayland the fallback chain now prefers uinput-based tools (`ydotool`, then `dotool`) before `wtype`, and `attempt_tool` logs failures and falls through instead of aborting on the first error. If the clipboard paste combo still fails on Wayland, it falls back to direct typing.

**Packaging & docs.** The `.deb` recommends `ydotool` + `wl-clipboard`, the CI gets a dependency step for Ubuntu 26.04 builds, and README/BUILD document 26.04 support plus the extra build deps (`clang`, `libclang-dev`, `libevdev-dev`).

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

- Tools used: Cursor (Claude).
- How extensively: used it to diagnose the Wayland/GNOME behavior, search related issues/PRs, and draft the Linux fallback logic and docs. I reviewed every change and tested the build on Ubuntu 26.04 myself.
