### PR TITLE
fix: prevent history audio players from playing simultaneously

### DIFF
--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/bindings";
 import { useOsType } from "@/hooks/useOsType";
 import { formatDateTime } from "@/utils/dateFormat";
-import { AudioPlayer } from "../../ui/AudioPlayer";
+import { AudioPlayer, AudioPlayerGroup } from "../../ui/AudioPlayer";
 import { Button } from "../../ui/Button";
 
 const IconButton: React.FC<{
@@ -251,19 +251,21 @@ export const HistorySettings: React.FC = () => {
   } else {
     content = (
       <>
-        <div className="divide-y divide-mid-gray/20">
-          {entries.map((entry) => (
-            <HistoryEntryComponent
-              key={entry.id}
-              entry={entry}
-              onToggleSaved={() => toggleSaved(entry.id)}
-              onCopyText={() => copyToClipboard(entry.transcription_text)}
-              getAudioUrl={getAudioUrl}
-              deleteAudio={deleteAudioEntry}
-              retryTranscription={retryHistoryEntry}
-            />
-          ))}
-        </div>
+        <AudioPlayerGroup>
+          <div className="divide-y divide-mid-gray/20">
+            {entries.map((entry) => (
+              <HistoryEntryComponent
+                key={entry.id}
+                entry={entry}
+                onToggleSaved={() => toggleSaved(entry.id)}
+                onCopyText={() => copyToClipboard(entry.transcription_text)}
+                getAudioUrl={getAudioUrl}
+                deleteAudio={deleteAudioEntry}
+                retryTranscription={retryHistoryEntry}
+              />
+            ))}
+          </div>
+        </AudioPlayerGroup>
         {/* Sentinel for infinite scroll */}
         <div ref={sentinelRef} className="h-1" />
       </>

--- a/src/components/ui/AudioPlayer.tsx
+++ b/src/components/ui/AudioPlayer.tsx
@@ -1,4 +1,12 @@
-import React, { useState, useRef, useEffect, useCallback } from "react";
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Play, Pause } from "lucide-react";
 
 interface AudioPlayerProps {
@@ -10,12 +18,45 @@ interface AudioPlayerProps {
   autoPlay?: boolean;
 }
 
+interface AudioPlayerGroupContextValue {
+  requestPlayback: (audio: HTMLAudioElement) => void;
+  releasePlayback: (audio: HTMLAudioElement) => void;
+}
+
+const AudioPlayerGroupContext =
+  createContext<AudioPlayerGroupContextValue | null>(null);
+
+export const AudioPlayerGroup: React.FC<React.PropsWithChildren> = ({
+  children,
+}) => {
+  const activeAudioRef = useRef<HTMLAudioElement | null>(null);
+  const value = useMemo<AudioPlayerGroupContextValue>(
+    () => ({
+      requestPlayback: (audio) => {
+        if (activeAudioRef.current !== audio) activeAudioRef.current?.pause();
+        activeAudioRef.current = audio;
+      },
+      releasePlayback: (audio) => {
+        if (activeAudioRef.current === audio) activeAudioRef.current = null;
+      },
+    }),
+    [],
+  );
+
+  return (
+    <AudioPlayerGroupContext.Provider value={value}>
+      {children}
+    </AudioPlayerGroupContext.Provider>
+  );
+};
+
 export const AudioPlayer: React.FC<AudioPlayerProps> = ({
   src: initialSrc,
   onLoadRequest,
   className = "",
   autoPlay = false,
 }) => {
+  const group = useContext(AudioPlayerGroupContext);
   const [isPlaying, setIsPlaying] = useState(false);
   const [duration, setDuration] = useState(0);
   const [currentTime, setCurrentTime] = useState(0);
@@ -87,12 +128,19 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = ({
     };
 
     const handleEnded = () => {
+      group?.releasePlayback(audio);
       setIsPlaying(false);
       setCurrentTime(audio.duration || 0);
     };
 
-    const handlePlay = () => setIsPlaying(true);
-    const handlePause = () => setIsPlaying(false);
+    const handlePlay = () => {
+      group?.requestPlayback(audio);
+      setIsPlaying(true);
+    };
+    const handlePause = () => {
+      group?.releasePlayback(audio);
+      setIsPlaying(false);
+    };
 
     audio.addEventListener("loadedmetadata", handleLoadedMetadata);
     audio.addEventListener("ended", handleEnded);
@@ -100,12 +148,13 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = ({
     audio.addEventListener("pause", handlePause);
 
     return () => {
+      group?.releasePlayback(audio);
       audio.removeEventListener("loadedmetadata", handleLoadedMetadata);
       audio.removeEventListener("ended", handleEnded);
       audio.removeEventListener("play", handlePlay);
       audio.removeEventListener("pause", handlePause);
     };
-  }, []);
+  }, [group]);
 
   // Auto-play when src becomes available (via onLoadRequest or autoPlay prop)
   const prevLoadedSrc = useRef<string | null>(null);


### PR DESCRIPTION
## Before Submitting This PR

<!--
HANDY IS UNDERGOING A FEATURE FREEZE. IF YOU ARE SUBMITTING A PR WHICH IS A NEW FEATURE THAT THE COMMUNITY HAS NOT ASKED FOR: PREPARE TO BE REJECTED. IF THE COMMUNITY HAS ASKED FOR IT, OR YOU HAVE EXPLICITLY GATHERED SUPPORT IT MAY STILL BE CONSIDERED.

BUG FIXES ARE THE TOP PRIORITY. THERE ARE 60+ ISSUES TO FIX.
-->

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

I noticed that audio in the history settings page continued playing when another track was started, causing them to overlap. This PR introduces an optional AudioPlayerGroup component that uses a context to keep track of the active audio element. When a player in the group starts, the currently active player is paused and the starting player is assigned as the active

<!-- Describe your changes clearly and concisely

Please write 2-3 sentences in your own words explaining:
- What problem you noticed or idea you had
- Why you think this change matters

This section should be YOUR thinking, not AI-generated text. Even if AI helped write the code, we want to hear from you directly. Your perspective as a human is what makes contributions meaningful. Your PR may be rejected if you do not
include a human-written description.
-->

## Testing
Ive tested the functionality on my Mac
<!-- Describe how you tested your changes and if you need help getting additional testing -->

## Screenshots/Videos (if applicable)


https://github.com/user-attachments/assets/5c5092ba-a122-4731-95cc-3f0d756da8bf



<!-- Add screenshots or videos demonstrating the change -->

## AI Assistance

<!-- AI-assisted PRs are welcome! Just let us know so we can review appropriately. -->

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: Codex was used to brainstorm the implementation approach and assist with writing the code.
