### PR TITLE
fix: gate whisper run extension on model arch, not Feature::InitialPrompt

### DIFF
--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -1156,6 +1156,12 @@ impl TranscriptionManager {
         // (whisper family). Gates the whisper-only run extension below, and
         // whether fuzzy custom-word correction still runs afterwards.
         let mut model_takes_initial_prompt = false;
+        // Whether the loaded model is actually whisper-family (arch string).
+        // Non-whisper archs (e.g. Voxtral Small) can advertise
+        // Feature::InitialPrompt yet reject the whisper-kind run extension
+        // with INVALID_ARG, so the whisper extension must be gated on the
+        // arch, not on the feature (see #1601).
+        let mut model_is_whisper = false;
 
         // Perform transcription with the appropriate engine.
         // We use catch_unwind to prevent engine panics from poisoning the mutex,
@@ -1189,6 +1195,7 @@ impl TranscriptionManager {
                 let model = session.model();
                 let caps = model.capabilities();
                 model_takes_initial_prompt = model.supports(Feature::InitialPrompt);
+                model_is_whisper = model.arch() == "whisper";
                 model_supports_translate = caps.supports_translate;
                 model_languages = caps.languages;
                 debug!(
@@ -1210,7 +1217,7 @@ impl TranscriptionManager {
                         // with INVALID_ARG, so skip it there and let the fuzzy
                         // post-correction handle custom words instead.
                         let family =
-                            if settings.custom_words.is_empty() || !model_takes_initial_prompt {
+                            if settings.custom_words.is_empty() || !model_is_whisper {
                                 None
                             } else {
                                 Some(RunExtension::Whisper(WhisperRunOptions {
@@ -1390,7 +1397,7 @@ impl TranscriptionManager {
         // family). Non-whisper transcribe-cpp models can't take a prompt, so they
         // still get fuzzy correction here, same as the ONNX engines.
         let filtered_result =
-            post_process_transcription_text(result, &settings, model_takes_initial_prompt);
+            post_process_transcription_text(result, &settings, model_is_whisper);
 
         let et = std::time::Instant::now();
         let translation_note = if settings.translate_to_english {

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -1152,9 +1152,11 @@ impl TranscriptionManager {
             );
         }
 
-        // Whether the loaded transcribe-cpp model accepts a decode prompt
-        // (whisper family). Gates the whisper-only run extension below, and
-        // whether fuzzy custom-word correction still runs afterwards.
+        // Whether the loaded transcribe-cpp model advertises
+        // Feature::InitialPrompt. Informational (logged below); the whisper
+        // run extension and the fuzzy-correction skip are gated on
+        // `model_is_whisper` instead, since non-whisper archs can advertise
+        // the feature while rejecting the whisper-kind extension.
         let mut model_takes_initial_prompt = false;
         // Whether the loaded model is actually whisper-family (arch string).
         // Non-whisper archs (e.g. Voxtral Small) can advertise
@@ -1394,8 +1396,9 @@ impl TranscriptionManager {
 
         // Apply fuzzy word correction if custom words are configured — UNLESS the
         // words were already handed to the model as an initial prompt (whisper
-        // family). Non-whisper transcribe-cpp models can't take a prompt, so they
-        // still get fuzzy correction here, same as the ONNX engines.
+        // family). We don't pass a prompt to non-whisper models (it requires the
+        // whisper-kind run extension), so they still get fuzzy correction here,
+        // same as the ONNX engines.
         let filtered_result =
             post_process_transcription_text(result, &settings, model_is_whisper);
 


### PR DESCRIPTION
As requested in #1601 — this is the patch we've been running locally.

## Problem
Non-whisper models such as Voxtral Small 24B advertise `Feature::InitialPrompt`, so when custom words are configured Handy attaches the whisper-kind run extension to them, and transcribe.cpp rejects the run with `INVALID_ARG`. (The CLI guards this case with `transcribe_model_accepts_ext_kind` before attaching, which is why CLI repros with `--initial-prompt` pass.)

## Change
Probe `model.arch() == "whisper"` once per run and gate on it:
- the whisper run extension (custom words as `initial_prompt`)
- the `custom_words_already_prompted` flag passed to the fuzzy fallback, so models like Voxtral that advertise `InitialPrompt` still get fuzzy custom-word correction

The timestamps half of #1601 is intentionally left to #1602 — no overlapping hunks, both apply cleanly together.

## Testing
- `cargo check` clean
- Built and running locally: Voxtral Small 24B Q5_K_M transcribes correctly (macOS, M5 Pro, Metal, Spanish dictation, custom words falling back to fuzzy correction)
- Whisper large-v3 unaffected (still gets the initial prompt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)