### PR TITLE
Use configurable transcribe.cpp output budget

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7195,9 +7195,8 @@ dependencies = [
 
 [[package]]
 name = "transcribe-cpp"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c3c4d6136eeccf56cfe8a6669e2d63770d1ef051c7cafd2cb9226218c66cded"
+version = "0.2.0"
+source = "git+https://github.com/vladkalinichencko/transcribe.cpp?branch=expose-max-new-tokens#b14d32e9520283a97d10f7c626697d045c2b0b61"
 dependencies = [
  "log",
  "thiserror 2.0.18",
@@ -7206,9 +7205,8 @@ dependencies = [
 
 [[package]]
 name = "transcribe-cpp-sys"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278fd6a6da4d9d8d5f2716bd6761a76ea55c129fda6ba57856b80249a8570ed4"
+version = "0.2.0"
+source = "git+https://github.com/vladkalinichencko/transcribe.cpp?branch=expose-max-new-tokens#b14d32e9520283a97d10f7c626697d045c2b0b61"
 dependencies = [
  "cmake",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -73,7 +73,7 @@ sha2 = "0.10"
 # transcribe-rs is now ONNX-only (Parakeet, Moonshine, SenseVoice, GigaAM,
 # Canary, Cohere). Per-platform backend features are added in the target tables.
 transcribe-rs = { version = "0.3.8", features = ["onnx"] }
-transcribe-cpp = { version = "0.1.3", default-features = false }
+transcribe-cpp = { version = "0.2.0", default-features = false }
 handy-keys = "0.3.3"
 ferrous-opencc = "0.2.3"
 clap = { version = "4", features = ["derive"] }
@@ -132,17 +132,17 @@ winreg = "0.55"
 # signtool verify entirely. CI pins -DGGML_NATIVE=OFF (see build.yml) so the
 # static build targets a portable ARM baseline, not the build runner's CPU.
 [target.'cfg(all(windows, target_arch = "x86_64"))'.dependencies]
-transcribe-cpp = { version = "0.1.3", default-features = false, features = [
+transcribe-cpp = { version = "0.2.0", default-features = false, features = [
   "dynamic-backends",
   "vulkan",
 ] }
 
 [target.'cfg(all(windows, target_arch = "aarch64"))'.dependencies]
-transcribe-cpp = { version = "0.1.3", default-features = false }
+transcribe-cpp = { version = "0.2.0", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2.1" }
-transcribe-cpp = { version = "0.1.3", default-features = false, features = ["metal"] }
+transcribe-cpp = { version = "0.2.0", default-features = false, features = ["metal"] }
 # Used by the receipt-sequenced ("reliable") paste path for lazy NSPasteboard
 # promises. Versions track what Tauri already pulls in.
 objc2 = "0.6"
@@ -153,7 +153,7 @@ objc2-service-management = "0.3.2"
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk-layer-shell = { version = "0.8", features = ["v0_6"] }
 gtk = "0.18"
-transcribe-cpp = { version = "0.1.3", default-features = false, features = [
+transcribe-cpp = { version = "0.2.0", default-features = false, features = [
   "dynamic-backends",
   "vulkan",
 ] }
@@ -175,6 +175,8 @@ transcribe-cpp = { version = "0.1.3", default-features = false, features = [
 # that, but Nix's importCargoLock vendors both to the same `tao-macros-0.1.3`
 # dir and fails with a symlink collision. Unifying the source removes the dup.
 [patch.crates-io]
+transcribe-cpp = { git = "https://github.com/vladkalinichencko/transcribe.cpp", branch = "expose-max-new-tokens" }
+transcribe-cpp-sys = { git = "https://github.com/vladkalinichencko/transcribe.cpp", branch = "expose-max-new-tokens" }
 tao = { git = "https://github.com/cjpais/tao", rev = "c3bee28c1d446d95f08c95c3b6f8d4bde052b876" }
 tao-macros = { git = "https://github.com/cjpais/tao", rev = "c3bee28c1d446d95f08c95c3b6f8d4bde052b876" }
 

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -17,8 +17,8 @@ use std::time::{Duration, Instant, SystemTime};
 use tauri::{AppHandle, Emitter, Manager};
 use tauri_specta::Event;
 use transcribe_cpp::{
-    Backend, Feature, Model, ModelOptions, RunExtension, RunOptions, Session, StreamOptions, Task,
-    WhisperRunOptions,
+    Backend, Error as TranscribeCppError, Feature, Model, ModelOptions, RunExtension, RunOptions,
+    Session, StreamOptions, Task, WhisperRunOptions,
 };
 use transcribe_rs::{
     onnx::{
@@ -35,6 +35,7 @@ use transcribe_rs::{
 
 const STREAM_PERF_LOG_INTERVAL: Duration = Duration::from_secs(5);
 const STREAM_FINALIZE_REPLY_TIMEOUT: Duration = Duration::from_secs(30);
+const TRANSCRIBE_CPP_MAX_NEW_TOKENS: i32 = 4096;
 
 fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
     if let Some(message) = payload.downcast_ref::<&str>() {
@@ -1256,6 +1257,7 @@ impl TranscriptionManager {
                             task: run_plan.task,
                             language: run_plan.language,
                             target_language: run_plan.target_language,
+                            max_new_tokens: TRANSCRIBE_CPP_MAX_NEW_TOKENS,
                             family,
                             ..Default::default()
                         };
@@ -1267,12 +1269,25 @@ impl TranscriptionManager {
                             run_options.family.is_some()
                         );
 
-                        session
-                            .run(&audio, &run_options)
-                            .map(|t| t.text)
-                            .map_err(|e| {
-                                anyhow::anyhow!("transcribe-cpp transcription failed: {}", e)
-                            })
+                        match session.run(&audio, &run_options) {
+                            Ok(transcript) => Ok(transcript.text),
+                            Err(error) => {
+                                if matches!(error, TranscribeCppError::OutputTruncated { .. }) {
+                                    if let Some(partial) = error.partial() {
+                                        if !partial.text.trim().is_empty() {
+                                            warn!(
+                                                "transcribe-cpp output truncated; using partial transcript"
+                                            );
+                                            return Ok(partial.text.clone());
+                                        }
+                                    }
+                                }
+                                Err(anyhow::anyhow!(
+                                    "transcribe-cpp transcription failed: {}",
+                                    error
+                                ))
+                            }
+                        }
                     }
                     LoadedEngine::Parakeet(parakeet_engine) => {
                         let params = ParakeetParams {

--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -347,7 +347,10 @@ const HistoryEntryComponent: React.FC<HistoryEntryProps> = ({
       await retryTranscription(entry.id);
     } catch (error) {
       console.error("Failed to re-transcribe:", error);
-      toast.error(t("settings.history.retranscribeError"));
+      toast.error(t("settings.history.retranscribeError"), {
+        description:
+          error instanceof Error ? error.message : String(error),
+      });
     } finally {
       setRetrying(false);
     }


### PR DESCRIPTION
Depends on handy-computer/transcribe.cpp#74. Until that is merged and released, the Cargo patch points to the PR branch so this integration can be reviewed and tested against the exact implementation.

This keeps the Handy-side change small:
- request a 4096-token output budget for transcribe.cpp runs
- keep non-empty partial text when transcribe.cpp reports `OUTPUT_TRUNCATED`
- show the backend error message when history re-transcription fails
- update the integration to the current transcribe.cpp 0.2.0 API

Validated with:
- `cargo fmt --check`
- `cargo check`
- 151 Rust tests
- frontend production build
- full Rust build
- headless transcription through Handy with an installed Whisper Medium model on Metal

After #74 is released, the temporary Cargo patch entries can be replaced by the released crate version.
