### PR TITLE
fix: show Processing for non-streaming Live overlay

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -74,6 +74,10 @@ fn is_blank_transcription(transcription: &str) -> bool {
     transcription.trim().is_empty()
 }
 
+fn should_use_streaming_overlay(style: OverlayStyle, is_streaming: bool) -> bool {
+    style == OverlayStyle::Live && is_streaming
+}
+
 async fn post_process_transcription(settings: &AppSettings, transcription: &str) -> Option<String> {
     if is_blank_transcription(transcription) {
         debug!("Post-processing skipped because the transcription is empty");
@@ -601,11 +605,13 @@ impl ShortcutAction for TranscribeAction {
         // spinner while the stream finalizes. Non-streaming paths use the
         // compact transcribing pill (None no-ops in show_*).
         let style = get_settings(app).overlay_style;
-        match (style, tm.is_streaming()) {
-            (OverlayStyle::Live, true) => {
-                tm.emit_stream_working(StreamWorkKind::Transcribing);
-            }
-            _ => show_transcribing_overlay(app),
+        // Capture this before finalizing the stream so every later working state
+        // targets the same overlay that was shown for this transcription.
+        let use_streaming_overlay = should_use_streaming_overlay(style, tm.is_streaming());
+        if use_streaming_overlay {
+            tm.emit_stream_working(StreamWorkKind::Transcribing);
+        } else {
+            show_transcribing_overlay(app);
         }
 
         // Unmute before playing audio feedback so the stop sound is audible
@@ -715,7 +721,7 @@ impl ShortcutAction for TranscribeAction {
                             );
 
                             if post_process {
-                                if style == OverlayStyle::Live {
+                                if use_streaming_overlay {
                                     tm.emit_stream_working(StreamWorkKind::Polishing);
                                 } else {
                                     show_processing_overlay(&ah);
@@ -890,7 +896,8 @@ pub static ACTION_MAP: Lazy<HashMap<String, Arc<dyn ShortcutAction>>> = Lazy::ne
 
 #[cfg(test)]
 mod tests {
-    use super::is_blank_transcription;
+    use super::{is_blank_transcription, should_use_streaming_overlay};
+    use crate::settings::OverlayStyle;
 
     #[test]
     fn blank_transcription_is_detected() {
@@ -903,5 +910,13 @@ mod tests {
     fn non_blank_transcription_is_kept() {
         assert!(!is_blank_transcription("hello"));
         assert!(!is_blank_transcription("  hello  "));
+    }
+
+    #[test]
+    fn live_overlay_uses_streaming_states_only_for_streaming_models() {
+        assert!(should_use_streaming_overlay(OverlayStyle::Live, true));
+        assert!(!should_use_streaming_overlay(OverlayStyle::Live, false));
+        assert!(!should_use_streaming_overlay(OverlayStyle::Minimal, true));
+        assert!(!should_use_streaming_overlay(OverlayStyle::None, true));
     }
 }


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

Not applicable: this is a new bug fix, not a feature or a previously rejected change.

## Human Written Description

I noticed that after upgrading to Handy 0.9.0, post-processing still ran successfully, but the overlay in Live mode showed only “Transcribing...” and never the “Processing...” phase when I used a non-streaming model. This made it difficult to tell whether the LLM stage was actually running. I used OpenAI Codex to investigate the logs and code path, and I wanted to restore the clear processing feedback Handy provided before.

## Related Issues/Discussions

Fixes #1596
Discussion: Not applicable; this is a focused bug fix tracked by #1596.

## Community Feedback

The reproduction, affected/unaffected configuration matrix, sanitized logs, and workaround are documented in #1596.

## Implementation Notes

When Live style is selected for a non-streaming model, Handy intentionally falls back to the compact overlay. The transcription stop path accounted for both the configured style and the active stream, but the post-processing path checked only the configured style and sent a streaming-only Polishing event to an inactive panel.

This change captures whether the current session is actually using the streaming overlay before stream finalization and reuses that decision for both Transcribing and Polishing/Processing updates. A focused unit test covers Live with and without an active stream, plus Minimal and None styles.

## Testing

- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` — passed
- `git diff --check` — passed
- Added a unit test covering the overlay routing decision matrix
- GitHub Actions `rust-tests` — passed
- GitHub Actions `nix-build` — passed
- Manually reproduced the original behavior on Handy 0.9.0 with Live + Qwen3-ASR 1.7B (`supports_streaming=false`), and confirmed that changing only the overlay style to Minimal restores the Processing state
- `cargo test --manifest-path src-tauri/Cargo.toml --lib actions::tests` was attempted locally, but the existing macOS Command Line Tools installation is missing the libc++ `<mutex>` and `<array>` headers required by `transcribe-cpp-sys`; the full test suite passed in the clean GitHub Actions environment

## Screenshots/Videos (if applicable)

Not included. The state transition is short-lived; the exact reproduction and non-reproduction conditions are documented in #1596.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Codex helped inspect the v0.9.0 overlay state flow and local debug logs, identify the mismatched routing condition, implement the focused fix and regression test, and prepare the technical issue/PR sections. The contributor independently reproduced and verified the affected and unaffected configurations and provided the required human-written description.
