### PR TITLE
fix(models): handle Hugging Face linked size headers

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2499,7 +2499,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hf-hub"
 version = "0.5.0"
-source = "git+https://github.com/cjpais/hf-hub?branch=cancellable-downloads#63b60347570622bf898f49e7f10c2429b8dd21b6"
+source = "git+https://github.com/JavaGT/hf-hub?rev=1fee8e5#1fee8e50c6ddd45e9b7e4615df2d53df24a0896f"
 dependencies = [
  "dirs 6.0.0",
  "futures",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2499,7 +2499,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hf-hub"
 version = "0.5.0"
-source = "git+https://github.com/JavaGT/hf-hub?rev=1fee8e5#1fee8e50c6ddd45e9b7e4615df2d53df24a0896f"
+source = "git+https://github.com/cjpais/hf-hub?branch=cancellable-downloads#9918f11ab3473135eb7865aa4a5d79d597e6e810"
 dependencies = [
  "dirs 6.0.0",
  "futures",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -81,7 +81,7 @@ specta = "=2.0.0-rc.22"
 specta-typescript = "0.0.9"
 tauri-specta = { version = "=2.0.0-rc.21", features = ["derive", "typescript"] }
 tauri-plugin-dialog = "2.6"
-hf-hub = { git = "https://github.com/JavaGT/hf-hub", rev = "1fee8e5", features = [
+hf-hub = { git = "https://github.com/cjpais/hf-hub", branch = "cancellable-downloads", features = [
   "tokio",
 ] }
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -81,7 +81,7 @@ specta = "=2.0.0-rc.22"
 specta-typescript = "0.0.9"
 tauri-specta = { version = "=2.0.0-rc.21", features = ["derive", "typescript"] }
 tauri-plugin-dialog = "2.6"
-hf-hub = { git = "https://github.com/cjpais/hf-hub", branch = "cancellable-downloads", features = [
+hf-hub = { git = "https://github.com/JavaGT/hf-hub", rev = "1fee8e5", features = [
   "tokio",
 ] }
 


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched existing issues and pull requests (including closed ones) to ensure this is not a duplicate
- [x] I have read CONTRIBUTING.md

## Human Written Description

TODO (human contributor): Please add 2–3 sentences in your own words describing the problem you encountered and why this change matters.

## Related Issues/Discussions

Fixes #1579

Dependency fix: cjpais/hf-hub#1

## Community Feedback

The linked issue contains reports from affected users, including the `Header content-range is missing` failure.

## Testing

- Added and passed the dependency regression test: `cargo test --features tokio api::tokio::tests::metadata_uses_linked_size_without_following_redirect -- --exact --nocapture`
- Passed `cargo check --locked --lib` in `src-tauri`.

## Screenshots/Videos (if applicable)

Not applicable; this is a download-path fix.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

- Tools used: Codex
- How extensively: Root-cause investigation, regression test, implementation, and verification; the Human Written Description is intentionally left for the contributor.