### PR TITLE
Add cancel download functionality to Onboarding component

### DIFF
--- a/src/components/onboarding/Onboarding.tsx
+++ b/src/components/onboarding/Onboarding.tsx
@@ -23,6 +23,7 @@ const Onboarding: React.FC<OnboardingProps> = ({ onModelSelected }) => {
     extractingModels,
     downloadProgress,
     downloadStats,
+    cancelDownload,
   } = useModelStore();
   const [selectedModelId, setSelectedModelId] = useState<string | null>(null);
   const [showAll, setShowAll] = useState(false);
@@ -111,6 +112,13 @@ const Onboarding: React.FC<OnboardingProps> = ({ onModelSelected }) => {
     }
   };
 
+  const handleCancelDownload = async (modelId: string) => {
+    const success = await cancelDownload(modelId);
+    if (success) {
+      setSelectedModelId(null);
+    }
+  };
+
   const handleSelectExistingModel = (modelId: string) => {
     setSelectedModelId(modelId);
   };
@@ -185,6 +193,7 @@ const Onboarding: React.FC<OnboardingProps> = ({ onModelSelected }) => {
                   disabled={isBusy}
                   onSelect={handleDownloadModel}
                   onDownload={handleDownloadModel}
+                  onCancel={handleCancelDownload}
                   downloadProgress={getModelDownloadProgress(model.id)}
                   downloadSpeed={getModelDownloadSpeed(model.id)}
                   showRecommended={false}
@@ -199,6 +208,7 @@ const Onboarding: React.FC<OnboardingProps> = ({ onModelSelected }) => {
                   disabled={isBusy}
                   onSelect={handleDownloadModel}
                   onDownload={handleDownloadModel}
+                  onCancel={handleCancelDownload}
                   downloadProgress={getModelDownloadProgress(model.id)}
                   downloadSpeed={getModelDownloadSpeed(model.id)}
                   showRecommended={false}
@@ -233,6 +243,7 @@ const Onboarding: React.FC<OnboardingProps> = ({ onModelSelected }) => {
                     disabled={isBusy}
                     onSelect={handleDownloadModel}
                     onDownload={handleDownloadModel}
+                    onCancel={handleCancelDownload}
                     downloadProgress={getModelDownloadProgress(model.id)}
                     downloadSpeed={getModelDownloadSpeed(model.id)}
                     showRecommended={false}


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

During onboarding there isn't a cancel button to stop the download. This is bad.

## Related Issues/Discussions

Fixes #1509
Discussion:

## Community Feedback

N/A (This fixes a minor UX bug during the onboarding experience where the UI gets locked mid-onboarding during a model download with no way to abort or change selections).

## Testing

Tested on Windows by checking component layout and verify scripts:
- Ran `bun run lint` successfully to ensure code style compliance.
- Ran `bun run format:frontend` to confirm formatting is correct.
- Verified state management updates: cancelling calls `cancelDownload` which stops the download on the backend, deletes the partial file, and resets `selectedModelId` to `null` to unlock all other cards in the onboarding UI.

## Screenshots/Videos (if applicable)

*(Add screenshots or videos demonstrating the change if desired)*

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Antigravity AI agent
- How extensively: The AI agent researched the codebase, mapped `cancelDownload` from the store inside `Onboarding.tsx`, and wired it to the `ModelCard` components, followed by verification using linting and formatting scripts.
