### PR TITLE
feat: add prompt picker hotkey for post-processing

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capabilities for the app",
-  "windows": ["main", "recording_overlay"],
+  "windows": ["main", "recording_overlay", "prompt_picker"],
   "permissions": [
     "core:default",
     "opener:default",

--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -49,6 +49,7 @@ pub trait ShortcutAction: Send + Sync {
 // Transcribe Action
 struct TranscribeAction {
     post_process: bool,
+    prompt_picker: bool,
 }
 
 /// Field name for structured output JSON schema
@@ -74,7 +75,22 @@ fn is_blank_transcription(transcription: &str) -> bool {
     transcription.trim().is_empty()
 }
 
-async fn post_process_transcription(settings: &AppSettings, transcription: &str) -> Option<String> {
+/// Resolves which prompt id to post-process with: an explicit per-call
+/// override (from the prompt picker) wins over the settings-selected prompt.
+fn resolve_prompt_id(
+    prompt_override_id: Option<&str>,
+    selected_prompt_id: &Option<String>,
+) -> Option<String> {
+    prompt_override_id
+        .map(|s| s.to_string())
+        .or_else(|| selected_prompt_id.clone())
+}
+
+async fn post_process_transcription(
+    settings: &AppSettings,
+    transcription: &str,
+    prompt_override_id: Option<&str>,
+) -> Option<String> {
     if is_blank_transcription(transcription) {
         debug!("Post-processing skipped because the transcription is empty");
         return None;
@@ -102,8 +118,11 @@ async fn post_process_transcription(settings: &AppSettings, transcription: &str)
         return None;
     }
 
-    let selected_prompt_id = match &settings.post_process_selected_prompt_id {
-        Some(id) => id.clone(),
+    let selected_prompt_id = match resolve_prompt_id(
+        prompt_override_id,
+        &settings.post_process_selected_prompt_id,
+    ) {
+        Some(id) => id,
         None => {
             debug!("Post-processing skipped because no prompt is selected");
             return None;
@@ -391,6 +410,7 @@ pub(crate) async fn process_transcription_output(
     app: &AppHandle,
     transcription: &str,
     post_process: bool,
+    prompt_override_id: Option<String>,
 ) -> ProcessedTranscription {
     let settings = get_settings(app);
     let mut final_text = transcription.to_string();
@@ -408,15 +428,21 @@ pub(crate) async fn process_transcription_output(
     }
 
     if post_process {
-        if let Some(processed_text) = post_process_transcription(&settings, &final_text).await {
+        if let Some(processed_text) =
+            post_process_transcription(&settings, &final_text, prompt_override_id.as_deref())
+                .await
+        {
             post_processed_text = Some(processed_text.clone());
             final_text = processed_text;
 
-            if let Some(prompt_id) = &settings.post_process_selected_prompt_id {
+            let used_prompt_id = prompt_override_id
+                .as_deref()
+                .or(settings.post_process_selected_prompt_id.as_deref());
+            if let Some(prompt_id) = used_prompt_id {
                 if let Some(prompt) = settings
                     .post_process_prompts
                     .iter()
-                    .find(|prompt| &prompt.id == prompt_id)
+                    .find(|prompt| prompt.id == prompt_id)
                 {
                     post_process_prompt = Some(prompt.prompt.clone());
                 }
@@ -616,6 +642,7 @@ impl ShortcutAction for TranscribeAction {
 
         let binding_id = binding_id.to_string(); // Clone binding_id for the async task
         let post_process = self.post_process;
+        let prompt_picker = self.prompt_picker;
         let cancel_generation = rm.cancel_generation();
 
         tauri::async_runtime::spawn(async move {
@@ -714,6 +741,41 @@ impl ShortcutAction for TranscribeAction {
                                 transcription
                             );
 
+                            let mut prompt_override_id: Option<String> = None;
+
+                            if prompt_picker && !is_blank_transcription(&transcription) {
+                                let picker_settings = get_settings(&ah);
+                                match crate::prompt_picker::await_prompt_choice(
+                                    &ah,
+                                    picker_settings.post_process_prompts.clone(),
+                                    picker_settings.post_process_last_used_prompt_id.clone(),
+                                )
+                                .await
+                                {
+                                    crate::prompt_picker::PromptChoiceResult::Chosen(id) => {
+                                        let mut s = get_settings(&ah);
+                                        s.post_process_last_used_prompt_id = Some(id.clone());
+                                        crate::settings::write_settings(&ah, s);
+                                        prompt_override_id = Some(id);
+                                    }
+                                    crate::prompt_picker::PromptChoiceResult::Cancelled => {
+                                        debug!("Prompt picker cancelled; discarding transcription");
+                                        utils::hide_recording_overlay(&ah);
+                                        change_tray_icon(&ah, TrayIconState::Idle);
+                                        return;
+                                    }
+                                }
+
+                                if rm.was_cancelled_since(cancel_generation) {
+                                    debug!(
+                                        "Transcription operation cancelled during prompt picker"
+                                    );
+                                    utils::hide_recording_overlay(&ah);
+                                    change_tray_icon(&ah, TrayIconState::Idle);
+                                    return;
+                                }
+                            }
+
                             if post_process {
                                 if style == OverlayStyle::Live {
                                     tm.emit_stream_working(StreamWorkKind::Polishing);
@@ -721,9 +783,13 @@ impl ShortcutAction for TranscribeAction {
                                     show_processing_overlay(&ah);
                                 }
                             }
-                            let processed =
-                                process_transcription_output(&ah, &transcription, post_process)
-                                    .await;
+                            let processed = process_transcription_output(
+                                &ah,
+                                &transcription,
+                                post_process,
+                                prompt_override_id,
+                            )
+                            .await;
 
                             if rm.was_cancelled_since(cancel_generation) {
                                 debug!("Transcription operation cancelled before paste");
@@ -871,11 +937,22 @@ pub static ACTION_MAP: Lazy<HashMap<String, Arc<dyn ShortcutAction>>> = Lazy::ne
         "transcribe".to_string(),
         Arc::new(TranscribeAction {
             post_process: false,
+            prompt_picker: false,
         }) as Arc<dyn ShortcutAction>,
     );
     map.insert(
         "transcribe_with_post_process".to_string(),
-        Arc::new(TranscribeAction { post_process: true }) as Arc<dyn ShortcutAction>,
+        Arc::new(TranscribeAction {
+            post_process: true,
+            prompt_picker: false,
+        }) as Arc<dyn ShortcutAction>,
+    );
+    map.insert(
+        "transcribe_with_prompt_picker".to_string(),
+        Arc::new(TranscribeAction {
+            post_process: true,
+            prompt_picker: true,
+        }) as Arc<dyn ShortcutAction>,
     );
     map.insert(
         "cancel".to_string(),
@@ -890,7 +967,7 @@ pub static ACTION_MAP: Lazy<HashMap<String, Arc<dyn ShortcutAction>>> = Lazy::ne
 
 #[cfg(test)]
 mod tests {
-    use super::is_blank_transcription;
+    use super::{is_blank_transcription, resolve_prompt_id};
 
     #[test]
     fn blank_transcription_is_detected() {
@@ -903,5 +980,25 @@ mod tests {
     fn non_blank_transcription_is_kept() {
         assert!(!is_blank_transcription("hello"));
         assert!(!is_blank_transcription("  hello  "));
+    }
+
+    #[test]
+    fn prompt_override_wins_over_selected() {
+        let selected = Some("selected-id".to_string());
+        assert_eq!(
+            resolve_prompt_id(Some("override-id"), &selected),
+            Some("override-id".to_string())
+        );
+    }
+
+    #[test]
+    fn falls_back_to_selected_when_no_override() {
+        let selected = Some("selected-id".to_string());
+        assert_eq!(resolve_prompt_id(None, &selected), selected);
+    }
+
+    #[test]
+    fn none_when_neither_set() {
+        assert_eq!(resolve_prompt_id(None, &None), None);
     }
 }

--- a/src-tauri/src/commands/history.rs
+++ b/src-tauri/src/commands/history.rs
@@ -94,7 +94,8 @@ pub async fn retry_history_entry_transcription(
     }
 
     let processed =
-        process_transcription_output(&app, &transcription, entry.post_process_requested).await;
+        process_transcription_output(&app, &transcription, entry.post_process_requested, None)
+            .await;
     history_manager
         .update_transcription(
             id,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ mod llm_client;
 mod managers;
 mod overlay;
 pub mod portable;
+mod prompt_picker;
 mod settings;
 mod shortcut;
 mod signal_handle;
@@ -308,6 +309,8 @@ fn initialize_core_logic(app_handle: &AppHandle) {
 
     // Create the recording overlay window (hidden by default)
     utils::create_recording_overlay(app_handle);
+    // Create the prompt picker window (hidden by default)
+    prompt_picker::create_prompt_picker_window(app_handle);
 }
 
 #[tauri::command]
@@ -637,11 +640,14 @@ pub fn run(cli_args: CliArgs) {
             commands::history::update_history_limit,
             commands::history::update_recording_retention_period,
             helpers::clamshell::is_laptop,
+            prompt_picker::submit_prompt_choice,
+            prompt_picker::cancel_prompt_choice,
         ])
         .events(collect_events![
             managers::history::HistoryUpdatePayload,
             managers::transcription::StreamTextEvent,
             managers::transcription::StreamPhaseEvent,
+            prompt_picker::PromptPickerShowEvent,
         ]);
 
     #[cfg(debug_assertions)] // <- Only export on non-release builds
@@ -830,6 +836,7 @@ pub fn run(cli_args: CliArgs) {
             WEBVIEW_LOG_STREAMING.store(settings.debug_mode, Ordering::Relaxed);
             let app_handle = app.handle().clone();
             app.manage(TranscriptionCoordinator::new(app_handle.clone()));
+            app.manage(prompt_picker::PendingPromptChoice::default());
 
             initialize_core_logic(&app_handle);
 

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -163,7 +163,7 @@ fn force_overlay_topmost(overlay_window: &tauri::webview::WebviewWindow) {
     });
 }
 
-fn get_monitor_with_cursor(app_handle: &AppHandle) -> Option<tauri::Monitor> {
+pub(crate) fn get_monitor_with_cursor(app_handle: &AppHandle) -> Option<tauri::Monitor> {
     if let Some(mouse_location) = input::get_cursor_position(app_handle) {
         if let Ok(monitors) = app_handle.available_monitors() {
             for monitor in monitors {

--- a/src-tauri/src/prompt_picker.rs
+++ b/src-tauri/src/prompt_picker.rs
@@ -1,0 +1,253 @@
+use crate::overlay::get_monitor_with_cursor;
+use crate::settings::LLMPrompt;
+use log::debug;
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use std::sync::Mutex;
+use tauri::{AppHandle, Manager};
+use tauri_specta::Event;
+use tokio::sync::oneshot;
+
+#[cfg(not(target_os = "macos"))]
+use tauri::WebviewWindowBuilder;
+
+#[cfg(target_os = "macos")]
+use tauri::WebviewUrl;
+
+#[cfg(target_os = "macos")]
+use tauri_nspanel::{
+    tauri_panel, CollectionBehavior, ManagerExt, PanelBuilder, PanelLevel, StyleMask,
+};
+
+const PROMPT_PICKER_WIDTH: f64 = 560.0;
+const PROMPT_PICKER_HEIGHT: f64 = 320.0;
+
+// Unlike the recording overlay's panel (which never wants keyboard focus), this
+// one must — arrow keys / digits / Enter drive the list. A plain focusable
+// NSWindow would work for that, but making a regular window key also activates
+// the whole app, which (once the picker hides again and Handy has no other
+// visible window) makes macOS deliver `applicationShouldHandleReopen:`, and
+// Handy's Reopen handler unconditionally re-shows the main window — stealing
+// the paste target out from under the just-finished transcription. A
+// nonactivating NSPanel with `can_become_key_window: true` gets keyboard focus
+// without that side effect (the same trick Spotlight-style panels use).
+#[cfg(target_os = "macos")]
+tauri_panel! {
+    panel!(PromptPickerPanel {
+        config: {
+            can_become_key_window: true,
+            is_floating_panel: true
+        }
+    })
+}
+
+pub enum PromptChoiceResult {
+    Chosen(String),
+    Cancelled,
+}
+
+#[derive(Default)]
+pub struct PendingPromptChoice(Mutex<Option<oneshot::Sender<PromptChoiceResult>>>);
+
+#[derive(Clone, Debug, Serialize, Deserialize, Type, tauri_specta::Event)]
+pub struct PromptPickerShowEvent {
+    pub prompts: Vec<LLMPrompt>,
+    pub last_used_prompt_id: Option<String>,
+}
+
+/// Creates the prompt picker window and keeps it hidden by default.
+#[cfg(not(target_os = "macos"))]
+pub fn create_prompt_picker_window(app_handle: &AppHandle) {
+    let mut builder = WebviewWindowBuilder::new(
+        app_handle,
+        "prompt_picker",
+        tauri::WebviewUrl::App("src/prompt-picker/index.html".into()),
+    )
+    .title("Select Prompt")
+    .resizable(false)
+    .inner_size(PROMPT_PICKER_WIDTH, PROMPT_PICKER_HEIGHT)
+    .shadow(false)
+    .maximizable(false)
+    .minimizable(false)
+    .closable(false)
+    .decorations(false)
+    .always_on_top(true)
+    .skip_taskbar(true)
+    .transparent(true)
+    .visible(false);
+
+    if let Some(data_dir) = crate::portable::data_dir() {
+        builder = builder.data_directory(data_dir.join("webview"));
+    }
+
+    if let Err(e) = builder.build() {
+        debug!("Failed to create prompt picker window: {}", e);
+    }
+}
+
+/// Creates the prompt picker panel and keeps it hidden by default (macOS).
+/// A nonactivating panel that can still become key window — see the comment
+/// on `PromptPickerPanel` above for why this shape is required here.
+#[cfg(target_os = "macos")]
+pub fn create_prompt_picker_window(app_handle: &AppHandle) {
+    match PanelBuilder::<_, PromptPickerPanel>::new(app_handle, "prompt_picker")
+        .url(WebviewUrl::App("src/prompt-picker/index.html".into()))
+        .title("Select Prompt")
+        .size(tauri::Size::Logical(tauri::LogicalSize {
+            width: PROMPT_PICKER_WIDTH,
+            height: PROMPT_PICKER_HEIGHT,
+        }))
+        .level(PanelLevel::Status)
+        .has_shadow(false)
+        .transparent(true)
+        .no_activate(true)
+        .corner_radius(0.0)
+        .style_mask(StyleMask::empty().borderless().nonactivating_panel())
+        .with_window(|w| w.decorations(false).transparent(true))
+        .collection_behavior(
+            CollectionBehavior::new()
+                .can_join_all_spaces()
+                .full_screen_auxiliary(),
+        )
+        .build()
+    {
+        Ok(panel) => {
+            panel.hide();
+        }
+        Err(e) => {
+            log::error!("Failed to create prompt picker panel: {}", e);
+        }
+    }
+}
+
+fn calculate_centered_position(
+    app_handle: &AppHandle,
+    width: f64,
+    height: f64,
+) -> Option<(f64, f64)> {
+    let monitor = get_monitor_with_cursor(app_handle)?;
+    let scale = monitor.scale_factor();
+    let monitor_x = monitor.position().x as f64 / scale;
+    let monitor_y = monitor.position().y as f64 / scale;
+    let monitor_width = monitor.size().width as f64 / scale;
+    let monitor_height = monitor.size().height as f64 / scale;
+
+    let x = monitor_x + (monitor_width - width) / 2.0;
+    let y = monitor_y + (monitor_height - height) / 2.0;
+    Some((x, y))
+}
+
+fn show_prompt_picker(
+    app_handle: &AppHandle,
+    prompts: Vec<LLMPrompt>,
+    last_used_prompt_id: Option<String>,
+) {
+    if let Some((x, y)) =
+        calculate_centered_position(app_handle, PROMPT_PICKER_WIDTH, PROMPT_PICKER_HEIGHT)
+    {
+        // Repositioning goes through the generic window handle regardless of
+        // platform — `PanelBuilder` registers a real Tauri window under the
+        // hood (see `create_prompt_picker_window`), and `Panel` has no
+        // position setter of its own.
+        if let Some(window) = app_handle.get_webview_window("prompt_picker") {
+            let _ = window.set_position(tauri::Position::Logical(tauri::LogicalPosition { x, y }));
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        // Tauri/tao's generic `WebviewWindow::set_focus()` unconditionally
+        // calls `NSApp.activateIgnoringOtherApps(true)` on macOS, which would
+        // activate the whole app regardless of the panel's nonactivating
+        // style mask — exactly what this window must avoid (see the comment
+        // on `PromptPickerPanel`). The panel's own `show_and_make_key()`
+        // gives it keyboard focus without ever touching `NSApplication`.
+        //
+        // Unlike the generic Tauri window API (which dispatches safely across
+        // threads), `Panel` trait methods are raw AppKit calls and must run on
+        // the main thread — this fires from inside the transcription
+        // pipeline's async task, on a tokio worker thread, so it needs
+        // `run_on_main_thread` or it crashes AppKit with "Must only be used
+        // from the main thread".
+        let app_handle_clone = app_handle.clone();
+        let _ = app_handle.run_on_main_thread(move || {
+            match app_handle_clone.get_webview_panel("prompt_picker") {
+                Ok(panel) => {
+                    panel.show_and_make_key();
+                    let _ = PromptPickerShowEvent {
+                        prompts,
+                        last_used_prompt_id,
+                    }
+                    .emit(&app_handle_clone);
+                }
+                Err(e) => {
+                    debug!("Prompt picker panel not found, skipping picker: {:?}", e);
+                }
+            }
+        });
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let Some(window) = app_handle.get_webview_window("prompt_picker") else {
+            debug!("Prompt picker window not found, skipping picker");
+            return;
+        };
+        let _ = window.show();
+        let _ = window.set_focus();
+        let _ = PromptPickerShowEvent {
+            prompts,
+            last_used_prompt_id,
+        }
+        .emit(app_handle);
+    }
+}
+
+fn hide_prompt_picker(app_handle: &AppHandle) {
+    if let Some(window) = app_handle.get_webview_window("prompt_picker") {
+        let _ = window.hide();
+    }
+}
+
+/// Shows the picker and waits for the user's choice. Resolves to `Cancelled`
+/// if the window is closed/hidden without an explicit choice (e.g. the sender
+/// is dropped without being used, which can't happen in practice since
+/// `cancel_prompt_choice` always sends before hiding, but is the correct
+/// fallback if it ever did).
+pub async fn await_prompt_choice(
+    app_handle: &AppHandle,
+    prompts: Vec<LLMPrompt>,
+    last_used_prompt_id: Option<String>,
+) -> PromptChoiceResult {
+    let (tx, rx) = oneshot::channel();
+    {
+        let state = app_handle.state::<PendingPromptChoice>();
+        *state.0.lock().unwrap() = Some(tx);
+    }
+    show_prompt_picker(app_handle, prompts, last_used_prompt_id);
+    rx.await.unwrap_or(PromptChoiceResult::Cancelled)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn submit_prompt_choice(app: AppHandle, prompt_id: String) -> Result<(), String> {
+    let sender = app.state::<PendingPromptChoice>().0.lock().unwrap().take();
+    hide_prompt_picker(&app);
+    match sender {
+        Some(tx) => {
+            let _ = tx.send(PromptChoiceResult::Chosen(prompt_id));
+            Ok(())
+        }
+        None => Err("No pending prompt choice".to_string()),
+    }
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn cancel_prompt_choice(app: AppHandle) -> Result<(), String> {
+    let sender = app.state::<PendingPromptChoice>().0.lock().unwrap().take();
+    hide_prompt_picker(&app);
+    if let Some(tx) = sender {
+        let _ = tx.send(PromptChoiceResult::Cancelled);
+    }
+    Ok(())
+}

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -403,6 +403,8 @@ pub struct AppSettings {
     #[serde(default)]
     pub post_process_selected_prompt_id: Option<String>,
     #[serde(default)]
+    pub post_process_last_used_prompt_id: Option<String>,
+    #[serde(default)]
     pub mute_while_recording: bool,
     #[serde(default)]
     pub append_trailing_space: bool,
@@ -787,6 +789,24 @@ pub fn get_default_settings() -> AppSettings {
             current_binding: default_post_process_shortcut.to_string(),
         },
     );
+
+    #[cfg(target_os = "macos")]
+    let default_prompt_picker_shortcut = "ctrlleft+fn";
+    #[cfg(not(target_os = "macos"))]
+    let default_prompt_picker_shortcut = "ctrl+alt+p";
+
+    bindings.insert(
+        "transcribe_with_prompt_picker".to_string(),
+        ShortcutBinding {
+            id: "transcribe_with_prompt_picker".to_string(),
+            name: "Transcribe with Prompt Picker".to_string(),
+            description:
+                "Converts your speech into text, then lets you pick which AI post-processing prompt to apply."
+                    .to_string(),
+            default_binding: default_prompt_picker_shortcut.to_string(),
+            current_binding: default_prompt_picker_shortcut.to_string(),
+        },
+    );
     bindings.insert(
         "cancel".to_string(),
         ShortcutBinding {
@@ -837,6 +857,7 @@ pub fn get_default_settings() -> AppSettings {
         post_process_models: default_post_process_models(),
         post_process_prompts: default_post_process_prompts(),
         post_process_selected_prompt_id: None,
+        post_process_last_used_prompt_id: None,
         mute_while_recording: false,
         append_trailing_space: false,
         app_language: default_app_language(),

--- a/src-tauri/src/shortcut/handy_keys.rs
+++ b/src-tauri/src/shortcut/handy_keys.rs
@@ -433,8 +433,10 @@ pub fn init_shortcuts(app: &AppHandle) -> Result<(), String> {
         if id == "cancel" {
             continue;
         }
-        // Skip post-processing shortcut when the feature is disabled
-        if id == "transcribe_with_post_process" && !user_settings.post_process_enabled {
+        // Skip post-processing shortcuts when the feature is disabled
+        if (id == "transcribe_with_post_process" || id == "transcribe_with_prompt_picker")
+            && !user_settings.post_process_enabled
+        {
             continue;
         }
 

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -392,8 +392,10 @@ fn register_all_shortcuts_for_implementation(
             continue;
         }
 
-        // Skip post-processing shortcut when the feature is disabled
-        if id == "transcribe_with_post_process" && !current_settings.post_process_enabled {
+        // Skip post-processing shortcuts when the feature is disabled
+        if (id == "transcribe_with_post_process" || id == "transcribe_with_prompt_picker")
+            && !current_settings.post_process_enabled
+        {
             continue;
         }
 
@@ -873,16 +875,14 @@ pub fn change_post_process_enabled_setting(app: AppHandle, enabled: bool) -> Res
     settings.post_process_enabled = enabled;
     settings::write_settings(&app, settings.clone());
 
-    // Register or unregister the post-processing shortcut
-    if let Some(binding) = settings
-        .bindings
-        .get("transcribe_with_post_process")
-        .cloned()
-    {
-        if enabled {
-            let _ = register_shortcut(&app, binding);
-        } else {
-            let _ = unregister_shortcut(&app, binding);
+    // Register or unregister the post-processing shortcuts
+    for id in ["transcribe_with_post_process", "transcribe_with_prompt_picker"] {
+        if let Some(binding) = settings.bindings.get(id).cloned() {
+            if enabled {
+                let _ = register_shortcut(&app, binding);
+            } else {
+                let _ = unregister_shortcut(&app, binding);
+            }
         }
     }
 

--- a/src-tauri/src/shortcut/tauri_impl.rs
+++ b/src-tauri/src/shortcut/tauri_impl.rs
@@ -23,8 +23,10 @@ pub fn init_shortcuts(app: &AppHandle) {
         if id == "cancel" {
             continue; // Skip cancel shortcut, it will be registered dynamically
         }
-        // Skip post-processing shortcut when the feature is disabled
-        if id == "transcribe_with_post_process" && !user_settings.post_process_enabled {
+        // Skip post-processing shortcuts when the feature is disabled
+        if (id == "transcribe_with_post_process" || id == "transcribe_with_prompt_picker")
+            && !user_settings.post_process_enabled
+        {
             continue;
         }
         let binding = user_settings

--- a/src-tauri/src/transcription_coordinator.rs
+++ b/src-tauri/src/transcription_coordinator.rs
@@ -38,7 +38,9 @@ pub struct TranscriptionCoordinator {
 }
 
 pub fn is_transcribe_binding(id: &str) -> bool {
-    id == "transcribe" || id == "transcribe_with_post_process"
+    id == "transcribe"
+        || id == "transcribe_with_post_process"
+        || id == "transcribe_with_prompt_picker"
 }
 
 impl TranscriptionCoordinator {

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -842,6 +842,22 @@ async isLaptop() : Promise<Result<boolean, string>> {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+async submitPromptChoice(promptId: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("submit_prompt_choice", { promptId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async cancelPromptChoice() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("cancel_prompt_choice") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 
@@ -850,10 +866,12 @@ async isLaptop() : Promise<Result<boolean, string>> {
 
 export const events = __makeEvents__<{
 historyUpdatePayload: HistoryUpdatePayload,
+promptPickerShowEvent: PromptPickerShowEvent,
 streamPhaseEvent: StreamPhaseEvent,
 streamTextEvent: StreamTextEvent
 }>({
 historyUpdatePayload: "history-update-payload",
+promptPickerShowEvent: "prompt-picker-show-event",
 streamPhaseEvent: "stream-phase-event",
 streamTextEvent: "stream-text-event"
 })
@@ -877,7 +895,7 @@ settings_schema_version?: number; bindings: Partial<{ [key in string]: ShortcutB
  * upgrading from before this key existed are blanked by the migration so they
  * see the current release's notes — see `apply_settings_migrations`.
  */
-whats_new_last_seen_version?: string; selected_model?: string; onboarding_completed?: boolean; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: SecretMap; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; experimental_enabled?: boolean; lazy_stream_close?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool; external_script_path: string | null; custom_filler_words?: string[] | null; transcribe_accelerator?: TranscribeAcceleratorSetting; ort_accelerator?: OrtAcceleratorSetting; transcribe_gpu_device?: number; extra_recording_buffer_ms?: number; vad_enabled?: boolean; 
+whats_new_last_seen_version?: string; selected_model?: string; onboarding_completed?: boolean; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: SecretMap; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; post_process_last_used_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; experimental_enabled?: boolean; lazy_stream_close?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool; external_script_path: string | null; custom_filler_words?: string[] | null; transcribe_accelerator?: TranscribeAcceleratorSetting; ort_accelerator?: OrtAcceleratorSetting; transcribe_gpu_device?: number; extra_recording_buffer_ms?: number; vad_enabled?: boolean; 
 /**
  * Which recording overlay to show: None / Minimal / Live. Streaming mode is
  * not gated on this — that follows model capability. Migrated from the old
@@ -951,6 +969,7 @@ export type PaginatedHistory = { entries: HistoryEntry[]; has_more: boolean }
 export type PasteMethod = "ctrl_v" | "direct" | "none" | "shift_insert" | "ctrl_shift_v" | "external_script"
 export type PermissionAccess = "allowed" | "denied" | "unknown"
 export type PostProcessProvider = { id: string; label: string; base_url: string; allow_base_url_edit?: boolean; models_endpoint?: string | null; supports_structured_output?: boolean }
+export type PromptPickerShowEvent = { prompts: LLMPrompt[]; last_used_prompt_id: string | null }
 export type RecordingRetentionPeriod = "never" | "preserve_limit" | "days_3" | "weeks_2" | "months_3"
 export type SecretMap = Partial<{ [key in string]: string }>
 export type ShortcutBinding = { id: string; name: string; description: string; default_binding: string; current_binding: string }

--- a/src/components/settings/post-processing/PostProcessingSettings.tsx
+++ b/src/components/settings/post-processing/PostProcessingSettings.tsx
@@ -435,6 +435,11 @@ export const PostProcessingSettings: React.FC = () => {
           descriptionMode="tooltip"
           grouped={true}
         />
+        <ShortcutInput
+          shortcutId="transcribe_with_prompt_picker"
+          descriptionMode="tooltip"
+          grouped={true}
+        />
       </SettingsGroup>
 
       <SettingsGroup title={t("settings.postProcessing.api.title")}>

--- a/src/prompt-picker/PromptPicker.css
+++ b/src/prompt-picker/PromptPicker.css
@@ -1,0 +1,83 @@
+@import "../styles/theme.css";
+
+html,
+body {
+  background: transparent;
+}
+
+.pp-container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  background: color-mix(in srgb, var(--color-background) 98%, transparent);
+  border: 1px solid
+    color-mix(in srgb, var(--color-mid-gray) 22%, transparent);
+  border-radius: 12px;
+  overflow: hidden;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  outline: none;
+}
+
+.pp-body {
+  display: flex;
+  flex: 1 1 auto;
+  gap: 8px;
+  padding: 8px;
+  min-height: 0;
+}
+
+.pp-list {
+  flex: 0 0 42%;
+  overflow-y: auto;
+  padding: 4px;
+  border: 1px solid
+    color-mix(in srgb, var(--color-mid-gray) 18%, transparent);
+  border-radius: 8px;
+}
+
+.pp-item {
+  padding: 6px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--color-text);
+  user-select: none;
+  font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pp-item:hover {
+  background: color-mix(in srgb, var(--color-logo-primary) 10%, transparent);
+}
+
+.pp-item.selected {
+  background: color-mix(in srgb, var(--color-logo-primary) 20%, transparent);
+  font-weight: 600;
+}
+
+.pp-preview {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 10px;
+  border: 1px solid
+    color-mix(in srgb, var(--color-mid-gray) 18%, transparent);
+  border-radius: 8px;
+  color: color-mix(in srgb, var(--color-text) 75%, transparent);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.pp-footer {
+  display: flex;
+  justify-content: space-between;
+  padding: 6px 12px;
+  border-top: 1px solid
+    color-mix(in srgb, var(--color-mid-gray) 18%, transparent);
+  color: color-mix(in srgb, var(--color-text) 55%, transparent);
+  font-size: 11px;
+}

--- a/src/prompt-picker/PromptPicker.tsx
+++ b/src/prompt-picker/PromptPicker.tsx
@@ -1,0 +1,130 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import "./PromptPicker.css";
+import { commands, events } from "@/bindings";
+import type { LLMPrompt } from "@/bindings";
+
+const PromptPicker: React.FC = () => {
+  const [prompts, setPrompts] = useState<LLMPrompt[]>([]);
+  const [lastUsedPromptId, setLastUsedPromptId] = useState<string | null>(
+    null,
+  );
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+  // The window reopens at the same screen position each time, so a mouse
+  // left resting over item 3 fires a stale `mouseenter` on reopen and
+  // silently overrides the keyboard-driven reset to the top item. Hover
+  // selection is only armed once the mouse actually moves after showing.
+  const mouseArmedRef = useRef(false);
+
+  // Most recently used prompt floats to the top; everything else keeps its order.
+  const displayList = useMemo(() => {
+    const idx = prompts.findIndex((p) => p.id === lastUsedPromptId);
+    if (idx <= 0) return prompts;
+    const reordered = [...prompts];
+    const [lastUsed] = reordered.splice(idx, 1);
+    reordered.unshift(lastUsed);
+    return reordered;
+  }, [prompts, lastUsedPromptId]);
+
+  useEffect(() => {
+    const unlistenPromise = events.promptPickerShowEvent.listen((event) => {
+      setPrompts(event.payload.prompts);
+      setLastUsedPromptId(event.payload.last_used_prompt_id ?? null);
+      setSelectedIndex(0);
+      mouseArmedRef.current = false;
+    });
+
+    const unlistenFocusPromise = getCurrentWindow().onFocusChanged(
+      ({ payload: focused }) => {
+        if (!focused) commands.cancelPromptChoice();
+      },
+    );
+
+    const onMouseMove = () => {
+      mouseArmedRef.current = true;
+    };
+    window.addEventListener("mousemove", onMouseMove);
+
+    return () => {
+      unlistenPromise.then((unlisten) => unlisten());
+      unlistenFocusPromise.then((unlisten) => unlisten());
+      window.removeEventListener("mousemove", onMouseMove);
+    };
+  }, []);
+
+  useEffect(() => {
+    listRef.current
+      ?.querySelector(`[data-index="${selectedIndex}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  const confirm = (index: number) => {
+    const prompt = displayList[index];
+    if (prompt) commands.submitPromptChoice(prompt.id);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      commands.cancelPromptChoice();
+      return;
+    }
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setSelectedIndex((i) => (i + 1) % displayList.length);
+      return;
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setSelectedIndex(
+        (i) => (i - 1 + displayList.length) % displayList.length,
+      );
+      return;
+    }
+    if (e.key === "Enter") {
+      e.preventDefault();
+      confirm(selectedIndex);
+      return;
+    }
+    const digit = Number(e.key);
+    if (Number.isInteger(digit) && digit >= 1 && digit <= 9) {
+      const index = digit - 1;
+      if (index < displayList.length) {
+        e.preventDefault();
+        confirm(index);
+      }
+    }
+  };
+
+  const selectedPrompt = displayList[selectedIndex];
+
+  return (
+    <div className="pp-container" tabIndex={0} autoFocus onKeyDown={handleKeyDown}>
+      <div className="pp-body">
+        <div className="pp-list" ref={listRef}>
+          {displayList.map((prompt, index) => (
+            <div
+              key={`${prompt.id}-${index}`}
+              data-index={index}
+              className={`pp-item ${index === selectedIndex ? "selected" : ""}`}
+              onMouseEnter={() => {
+                if (mouseArmedRef.current) setSelectedIndex(index);
+              }}
+              onClick={() => confirm(index)}
+            >
+              {prompt.name}
+            </div>
+          ))}
+        </div>
+        <div className="pp-preview">{selectedPrompt?.prompt}</div>
+      </div>
+      <div className="pp-footer">
+        <span>Prompt library</span>
+        <span>Paste ⏎</span>
+      </div>
+    </div>
+  );
+};
+
+export default PromptPicker;

--- a/src/prompt-picker/index.html
+++ b/src/prompt-picker/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8" />
+    <title>Select Prompt</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: transparent;
+        overflow: hidden;
+        width: 100%;
+        height: 100%;
+      }
+      #root {
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/prompt-picker/main.tsx"></script>
+  </body>
+</html>

--- a/src/prompt-picker/main.tsx
+++ b/src/prompt-picker/main.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import PromptPicker from "./PromptPicker";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <PromptPicker />
+  </React.StrictMode>,
+);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig(async () => ({
       input: {
         main: resolve(__dirname, "index.html"),
         overlay: resolve(__dirname, "src/overlay/index.html"),
+        prompt_picker: resolve(__dirname, "src/prompt-picker/index.html"),
       },
     },
   },


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

In Handy, post-processing is tied to a single prompt selected in settings — switching prompts means going into settings and changing it manually every time. In practice, I work across different contexts (code editor, social media, notes), and I need a different processing style for each one, with the choice happening at the moment of transcription rather than ahead of time. So I added the ability to pick a prompt right during recording, without interrupting the flow.

## Related Issues/Discussions

Fixes #
Discussion:

## Community Feedback

No discussion opened yet. Happy to gather feedback if maintainers want to see community interest before reviewing further.

## Testing

Manually tested on macOS (Apple Silicon):

- Recorded with the new hotkey with 2+ saved prompts — picker window appears centered on the active display, list on the left and full prompt text preview on the right.
- Arrow keys, digit keys (1-9), Enter, mouse click, and mouse hover all select/confirm correctly; most-recently-used prompt moves to the top of the list on repeat use.
- Escape, clicking outside the window, and losing window focus all cancel cleanly — no paste, no history entry written.
- Verified the picker window never steals app focus/activation from the target app (this needed a non-activating NSPanel on macOS; a regular focusable window would incorrectly reactivate Handy after the picker closes).
- `cargo check`, `cargo clippy`, `bun run build` all clean.
- Not yet tested on Windows/Linux (default binding there is `Ctrl+Alt+P`, no Fn-key dependency).

## Screenshots/Videos (if applicable)

_Will add a screenshot/recording of the picker in a follow-up comment._

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Implementation (Rust backend + React frontend) was written with Claude Code, iterating with manual testing on real hardware; UI design direction and product decisions (interaction model, cancel behavior, list ordering) were mine.
