### PR TITLE
fix(models): don't reload the already-active model when its card is clicked

### DIFF
--- a/src/components/onboarding/ModelCard.tsx
+++ b/src/components/onboarding/ModelCard.tsx
@@ -92,8 +92,9 @@ const ModelCard: React.FC<ModelCardProps> = ({
 }) => {
   const { t } = useTranslation();
   const isFeatured = variant === "featured";
-  const isClickable =
-    status === "available" || status === "active" || status === "downloadable";
+  // The active model is already loaded — re-selecting it just reloads it for no
+  // gain, so it is deliberately not clickable.
+  const isClickable = status === "available" || status === "downloadable";
 
   // Get translated model name and description
   const displayName = getTranslatedModelName(model, t);


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Human Written Description

I noticed that in **Settings → Models**, clicking the model that's already active kicks off a full reload of that same model. Nothing about the app's state changes — you end up exactly where you started — but you sit through the "Switching…" / "Loading…" spinner for no reason, and on the larger models that's a real wait. It also just feels wrong that the current model looks and behaves like a button when there's nothing to switch to. This makes the active card non-interactive so an accidental click can't trigger a pointless reload.

## Related Issues/Discussions

<!-- No existing issue found for this specific UX behaviour; noticed directly while using the app. -->

Fixes #
Discussion:

## Community Feedback

<!-- Bug fix / UX polish — no dedicated issue found. Happy to open a discussion if the maintainers prefer one. -->

## Testing

- In **Settings → Models**, the currently-active model card (badged "Active") no longer responds to clicks: no pointer cursor, no hover lift, no `role="button"`, and clicking it does nothing — so it can't re-trigger a reload of the model that's already loaded.
- Switching to a different **downloaded** model (status "available") still selects and loads it as before.
- Clicking a **downloadable** model still starts its download.
- The active card's Delete button and status badge continue to work.
- `bun run lint` passes clean.

**Why the change is a one-liner:** a single `isClickable` flag in `ModelCard.tsx` gates the click handler, the Enter-key handler, `role="button"`, `tabIndex`, the pointer cursor, and the hover styling all at once. It previously included `status === "active"`; dropping that from the flag disables the whole interaction for the active card — the click _and_ every visual cue that it's clickable — while leaving `"available"` and `"downloadable"` untouched.

## Screenshots/Videos (if applicable)

<!-- Optional: a short clip showing the active card no longer reloading on click. -->

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: AI located the root cause (the `isClickable` flag including `"active"`) and made the one-line change plus the explanatory comment. The description above is my own; I reviewed and verified the change.
