### PR TITLE
fix: tray icon invisible on Windows with dark taskbar + light apps (#1423)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -278,6 +278,7 @@ fn initialize_core_logic(app_handle: &AppHandle) {
         .build(app_handle)
         .unwrap();
     app_handle.manage(tray);
+    app_handle.manage(tray::CurrentTrayState::default());
 
     // Initialize tray menu with idle state
     utils::update_tray_menu(app_handle, &utils::TrayIconState::Idle, None);
@@ -895,8 +896,8 @@ pub fn run(cli_args: CliArgs) {
             }
             tauri::WindowEvent::ThemeChanged(theme) => {
                 log::info!("Theme changed to: {:?}", theme);
-                // Update tray icon to match new theme, maintaining idle state
-                utils::change_tray_icon(window.app_handle(), utils::TrayIconState::Idle);
+                // Re-apply the current tray state with the new theme's icon set
+                utils::refresh_tray_icon(window.app_handle());
             }
             _ => {}
         })

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -31,6 +31,16 @@ pub fn get_current_theme(app: &AppHandle) -> AppTheme {
         // On Linux, always use the colored theme
         AppTheme::Colored
     } else {
+        // On Windows the tray icon sits on the taskbar, which follows the
+        // *system* theme (SystemUsesLightTheme), not the app theme. With the
+        // "Custom" personalization mode the two can differ (e.g. dark taskbar
+        // + light apps), and the window theme would pick an icon that is
+        // invisible against the taskbar.
+        #[cfg(target_os = "windows")]
+        if let Some(theme) = windows_taskbar_theme() {
+            return theme;
+        }
+
         // On other platforms, map system theme to our app theme
         if let Some(main_window) = app.get_webview_window("main") {
             match main_window.theme().unwrap_or(Theme::Dark) {
@@ -42,6 +52,27 @@ pub fn get_current_theme(app: &AppHandle) -> AppTheme {
             AppTheme::Dark
         }
     }
+}
+
+/// Reads the Windows taskbar theme from the registry.
+///
+/// Returns None if the value is missing (older Windows 10 builds default to a
+/// dark taskbar there, but falling back to the window theme is safer than
+/// guessing).
+#[cfg(target_os = "windows")]
+fn windows_taskbar_theme() -> Option<AppTheme> {
+    use winreg::enums::HKEY_CURRENT_USER;
+    use winreg::RegKey;
+
+    let personalize = RegKey::predef(HKEY_CURRENT_USER)
+        .open_subkey("Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize")
+        .ok()?;
+    let system_uses_light: u32 = personalize.get_value("SystemUsesLightTheme").ok()?;
+    Some(if system_uses_light == 1 {
+        AppTheme::Light
+    } else {
+        AppTheme::Dark
+    })
 }
 
 /// Gets the appropriate icon path for the given theme and state
@@ -83,8 +114,9 @@ pub fn change_tray_icon(app: &AppHandle, icon: TrayIconState) {
     let menu_started = std::time::Instant::now();
     update_tray_menu(app, &icon, None);
     debug!(
-        "tray icon change ({:?}): set_icon={:?} menu={:?}",
+        "tray icon change ({:?}): icon={} set_icon={:?} menu={:?}",
         icon,
+        icon_path,
         icon_elapsed,
         menu_started.elapsed()
     );

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -4,19 +4,25 @@ use crate::managers::transcription::TranscriptionManager;
 use crate::settings;
 use crate::tray_i18n::get_tray_translations;
 use log::{debug, error, info, warn};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tauri::image::Image;
 use tauri::menu::{CheckMenuItem, Menu, MenuItem, PredefinedMenuItem, Submenu};
 use tauri::tray::TrayIcon;
 use tauri::{AppHandle, Manager, Theme};
 use tauri_plugin_clipboard_manager::ClipboardExt;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub enum TrayIconState {
+    #[default]
     Idle,
     Recording,
     Transcribing,
 }
+
+/// Last state passed to `change_tray_icon`, so theme-only refreshes can
+/// re-apply it instead of guessing (e.g. resetting to Idle mid-recording).
+#[derive(Default)]
+pub struct CurrentTrayState(Mutex<TrayIconState>);
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum AppTheme {
@@ -94,6 +100,22 @@ pub fn get_icon_path(theme: AppTheme, state: TrayIconState) -> &'static str {
 }
 
 pub fn change_tray_icon(app: &AppHandle, icon: TrayIconState) {
+    if let Some(state) = app.try_state::<CurrentTrayState>() {
+        *state.0.lock().unwrap_or_else(|e| e.into_inner()) = icon.clone();
+    }
+    apply_tray_icon(app, &icon);
+}
+
+/// Re-applies the last known tray state — for when only the *theme* changed.
+pub fn refresh_tray_icon(app: &AppHandle) {
+    let icon = app
+        .try_state::<CurrentTrayState>()
+        .map(|s| s.0.lock().unwrap_or_else(|e| e.into_inner()).clone())
+        .unwrap_or_default();
+    apply_tray_icon(app, &icon);
+}
+
+fn apply_tray_icon(app: &AppHandle, icon: &TrayIconState) {
     let tray = app.state::<TrayIcon>();
     let theme = get_current_theme(app);
 
@@ -112,7 +134,7 @@ pub fn change_tray_icon(app: &AppHandle, icon: TrayIconState) {
 
     // Update menu based on state
     let menu_started = std::time::Instant::now();
-    update_tray_menu(app, &icon, None);
+    update_tray_menu(app, icon, None);
     debug!(
         "tray icon change ({:?}): icon={} set_icon={:?} menu={:?}",
         icon,


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description
This PR fixes the issue where the tray icon was invisible on Windows 11 when using a dark taskbar with light application themes. 

## Related Issues/Discussions

Fixes #1423
[BUG] Incorrect system tray icon is used in some scenarios on Windows 11/10 #1423

## Community Feedback

Reported in #1423 with screenshots showing the invisible icon on Windows 11 with mixed personalization ("Custom" mode: dark taskbar + light apps).

## Testing

Reproduced and verified on Windows 11 (10.0.26200):

**Root cause:** `get_current_theme()` in `tray.rs` reads the **window** theme (`main_window.theme()`, which follows `AppsUseLightTheme`), but the tray icon sits on the **taskbar**, which follows `SystemUsesLightTheme`. With Windows' "Custom" personalization mode the two differ, so a dark taskbar + light apps got dark icons — invisible against the taskbar.

**Fix:** On Windows, read `HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize\SystemUsesLightTheme` (via the already-present `winreg` dependency) to pick the icon variant, falling back to the window theme if the value is missing (older Windows 10 builds). All three call sites (initial tray build, state changes, `ThemeChanged` events) go through this function, so they're all fixed at once.

**Verification** :

- `SystemUsesLightTheme=0` (dark taskbar) + `AppsUseLightTheme=1` (light apps) — the exact bug scenario: app logs `Theme changed to: Light` followed by `tray icon change (Idle): icon=resources/tray_idle.png` — the **light** icon is kept, visible on the dark taskbar. (Before the fix this picked `tray_idle_dark.png`.)
- `SystemUsesLightTheme=1` (light taskbar): logs `tray icon change (Idle): icon=resources/tray_idle_dark.png` — correctly switches to the dark icon.
- Windows broadcasts `WM_SETTINGCHANGE`/`ImmersiveColorSet` on taskbar-theme changes, which fires Tauri's `ThemeChanged`, so the icon also updates promptly when only the taskbar theme changes.
- `cargo fmt --check` passes; `cargo clippy` reports no new warnings (the two existing warnings are in unrelated files); macOS/Linux behavior unchanged (`#[cfg(target_os = "windows")]` only).
