### PR TITLE
fix: modifier-only shortcuts now activate on a single tap instead of on every press

### DIFF
--- a/src-tauri/src/transcription_coordinator.rs
+++ b/src-tauri/src/transcription_coordinator.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant};
 use tauri::{AppHandle, Manager};
 
 const DEBOUNCE: Duration = Duration::from_millis(30);
+const MODIFIER_TAP_MAX_DURATION: Duration = Duration::from_millis(250);
 
 /// Commands processed sequentially by the coordinator thread.
 enum Command {
@@ -49,6 +50,7 @@ impl TranscriptionCoordinator {
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 let mut stage = Stage::Idle;
                 let mut last_press: Option<Instant> = None;
+                let mut modifier_only_press: Option<(String, Instant)> = None;
 
                 while let Ok(cmd) = rx.recv() {
                     match cmd {
@@ -77,23 +79,47 @@ impl TranscriptionCoordinator {
                                 {
                                     stop(&app, &mut stage, &binding_id, &hotkey_string);
                                 }
-                            } else if is_pressed {
-                                match &stage {
-                                    Stage::Idle => {
-                                        start(&app, &mut stage, &binding_id, &hotkey_string);
-                                    }
-                                    Stage::Recording(id) if id == &binding_id => {
-                                        stop(&app, &mut stage, &binding_id, &hotkey_string);
-                                    }
-                                    _ => {
-                                        debug!("Ignoring press for '{binding_id}': pipeline busy")
-                                    }
+                            } else if is_modifier_only_hotkey(&hotkey_string) {
+                                if is_pressed {
+                                    modifier_only_press =
+                                        Some((binding_id.clone(), Instant::now()));
+                                    continue;
                                 }
+
+                                let Some((pressed_binding_id, pressed_at)) =
+                                    modifier_only_press.as_ref()
+                                else {
+                                    continue;
+                                };
+
+                                if pressed_binding_id != &binding_id {
+                                    debug!(
+                                        "Ignoring release for '{binding_id}' because the active modifier tap belongs to '{pressed_binding_id}'"
+                                    );
+                                    continue;
+                                }
+
+                                let pressed_at = *pressed_at;
+                                modifier_only_press = None;
+
+                                let now = Instant::now();
+                                if !is_quick_modifier_tap(pressed_at, now) {
+                                    debug!(
+                                        "Ignoring modifier-only shortcut hold for '{binding_id}' after {:?}",
+                                        now.duration_since(pressed_at)
+                                    );
+                                    continue;
+                                }
+
+                                toggle(&app, &mut stage, &binding_id, &hotkey_string);
+                            } else if is_pressed {
+                                toggle(&app, &mut stage, &binding_id, &hotkey_string);
                             }
                         }
                         Command::Cancel {
                             recording_was_active,
                         } => {
+                            modifier_only_press = None;
                             // Don't reset during processing — wait for the pipeline to finish.
                             if !matches!(stage, Stage::Processing)
                                 && (recording_was_active || matches!(stage, Stage::Recording(_)))
@@ -102,6 +128,7 @@ impl TranscriptionCoordinator {
                             }
                         }
                         Command::ProcessingFinished => {
+                            modifier_only_press = None;
                             stage = Stage::Idle;
                         }
                     }
@@ -156,6 +183,29 @@ impl TranscriptionCoordinator {
             warn!("Transcription coordinator channel closed");
         }
     }
+}
+
+fn toggle(app: &AppHandle, stage: &mut Stage, binding_id: &str, hotkey_string: &str) {
+    match &stage {
+        Stage::Idle => {
+            start(app, stage, binding_id, hotkey_string);
+        }
+        Stage::Recording(id) if id == binding_id => {
+            stop(app, stage, binding_id, hotkey_string);
+        }
+        _ => debug!("Ignoring press for '{binding_id}': pipeline busy"),
+    }
+}
+
+fn is_modifier_only_hotkey(hotkey_string: &str) -> bool {
+    hotkey_string
+        .parse::<handy_keys::Hotkey>()
+        .map(|hotkey| hotkey.key.is_none())
+        .unwrap_or(false)
+}
+
+fn is_quick_modifier_tap(pressed_at: Instant, released_at: Instant) -> bool {
+    released_at.duration_since(pressed_at) <= MODIFIER_TAP_MAX_DURATION
 }
 
 fn start(app: &AppHandle, stage: &mut Stage, binding_id: &str, hotkey_string: &str) {


### PR DESCRIPTION
## Before Submitting This PR

<!--
HANDY IS UNDERGOING A FEATURE FREEZE. IF YOU ARE SUBMITTING A PR WHICH IS A NEW FEATURE THAT THE COMMUNITY HAS NOT ASKED FOR: PREPARE TO BE REJECTED. IF THE COMMUNITY HAS ASKED FOR IT, OR YOU HAVE EXPLICITLY GATHERED SUPPORT IT MAY STILL BE CONSIDERED.

BUG FIXES ARE THE TOP PRIORITY. THERE ARE 60+ ISSUES TO FIX.
-->

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [x] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

<!-- Describe your changes clearly and concisely

Please write 2-3 sentences in your own words explaining:
- What problem you noticed or idea you had
- Why you think this change matters

This section should be YOUR thinking, not AI-generated text. Even if AI helped write the code, we want to hear from you directly. Your perspective as a human is what makes contributions meaningful. Your PR may be rejected if you do not
include a human-written description.
-->

With Handy I like using the Right Option key to toggle recording (Push To Talk disabled) but I don't think that the current approach of starting the recording on press down provides the best experience. The reasoning is that if I use Option to move across words with `Option + Left/Right Arrow` I don't want Handy to start recording, and the simplest way of solving it without being too invasive is to just enable handy on an actual tap and not when holding down a key. I find 250ms to be a reasonable amount of time to differentiate tap from hold. 

I think this is a straight improvement of the app given that starting the recording on press down is valuable when Push To Talk is enabled and not when it's disabled. If we were to be more conservative it could be a toggle in the UI but I don't see the benefits of the current option.

## Related Issues/Discussions

<!-- Link to related issues, discussions, or previous PRs -->
<!-- If reopening something previously closed, explain why this should be reconsidered -->

Partially Addresses #956, though this issue mentions two things:
- Handy does not activate on keydown
- Handy doesn't activate if I use the modifier key as combination with some other key

The PR fixes just the first one but the second one is not fully addressed because a proper fix for that would be a bit more invasive. However, in regular conditions I'd say that it solves both because when using more than one key the user generally doesn't just press the modifier-key for less than 250ms, but it's usually held and what's tapped is the other key (for example, in `Option + Left Arrow` I press option and then tap on the arrow. Handy doesn't activate in this branch).

I see that something along the lines has been done in #914 but the approach is not the same and perhaps the current one may be preferred. I understand if this PR is closed because I've seen some comments in issues mentioning this should probably be handled in `handy-keys`. Sorry if opening this was inadequate, I just wanted to give it a try. I'll continue to use my fork of Handy if that's the case. Thanks.

<!--
## Community Feedback

PRs with community support are much more likely to be merged.

For features: Link to a discussion where community members have expressed interest.
For bug fixes: Link to the issue where others have confirmed the bug.

If you haven't gathered feedback yet, consider starting a discussion first:
https://github.com/cjpais/Handy/discussions

It is not explicitly required to gather feedback, but it certainly helps your PR get merged.
-->

## Testing

<!-- Describe how you tested your changes and if you need help getting additional testing -->
- I compiled and installed the app and it's what I'm currently using. Everything working perfectly fine. Tried other shortcuts like `Option + Space` and it also works well.

## AI Assistance

<!-- AI-assisted PRs are welcome! Just let us know so we can review appropriately. -->

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Opus 4.8 xhigh)
- How extensively: Just thought of the idea myself and I told it to apply it in the code. Iterated a bit to make it minimal.