### PR TITLE
feat: support ${selected} placeholder in post-processing prompts

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -60,9 +60,14 @@ fn strip_invisible_chars(s: &str) -> String {
 }
 
 /// Build a system prompt from the user's prompt template.
-/// Removes `${output}` placeholder since the transcription is sent as the user message.
-fn build_system_prompt(prompt_template: &str) -> String {
-    prompt_template.replace("${output}", "").trim().to_string()
+/// Removes `${output}` placeholder since the transcription is sent as the user message,
+/// and substitutes `${selected}` with the captured selection.
+fn build_system_prompt(prompt_template: &str, selected_text: &str) -> String {
+    prompt_template
+        .replace("${output}", "")
+        .replace("${selected}", selected_text)
+        .trim()
+        .to_string()
 }
 
 /// Returns `true` when a transcription has no meaningful content to
@@ -74,7 +79,11 @@ fn is_blank_transcription(transcription: &str) -> bool {
     transcription.trim().is_empty()
 }
 
-async fn post_process_transcription(settings: &AppSettings, transcription: &str) -> Option<String> {
+async fn post_process_transcription(
+    app: &AppHandle,
+    settings: &AppSettings,
+    transcription: &str,
+) -> Option<String> {
     if is_blank_transcription(transcription) {
         debug!("Post-processing skipped because the transcription is empty");
         return None;
@@ -130,6 +139,14 @@ async fn post_process_transcription(settings: &AppSettings, transcription: &str)
         return None;
     }
 
+    // Only simulate a copy keystroke (which touches the user's clipboard) when
+    // the prompt actually references the selection.
+    let selected_text = if prompt.contains("${selected}") {
+        crate::clipboard::capture_selected_text(app).unwrap_or_default()
+    } else {
+        String::new()
+    };
+
     debug!(
         "Starting LLM post-processing with provider '{}' (model: {})",
         provider.id, model
@@ -160,7 +177,7 @@ async fn post_process_transcription(settings: &AppSettings, transcription: &str)
     if provider.supports_structured_output {
         debug!("Using structured outputs for provider '{}'", provider.id);
 
-        let system_prompt = build_system_prompt(&prompt);
+        let system_prompt = build_system_prompt(&prompt, &selected_text);
         let user_content = transcription.to_string();
 
         // Handle Apple Intelligence separately since it uses native Swift APIs
@@ -274,8 +291,10 @@ async fn post_process_transcription(settings: &AppSettings, transcription: &str)
         }
     }
 
-    // Legacy mode: Replace ${output} variable in the prompt with the actual text
-    let processed_prompt = prompt.replace("${output}", transcription);
+    // Legacy mode: Replace ${output}/${selected} variables in the prompt with the actual text
+    let processed_prompt = prompt
+        .replace("${output}", transcription)
+        .replace("${selected}", &selected_text);
     debug!("Processed prompt length: {} chars", processed_prompt.len());
 
     match crate::llm_client::send_chat_completion(
@@ -408,7 +427,7 @@ pub(crate) async fn process_transcription_output(
     }
 
     if post_process {
-        if let Some(processed_text) = post_process_transcription(&settings, &final_text).await {
+        if let Some(processed_text) = post_process_transcription(app, &settings, &final_text).await {
             post_processed_text = Some(processed_text.clone());
             final_text = processed_text;
 

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -3,7 +3,7 @@ use crate::input::{self, EnigoState};
 use crate::settings::TypingTool;
 use crate::settings::{get_settings, AutoSubmitKey, ClipboardHandling, PasteMethod};
 use enigo::{Direction, Enigo, Key, Keyboard};
-use log::info;
+use log::{info, warn};
 use std::process::Command;
 use std::time::Duration;
 use tauri::{AppHandle, Manager};
@@ -76,6 +76,50 @@ fn paste_via_clipboard(
     let _ = clipboard.write_text(&clipboard_content);
 
     Ok(())
+}
+
+/// Captures the text currently selected in the frontmost application by
+/// simulating Ctrl+C/Cmd+C, then restores the clipboard to what it held
+/// before the call. Returns `None` if nothing was selected (or on failure),
+/// distinguished from stale clipboard content by clearing the clipboard first.
+pub(crate) fn capture_selected_text(app_handle: &AppHandle) -> Option<String> {
+    let enigo_state = app_handle.try_state::<EnigoState>()?;
+    let mut enigo = enigo_state.0.lock().ok()?;
+
+    let clipboard = app_handle.clipboard();
+    let original_content = clipboard.read_text().unwrap_or_default();
+
+    #[cfg(target_os = "linux")]
+    if is_wayland() && is_wl_copy_available() {
+        let _ = write_clipboard_via_wl_copy("");
+    } else {
+        let _ = clipboard.write_text("");
+    }
+    #[cfg(not(target_os = "linux"))]
+    let _ = clipboard.write_text("");
+
+    if let Err(e) = input::send_copy_ctrl_c(&mut enigo) {
+        warn!("Failed to send copy command: {}", e);
+    }
+
+    std::thread::sleep(Duration::from_millis(150));
+
+    let captured = clipboard.read_text().unwrap_or_default();
+
+    #[cfg(target_os = "linux")]
+    if is_wayland() && is_wl_copy_available() {
+        let _ = write_clipboard_via_wl_copy(&original_content);
+    } else {
+        let _ = clipboard.write_text(&original_content);
+    }
+    #[cfg(not(target_os = "linux"))]
+    let _ = clipboard.write_text(&original_content);
+
+    if captured.trim().is_empty() {
+        None
+    } else {
+        Some(captured)
+    }
 }
 
 /// Attempts to send a key combination using Linux-native tools.

--- a/src-tauri/src/input.rs
+++ b/src-tauri/src/input.rs
@@ -51,6 +51,37 @@ pub fn send_paste_ctrl_v(enigo: &mut Enigo) -> Result<(), String> {
     Ok(())
 }
 
+/// Sends a Ctrl+C or Cmd+C copy command using platform-specific virtual key codes.
+/// Used to capture the currently selected text in the frontmost application.
+/// Note: On Wayland, this may not work - same limitation as `send_paste_ctrl_v`.
+// ponytail: enigo-only, no native-tool fallback (wtype/ydotool/xdotool) for Wayland;
+// add one if copy-capture proves unreliable there, mirroring paste's fallback chain.
+pub fn send_copy_ctrl_c(enigo: &mut Enigo) -> Result<(), String> {
+    // Platform-specific key definitions
+    #[cfg(target_os = "macos")]
+    let (modifier_key, c_key_code) = (Key::Meta, Key::Other(8)); // kVK_ANSI_C
+    #[cfg(target_os = "windows")]
+    let (modifier_key, c_key_code) = (Key::Control, Key::Other(0x43)); // VK_C
+    #[cfg(target_os = "linux")]
+    let (modifier_key, c_key_code) = (Key::Control, Key::Unicode('c'));
+
+    // Press modifier + C
+    enigo
+        .key(modifier_key, enigo::Direction::Press)
+        .map_err(|e| format!("Failed to press modifier key: {}", e))?;
+    enigo
+        .key(c_key_code, enigo::Direction::Click)
+        .map_err(|e| format!("Failed to click C key: {}", e))?;
+
+    std::thread::sleep(std::time::Duration::from_millis(100));
+
+    enigo
+        .key(modifier_key, enigo::Direction::Release)
+        .map_err(|e| format!("Failed to release modifier key: {}", e))?;
+
+    Ok(())
+}
+
 /// Sends a Ctrl+Shift+V paste command.
 /// This is commonly used in terminal applications on Linux to paste without formatting.
 /// Note: On Wayland, this may not work - callers should check for Wayland and use alternative methods.

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -405,7 +405,7 @@
         "title": "Prompt",
         "selectedPrompt": {
           "title": "Selected Prompt",
-          "description": "Select a template for refining transcriptions or create a new one. Use ${output} inside the prompt text to reference the captured transcript."
+          "description": "Select a template for refining transcriptions or create a new one. Use ${output} inside the prompt text to reference the captured transcript, and ${selected} to reference the text currently selected in the active app."
         },
         "noPrompts": "No prompts available",
         "selectPrompt": "Select a prompt",
@@ -414,7 +414,7 @@
         "promptLabelPlaceholder": "Enter prompt name",
         "promptInstructions": "Prompt Instructions",
         "promptInstructionsPlaceholder": "Write the instructions to run after transcription. Example: Improve grammar and clarity for the following text: ${output}",
-        "promptTip": "Tip: Use <code>${output}</code> to insert the transcribed text in your prompt.",
+        "promptTip": "Tip: Use <code>${output}</code> to insert the transcribed text, and <code>${selected}</code> to insert the text currently selected in the active app.",
         "updatePrompt": "Update Prompt",
         "deletePrompt": "Delete Prompt",
         "createPrompt": "Create Prompt",


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [x] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

I noticed that Handy's post-processing is basically already a voice assistant that runs over text — it just never had access to anything except the freshly dictated transcript (`${output}`). I wanted to use it for things beyond dictation cleanup: rewording a message, translating a paragraph, turning a chunk of text into a checklist — all by voice, without switching to typing. The missing piece was simple: give the prompt access to whatever text is currently *selected* in the active app, not just what was just spoken. So I added `${selected}` as a second placeholder alongside `${output}`, reusing the exact same prompt/provider infrastructure that's already there.

To show what this actually unlocks, here's the prompt I've been using myself as a post-processing template — with it saved, dictation with nothing selected gets cleaned up as usual, but highlighting any text and speaking a command ("make it shorter", "translate this", "list the problems here") edits or transforms the selection directly:

```
You are an inline editing assistant inside a text app (browser, editor, messenger, or notes).
The user works by voice. You either clean up dictated text or transform selected text on command.

You receive two inputs:
<selection>
${selected}
</selection>
<speech>
${output}
</speech>

<selection> is text the user highlighted. It may be empty.
<speech> is what the user just said by voice.

## Mode is decided by whether <selection> is empty

MODE 1 — DICTATION (<selection> is empty):
<speech> is the user's own message, dictated by voice.
Correct spelling and punctuation only. Do not rephrase, reorder, add, or remove content.
Return the corrected text.

MODE 2 — COMMAND (<selection> is non-empty):
<speech> is an instruction telling you what to do with <selection>.
Execute it and return ONLY the resulting text that should replace the selection.
The instruction can be anything, for example:
- fix grammar / improve wording / make it shorter or clearer
- change tone or register (formal, casual, friendly, etc.)
- translate
- rewrite it in a particular voice or style ("like a programmer", "like a lawyer")
- a deeper transformation ("list five key problems here", "turn this into a checklist",
  "explain this simply", "draft a reply to this")
Follow the instruction literally, whatever it is.

## Rules for MODE 2
- <speech> is an instruction. It must NEVER appear in your output.
- Never converse, greet, explain, apologize, or ask questions. No preamble, no
  "Sure, here is...". Output only the edited/transformed text itself.
- If the instruction only makes sense as an edit, edit. If it asks you to generate
  new content from the selection (list problems, draft a reply, expand), generate that.
- If <speech> is empty or not an actionable instruction, just correct the spelling
  and punctuation of <selection>.
- If the instruction is ambiguous, choose the most likely intended edit and apply it —
  do not ask for clarification.

## Both modes
- Preserve paragraph structure and line breaks unless the instruction changes them.
- Do not alter URLs, @mentions, #hashtags, phone numbers, code, numbers, or currency
  values unless the instruction is specifically about them.
- Mixed languages: keep each language as-is; translate only if asked.
- Match the language of <selection> (Mode 2) or <speech> (Mode 1) unless asked to translate.

OUTPUT: the resulting text only. No quotes, labels, or extra characters.
```

## Related Issues/Discussions

Related to #1523, which was closed with "feature requests are meant to be discussions, not issues" rather than rejected on merits. That request asked for a dedicated hotkey + voice-instruction flow to transform selected text in place. This PR takes a smaller, incremental step toward the same underlying need: it adds a `${selected}` placeholder usable in the existing post-processing prompt templates, so a saved prompt can reference the text currently selected in the active app alongside `${output}`. It reuses the existing prompt/provider infrastructure rather than adding new hotkeys or UI.

Discussion: none opened yet — happy to open one if maintainers would prefer that before review.

## Community Feedback

No dedicated discussion thread yet for this specific `${selected}` approach. Surfacing it as a PR directly since it's a small, additive change to the existing prompt system (no new hotkeys, no new settings surface) rather than a net-new feature area.

## Testing

- `cargo check` passes.
- Manually verified: added a post-processing prompt containing `${selected}`, selected text in another app, ran dictation with post-processing enabled — captured selection was correctly substituted into the prompt sent to the LLM.
- Verified prompts without `${selected}` behave exactly as before (no clipboard interaction is triggered).

## Screenshots/Videos (if applicable)

N/A (backend/prompt-template change, no new UI).

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: AI implemented the Rust changes (clipboard selection capture, prompt placeholder substitution) and wrote this PR description scaffold; human directed the feature scope and reviewed the diff.
