### PR TITLE
feat: add Apple Speech (SpeechAnalyzer) model on macOS 26+

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -507,12 +507,13 @@ fn build_apple_intelligence_bridge() {
 }
 
 /// Compile the SpeechAnalyzer (Speech framework, macOS 26+) Swift bridge.
-/// Mirrors `build_apple_intelligence_bridge`, but instead of probing the SDK
-/// up front it simply attempts to compile the real bridge and falls back to
-/// the stub if the toolchain can't build it (older SDK, CLT-only, …).
+/// A small type-check probe distinguishes an SDK that lacks the API (where the
+/// stub is expected) from a regression in the real bridge (which must fail the
+/// build instead of silently shipping without support).
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 fn build_speech_analyzer_bridge() {
     use std::env;
+    use std::fs;
     use std::path::{Path, PathBuf};
     use std::process::Command;
 
@@ -523,6 +524,9 @@ fn build_speech_analyzer_bridge() {
     println!("cargo:rerun-if-changed={REAL_SWIFT_FILE}");
     println!("cargo:rerun-if-changed={STUB_SWIFT_FILE}");
     println!("cargo:rerun-if-changed={BRIDGE_HEADER}");
+    println!("cargo:rerun-if-env-changed=HANDY_FORCE_SA_STUB");
+    println!("cargo:rerun-if-env-changed=SDKROOT");
+    println!("cargo:rerun-if-env-changed=SWIFTC");
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
     let object_path = out_dir.join("speech_analyzer.o");
@@ -554,46 +558,75 @@ fn build_speech_analyzer_bridge() {
         .to_string()
     });
 
-    let compile = |source_file: &str| -> bool {
-        Command::new(&swiftc_path)
+    let force_stub = env::var("HANDY_FORCE_SA_STUB").as_deref() == Ok("1");
+    let probe_path = out_dir.join("speech_analyzer_probe.swift");
+    fs::write(
+        &probe_path,
+        r#"import Speech
+
+@available(macOS 26.0, *)
+func handySpeechAnalyzerCapabilityProbe() {
+    _ = SpeechAnalyzer.self
+    _ = SpeechTranscriber.self
+    _ = AssetInventory.self
+}
+"#,
+    )
+    .expect("Failed to write SpeechAnalyzer capability probe");
+
+    let probe_succeeded = !force_stub
+        && Command::new(&swiftc_path)
             .args([
-                "-parse-as-library",
                 "-target",
                 "arm64-apple-macosx11.0",
                 "-sdk",
                 &sdk_path,
-                "-O",
-                "-import-objc-header",
-                BRIDGE_HEADER,
-                "-c",
-                source_file,
-                "-o",
-                object_path
+                "-typecheck",
+                probe_path
                     .to_str()
-                    .expect("Failed to convert object path to string"),
+                    .expect("Failed to convert probe path to string"),
             ])
-            .status()
-            .expect("Failed to invoke swiftc for SpeechAnalyzer bridge")
-            .success()
-    };
+            .output()
+            .expect("Failed to invoke swiftc for SpeechAnalyzer capability probe")
+            .status
+            .success();
 
-    let force_stub = env::var("HANDY_FORCE_SA_STUB").as_deref() == Ok("1");
-    let built_real = if force_stub {
+    let (source_file, built_real) = if force_stub {
         println!("cargo:warning=HANDY_FORCE_SA_STUB=1 set; building SpeechAnalyzer stubs.");
-        false
-    } else if compile(REAL_SWIFT_FILE) {
+        (STUB_SWIFT_FILE, false)
+    } else if probe_succeeded {
         println!("cargo:warning=Building with SpeechAnalyzer support.");
-        true
+        (REAL_SWIFT_FILE, true)
     } else {
         println!(
-            "cargo:warning=SpeechAnalyzer bridge failed to compile (SDK/toolchain too old?). \
+            "cargo:warning=SpeechAnalyzer API is unavailable in the active SDK/toolchain. \
              Building with stubs."
         );
-        false
+        (STUB_SWIFT_FILE, false)
     };
 
-    if !built_real && !compile(STUB_SWIFT_FILE) {
-        panic!("swiftc failed to compile {STUB_SWIFT_FILE}");
+    let status = Command::new(&swiftc_path)
+        .args([
+            "-parse-as-library",
+            "-target",
+            "arm64-apple-macosx11.0",
+            "-sdk",
+            &sdk_path,
+            "-O",
+            "-import-objc-header",
+            BRIDGE_HEADER,
+            "-c",
+            source_file,
+            "-o",
+            object_path
+                .to_str()
+                .expect("Failed to convert object path to string"),
+        ])
+        .status()
+        .expect("Failed to invoke swiftc for SpeechAnalyzer bridge");
+
+    if !status.success() {
+        panic!("swiftc failed to compile {source_file}");
     }
 
     let status = Command::new("libtool")

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -2,6 +2,9 @@ fn main() {
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
     build_apple_intelligence_bridge();
 
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    build_speech_analyzer_bridge();
+
     generate_tray_translations();
 
     // Linux ships transcribe-cpp as a shared libtranscribe + loadable ggml
@@ -498,6 +501,142 @@ fn build_apple_intelligence_bridge() {
         // Use weak linking so the app can launch on systems without FoundationModels
         println!("cargo:rustc-link-arg=-weak_framework");
         println!("cargo:rustc-link-arg=FoundationModels");
+    }
+
+    println!("cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift");
+}
+
+/// Compile the SpeechAnalyzer (Speech framework, macOS 26+) Swift bridge.
+/// Mirrors `build_apple_intelligence_bridge`, but instead of probing the SDK
+/// up front it simply attempts to compile the real bridge and falls back to
+/// the stub if the toolchain can't build it (older SDK, CLT-only, …).
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn build_speech_analyzer_bridge() {
+    use std::env;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    const REAL_SWIFT_FILE: &str = "swift/speech_analyzer.swift";
+    const STUB_SWIFT_FILE: &str = "swift/speech_analyzer_stub.swift";
+    const BRIDGE_HEADER: &str = "swift/speech_analyzer_bridge.h";
+
+    println!("cargo:rerun-if-changed={REAL_SWIFT_FILE}");
+    println!("cargo:rerun-if-changed={STUB_SWIFT_FILE}");
+    println!("cargo:rerun-if-changed={BRIDGE_HEADER}");
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
+    let object_path = out_dir.join("speech_analyzer.o");
+    let static_lib_path = out_dir.join("libspeech_analyzer.a");
+
+    let sdk_path = env::var("SDKROOT").unwrap_or_else(|_| {
+        String::from_utf8(
+            Command::new("xcrun")
+                .args(["--sdk", "macosx", "--show-sdk-path"])
+                .output()
+                .expect("Failed to locate macOS SDK")
+                .stdout,
+        )
+        .expect("SDK path is not valid UTF-8")
+        .trim()
+        .to_string()
+    });
+
+    let swiftc_path = env::var("SWIFTC").unwrap_or_else(|_| {
+        String::from_utf8(
+            Command::new("xcrun")
+                .args(["--find", "swiftc"])
+                .output()
+                .expect("Failed to locate swiftc")
+                .stdout,
+        )
+        .expect("swiftc path is not valid UTF-8")
+        .trim()
+        .to_string()
+    });
+
+    let compile = |source_file: &str| -> bool {
+        Command::new(&swiftc_path)
+            .args([
+                "-parse-as-library",
+                "-target",
+                "arm64-apple-macosx11.0",
+                "-sdk",
+                &sdk_path,
+                "-O",
+                "-import-objc-header",
+                BRIDGE_HEADER,
+                "-c",
+                source_file,
+                "-o",
+                object_path
+                    .to_str()
+                    .expect("Failed to convert object path to string"),
+            ])
+            .status()
+            .expect("Failed to invoke swiftc for SpeechAnalyzer bridge")
+            .success()
+    };
+
+    let force_stub = env::var("HANDY_FORCE_SA_STUB").as_deref() == Ok("1");
+    let built_real = if force_stub {
+        println!("cargo:warning=HANDY_FORCE_SA_STUB=1 set; building SpeechAnalyzer stubs.");
+        false
+    } else if compile(REAL_SWIFT_FILE) {
+        println!("cargo:warning=Building with SpeechAnalyzer support.");
+        true
+    } else {
+        println!(
+            "cargo:warning=SpeechAnalyzer bridge failed to compile (SDK/toolchain too old?). \
+             Building with stubs."
+        );
+        false
+    };
+
+    if !built_real && !compile(STUB_SWIFT_FILE) {
+        panic!("swiftc failed to compile {STUB_SWIFT_FILE}");
+    }
+
+    let status = Command::new("libtool")
+        .args([
+            "-static",
+            "-o",
+            static_lib_path
+                .to_str()
+                .expect("Failed to convert static lib path to string"),
+            object_path
+                .to_str()
+                .expect("Failed to convert object path to string"),
+        ])
+        .status()
+        .expect("Failed to create static library for SpeechAnalyzer bridge");
+
+    if !status.success() {
+        panic!("libtool failed for SpeechAnalyzer bridge");
+    }
+
+    let toolchain_swift_lib = Path::new(&swiftc_path)
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|root| root.join("lib/swift/macosx"))
+        .expect("Unable to determine Swift toolchain lib directory");
+    let sdk_swift_lib = Path::new(&sdk_path).join("usr/lib/swift");
+
+    println!("cargo:rustc-link-search=native={}", out_dir.display());
+    println!("cargo:rustc-link-lib=static=speech_analyzer");
+    println!(
+        "cargo:rustc-link-search=native={}",
+        toolchain_swift_lib.display()
+    );
+    println!("cargo:rustc-link-search=native={}", sdk_swift_lib.display());
+    println!("cargo:rustc-link-lib=framework=Foundation");
+
+    if built_real {
+        // Weak linking so the app still launches on macOS versions without the
+        // SpeechAnalyzer symbols; @available guards handle runtime availability.
+        println!("cargo:rustc-link-arg=-weak_framework");
+        println!("cargo:rustc-link-arg=Speech");
+        println!("cargo:rustc-link-arg=-weak_framework");
+        println!("cargo:rustc-link-arg=AVFoundation");
     }
 
     println!("cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift");

--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -1,4 +1,4 @@
-use crate::managers::model::{ModelInfo, ModelManager};
+use crate::managers::model::{ModelInfo, ModelManager, ModelSource};
 use crate::managers::transcription::{ModelStateEvent, TranscriptionManager};
 use crate::settings::{get_settings, write_settings, ModelUnloadTimeout};
 use std::sync::Arc;
@@ -65,6 +65,13 @@ pub async fn delete_model(
     transcription_manager: State<'_, Arc<TranscriptionManager>>,
     model_id: String,
 ) -> Result<(), String> {
+    let model_info = model_manager
+        .get_model_info(&model_id)
+        .ok_or_else(|| format!("Model not found: {model_id}"))?;
+    if matches!(model_info.source, ModelSource::System) {
+        return Err("System-managed models cannot be deleted".to_string());
+    }
+
     // If deleting the active model, unload it and clear the setting
     let settings = get_settings(&app_handle);
     if settings.selected_model == model_id {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ pub mod portable;
 mod settings;
 mod shortcut;
 mod signal_handle;
+mod speech_analyzer;
 mod transcription_coordinator;
 mod tray;
 mod tray_i18n;

--- a/src-tauri/src/managers/model.rs
+++ b/src-tauri/src/managers/model.rs
@@ -506,7 +506,7 @@ impl ModelManager {
                                 id: crate::speech_analyzer::MODEL_ID.to_string(),
                                 name: "Apple Speech".to_string(),
                                 description:
-                                    "Apple's built-in on-device speech recognition (macOS 26+). Speech assets are downloaded by macOS on first use."
+                                    "Apple's new on-device SpeechAnalyzer engine (macOS 26+). Speech assets are downloaded and managed by macOS."
                                         .to_string(),
                                 filename: String::new(),
                                 source: ModelSource::System,

--- a/src-tauri/src/managers/model.rs
+++ b/src-tauri/src/managers/model.rs
@@ -57,6 +57,9 @@ pub enum ModelSource {
     /// Already present on disk — a user-provided custom model, or one discovered
     /// in a shared cache. Nothing to download.
     Local,
+    /// Supplied and managed by the operating system. There is no Handy-owned
+    /// model file to download, resolve, or delete.
+    System,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
@@ -470,41 +473,61 @@ impl ModelManager {
 
         let mut available_models = HashMap::new();
 
-        // Apple's SpeechAnalyzer (macOS 26+): only registered when the running
-        // OS actually has the API. The OS manages the model assets, so the
-        // entry is always "downloaded" — asset installation happens at load.
+        // Apple's SpeechTranscriber (macOS 26+): only register it when both the
+        // API and the current device support the model. The OS owns its assets;
+        // `is_downloaded` means selectable here, not that Handy owns a file.
         if crate::speech_analyzer::is_available() {
-            available_models.insert(
-                "apple-speechanalyzer".to_string(),
-                ModelInfo {
-                    id: "apple-speechanalyzer".to_string(),
-                    name: "Apple SpeechAnalyzer".to_string(),
-                    description: "Apple's built-in on-device speech recognition (macOS 26+)."
-                        .to_string(),
-                    filename: String::new(),
-                    source: ModelSource::Local,
-                    size_mb: 0,
-                    is_downloaded: true,
-                    is_downloading: false,
-                    partial_size: 0,
-                    is_directory: false,
-                    engine_type: EngineType::SpeechAnalyzer,
-                    accuracy_score: 0.85,
-                    speed_score: 0.95,
-                    supports_translation: false,
-                    is_recommended: false,
-                    supported_languages: vec![
-                        "en", "es", "fr", "de", "it", "pt", "ja", "ko", "zh", "yue", "ar",
-                    ]
-                    .into_iter()
-                    .map(String::from)
-                    .collect(),
-                    supports_language_selection: true,
-                    is_custom: false,
-                    supports_streaming: false,
-                    supports_language_detection: false,
-                },
-            );
+            match crate::speech_analyzer::supported_locales() {
+                Ok(locales) => {
+                    let mut supported_languages = canonicalize_supported_languages(
+                        locales
+                            .into_iter()
+                            .map(|locale| base_language(&locale).to_string())
+                            .collect(),
+                    );
+                    supported_languages.sort();
+
+                    if supported_languages.is_empty() {
+                        warn!(
+                            "SpeechTranscriber reported no supported locales; hiding system model"
+                        );
+                    } else {
+                        available_models.insert(
+                            crate::speech_analyzer::MODEL_ID.to_string(),
+                            ModelInfo {
+                                id: crate::speech_analyzer::MODEL_ID.to_string(),
+                                name: "Apple SpeechTranscriber".to_string(),
+                                description:
+                                    "Apple's built-in on-device speech recognition (macOS 26+)."
+                                        .to_string(),
+                                filename: String::new(),
+                                source: ModelSource::System,
+                                size_mb: 0,
+                                is_downloaded: true,
+                                is_downloading: false,
+                                partial_size: 0,
+                                is_directory: false,
+                                engine_type: EngineType::SpeechAnalyzer,
+                                // No comparable Handy benchmark exists yet; zero hides the
+                                // editorial score bars instead of asserting unsupported ranks.
+                                accuracy_score: 0.0,
+                                speed_score: 0.0,
+                                supports_translation: false,
+                                is_recommended: false,
+                                supports_language_selection: supported_languages.len() > 1,
+                                supported_languages,
+                                is_custom: false,
+                                supports_streaming: false,
+                                supports_language_detection: false,
+                            },
+                        );
+                    }
+                }
+                Err(error) => warn!(
+                    "Failed to query SpeechTranscriber supported locales; hiding system model: {}",
+                    error
+                ),
+            }
         }
 
         // Whisper supported languages (99 languages from tokenizer)
@@ -1346,9 +1369,8 @@ impl ModelManager {
         let mut models = self.available_models.lock().unwrap();
 
         for model in models.values_mut() {
-            // SpeechAnalyzer has no on-disk footprint; availability is an OS
-            // property, not a filesystem one.
-            if matches!(model.engine_type, EngineType::SpeechAnalyzer) {
+            // System-managed engines have no Handy-owned on-disk footprint.
+            if matches!(model.source, ModelSource::System) {
                 model.is_downloaded = crate::speech_analyzer::is_available();
                 model.is_downloading = false;
                 model.partial_size = 0;
@@ -1890,6 +1912,11 @@ impl ModelManager {
             ModelSource::Local => {
                 return Err(anyhow::anyhow!("No download source for model"));
             }
+            ModelSource::System => {
+                return Err(anyhow::anyhow!(
+                    "System-managed models are prepared by the operating system"
+                ));
+            }
         };
         let model_path = self.models_dir.join(&model_info.filename);
         let partial_path = self
@@ -2232,6 +2259,10 @@ impl ModelManager {
 
         debug!("ModelManager: Found model info: {:?}", model_info);
 
+        if matches!(model_info.source, ModelSource::System) {
+            return Err(anyhow::anyhow!("System-managed models cannot be deleted"));
+        }
+
         if let ModelSource::HuggingFace { repo_id, revision } = &model_info.source {
             // Cached at <cache>/models--org--name/snapshots/<rev>/<file>; remove
             // the whole repo dir (blobs + refs + snapshots). Per product decision,
@@ -2329,6 +2360,12 @@ impl ModelManager {
             return Err(anyhow::anyhow!(
                 "Model is currently downloading: {}",
                 model_id
+            ));
+        }
+
+        if matches!(model_info.source, ModelSource::System) {
+            return Err(anyhow::anyhow!(
+                "System-managed models do not have a local model path"
             ));
         }
 

--- a/src-tauri/src/managers/model.rs
+++ b/src-tauri/src/managers/model.rs
@@ -35,6 +35,9 @@ pub enum EngineType {
     GigaAM,
     Canary,
     Cohere,
+    /// Apple's on-device SpeechAnalyzer API (macOS 26+). The OS manages the
+    /// model assets; there is no file for Handy to download or load.
+    SpeechAnalyzer,
 }
 
 /// Where a model comes from and how Handy obtains it — the routing discriminant
@@ -466,6 +469,43 @@ impl ModelManager {
         }
 
         let mut available_models = HashMap::new();
+
+        // Apple's SpeechAnalyzer (macOS 26+): only registered when the running
+        // OS actually has the API. The OS manages the model assets, so the
+        // entry is always "downloaded" — asset installation happens at load.
+        if crate::speech_analyzer::is_available() {
+            available_models.insert(
+                "apple-speechanalyzer".to_string(),
+                ModelInfo {
+                    id: "apple-speechanalyzer".to_string(),
+                    name: "Apple SpeechAnalyzer".to_string(),
+                    description: "Apple's built-in on-device speech recognition (macOS 26+)."
+                        .to_string(),
+                    filename: String::new(),
+                    source: ModelSource::Local,
+                    size_mb: 0,
+                    is_downloaded: true,
+                    is_downloading: false,
+                    partial_size: 0,
+                    is_directory: false,
+                    engine_type: EngineType::SpeechAnalyzer,
+                    accuracy_score: 0.85,
+                    speed_score: 0.95,
+                    supports_translation: false,
+                    is_recommended: false,
+                    supported_languages: vec![
+                        "en", "es", "fr", "de", "it", "pt", "ja", "ko", "zh", "yue", "ar",
+                    ]
+                    .into_iter()
+                    .map(String::from)
+                    .collect(),
+                    supports_language_selection: true,
+                    is_custom: false,
+                    supports_streaming: false,
+                    supports_language_detection: false,
+                },
+            );
+        }
 
         // Whisper supported languages (99 languages from tokenizer)
         let whisper_languages: Vec<String> = vec![
@@ -1306,6 +1346,14 @@ impl ModelManager {
         let mut models = self.available_models.lock().unwrap();
 
         for model in models.values_mut() {
+            // SpeechAnalyzer has no on-disk footprint; availability is an OS
+            // property, not a filesystem one.
+            if matches!(model.engine_type, EngineType::SpeechAnalyzer) {
+                model.is_downloaded = crate::speech_analyzer::is_available();
+                model.is_downloading = false;
+                model.partial_size = 0;
+                continue;
+            }
             if let ModelSource::HuggingFace { repo_id, revision } = &model.source {
                 model.is_downloaded = hf_cached_path(repo_id, revision, &model.filename).is_some();
                 model.is_downloading = false;

--- a/src-tauri/src/managers/model.rs
+++ b/src-tauri/src/managers/model.rs
@@ -489,14 +489,14 @@ impl ModelManager {
 
                     if supported_languages.is_empty() {
                         warn!(
-                            "SpeechTranscriber reported no supported locales; hiding system model"
+                            "Apple speech recognition reported no supported locales; hiding system model"
                         );
                     } else {
                         available_models.insert(
                             crate::speech_analyzer::MODEL_ID.to_string(),
                             ModelInfo {
                                 id: crate::speech_analyzer::MODEL_ID.to_string(),
-                                name: "Apple SpeechTranscriber".to_string(),
+                                name: "Apple Speech".to_string(),
                                 description:
                                     "Apple's built-in on-device speech recognition (macOS 26+)."
                                         .to_string(),
@@ -524,7 +524,7 @@ impl ModelManager {
                     }
                 }
                 Err(error) => warn!(
-                    "Failed to query SpeechTranscriber supported locales; hiding system model: {}",
+                    "Failed to query Apple speech recognition supported locales; hiding system model: {}",
                     error
                 ),
             }

--- a/src-tauri/src/managers/model.rs
+++ b/src-tauri/src/managers/model.rs
@@ -498,7 +498,7 @@ impl ModelManager {
                                 id: crate::speech_analyzer::MODEL_ID.to_string(),
                                 name: "Apple Speech".to_string(),
                                 description:
-                                    "Apple's built-in on-device speech recognition (macOS 26+)."
+                                    "Apple's built-in on-device speech recognition (macOS 26+). Speech assets are downloaded by macOS on first use."
                                         .to_string(),
                                 filename: String::new(),
                                 source: ModelSource::System,

--- a/src-tauri/src/managers/model.rs
+++ b/src-tauri/src/managers/model.rs
@@ -525,7 +525,7 @@ impl ModelManager {
                                 supports_language_selection: supported_languages.len() > 1,
                                 supported_languages,
                                 is_custom: false,
-                                supports_streaming: false,
+                                supports_streaming: true,
                                 supports_language_detection: false,
                             },
                         );

--- a/src-tauri/src/managers/model.rs
+++ b/src-tauri/src/managers/model.rs
@@ -121,6 +121,20 @@ fn canonicalize_supported_languages(languages: Vec<String>) -> Vec<String> {
     canonical
 }
 
+/// Map the raw BCP-47 locale list reported by Apple's SpeechAnalyzer
+/// (`en-US`, `en-GB`, `zh-CN`, …) to the deduplicated base-language codes the
+/// language picker works with (`en`, `zh`, …), sorted for stable display.
+fn speech_analyzer_languages(locales: Vec<String>) -> Vec<String> {
+    let mut languages = canonicalize_supported_languages(
+        locales
+            .into_iter()
+            .map(|locale| base_language(&locale).to_string())
+            .collect(),
+    );
+    languages.sort();
+    languages
+}
+
 /// One downloadable quantization of a model. Mirrors a `files[]` entry in
 /// `catalog.json`, so it deserializes straight from the catalog.
 #[derive(Debug, Clone, Deserialize)]
@@ -479,13 +493,7 @@ impl ModelManager {
         if crate::speech_analyzer::is_available() {
             match crate::speech_analyzer::supported_locales() {
                 Ok(locales) => {
-                    let mut supported_languages = canonicalize_supported_languages(
-                        locales
-                            .into_iter()
-                            .map(|locale| base_language(&locale).to_string())
-                            .collect(),
-                    );
-                    supported_languages.sort();
+                    let supported_languages = speech_analyzer_languages(locales);
 
                     if supported_languages.is_empty() {
                         warn!(
@@ -2489,6 +2497,51 @@ mod tests {
 
         assert_eq!(effective_language("zh-Hans", &languages, true), "zh-Hans");
         assert_eq!(effective_language("zh-Hant", &languages, true), "zh-Hant");
+    }
+
+    #[test]
+    fn test_effective_language_never_yields_auto_without_detection_support() {
+        // Load-bearing for Apple SpeechAnalyzer: the load path resolves the
+        // user's language via effective_language() and hands the result
+        // straight to the OS as a locale identifier (ffi::prepare). The model
+        // registers with supports_language_detection = false, so the only
+        // thing keeping the literal string "auto" — the default setting —
+        // from reaching the OS is this fallback resolving to a concrete
+        // language, preferring English.
+        let languages: Vec<String> = vec!["de", "en", "es"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+
+        assert_eq!(effective_language("auto", &languages, false), "en");
+        // Same invariant when the user picked a language the model lacks.
+        assert_eq!(effective_language("fr", &languages, false), "en");
+    }
+
+    #[test]
+    fn test_speech_analyzer_languages_collapses_locales_for_picker() {
+        // SpeechAnalyzer reports full BCP-47 locales, but the language picker
+        // and effective_language() matching work on base codes. Regressions
+        // here surface as duplicate entries in the picker (en-US + en-GB) or
+        // a wrongly enabled picker for a single-language asset list.
+        let result = speech_analyzer_languages(
+            vec!["en-US", "en-GB", "zh-CN", "zh-TW", "yue-CN", "de-DE"]
+                .into_iter()
+                .map(String::from)
+                .collect(),
+        );
+
+        // Deduplicated to base codes (yue is its own language, not zh), sorted.
+        assert_eq!(result, vec!["de", "en", "yue", "zh"]);
+
+        // Regional variants of one language collapse to a single entry, so
+        // supports_language_selection (len > 1) stays off.
+        let single = speech_analyzer_languages(vec![
+            "en-US".to_string(),
+            "en-GB".to_string(),
+            "en-AU".to_string(),
+        ]);
+        assert_eq!(single, vec!["en"]);
     }
 
     #[test]

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -675,12 +675,11 @@ impl TranscriptionManager {
                 let settings = get_settings(&self.app_handle);
                 let locale =
                     effective_language_for_model(&settings, self.model_manager.as_ref(), model_id);
-                let engine = SpeechAnalyzerEngine::load(&locale, self.app_handle.clone(), model_id)
-                    .map_err(|e| {
-                        let error_msg = format!("Failed to load SpeechAnalyzer: {}", e);
-                        emit_loading_failed(&error_msg);
-                        anyhow::anyhow!(error_msg)
-                    })?;
+                let engine = SpeechAnalyzerEngine::load(&locale).map_err(|e| {
+                    let error_msg = format!("Failed to load SpeechAnalyzer: {}", e);
+                    emit_loading_failed(&error_msg);
+                    anyhow::anyhow!(error_msg)
+                })?;
                 LoadedEngine::SpeechAnalyzer(engine)
             }
         };

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -36,6 +36,8 @@ use transcribe_rs::{
 
 const STREAM_PERF_LOG_INTERVAL: Duration = Duration::from_secs(5);
 const STREAM_FINALIZE_REPLY_TIMEOUT: Duration = Duration::from_secs(30);
+const APPLE_STREAM_CHUNK_SAMPLES: usize = 1_600; // 100 ms at 16 kHz.
+const APPLE_STREAM_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 #[derive(Clone, Debug, Serialize)]
 pub struct ModelStateEvent {
@@ -88,8 +90,8 @@ pub struct StreamPhaseEvent {
 /// is processed before finalize runs.
 enum StreamCmd {
     Feed(Vec<f32>),
-    /// Flush the stream and reply with the final text, or `None` if no stream
-    /// was ever active (caller should fall back to batch transcription).
+    /// Flush the stream and reply with its result, or `None` if no stream was
+    /// ever active (caller should fall back to batch transcription).
     Finalize(mpsc::Sender<Option<String>>),
     Cancel,
 }
@@ -244,8 +246,8 @@ pub struct TranscriptionManager {
     /// [`StreamRouter`]. Shared with the audio recorder so per-frame feeds skip
     /// Tauri state and the manager lock.
     router: Arc<StreamRouter>,
-    /// True only while a transcribe-cpp `Stream` is actually in flight (set by
-    /// the worker once `stream()` succeeds). Used for overlay/UI decisions.
+    /// True only while a native or transcribe-cpp stream is actually in flight
+    /// (set by the worker once startup succeeds). Used for overlay/UI decisions.
     stream_active: Arc<AtomicBool>,
     /// Streaming uses four independent flags: router open = frames should route,
     /// worker active = no second worker may start, engine lease = engine is out
@@ -863,9 +865,22 @@ impl TranscriptionManager {
             }
         };
 
-        // Only transcribe-cpp models expose streaming; ONNX engines fall back to
-        // batch. The loaded session (not the ModelManager copy) is the source of
-        // truth for run-path capabilities.
+        // SpeechAnalyzer exposes its own native incremental input and volatile
+        // result stream. Run it through the same router/overlay contract as
+        // transcribe-cpp, then return the stateless engine before replying so a
+        // failed stream can immediately fall back to batch transcription.
+        if let LoadedEngine::SpeechAnalyzer(speech_analyzer) = &engine {
+            let outcome = self.run_speech_analyzer_stream(speech_analyzer, rx, &model_id);
+            self.return_engine(engine, &model_id);
+            if let Some((reply, result)) = outcome {
+                let _ = reply.send(result);
+            }
+            return;
+        }
+
+        // Transcribe-cpp is the other streaming implementation; ONNX engines
+        // fall back to batch. The loaded session (not the ModelManager copy) is
+        // the source of truth for run-path capabilities.
         let (supports_streaming, supports_translate, languages) = match &engine {
             LoadedEngine::TranscribeCpp(session) => {
                 let model = session.model();
@@ -1044,6 +1059,145 @@ impl TranscriptionManager {
         }
         // `_worker` drops here, clearing this worker's active/lease flags after
         // the engine has been returned to the pool.
+    }
+
+    fn run_speech_analyzer_stream(
+        &self,
+        engine: &SpeechAnalyzerEngine,
+        rx: mpsc::Receiver<StreamCmd>,
+        model_id: &str,
+    ) -> Option<(mpsc::Sender<Option<String>>, Option<String>)> {
+        let settings = get_settings(&self.app_handle);
+        let language =
+            effective_language_for_model(&settings, self.model_manager.as_ref(), model_id);
+        let language = (language != "auto").then_some(language.as_str());
+
+        let mut stream = match engine.start_stream(language) {
+            Ok(stream) => stream,
+            Err(error) => {
+                error!("Failed to begin SpeechAnalyzer stream: {error}");
+                return wait_for_stream_finalize(rx).map(|reply| (reply, None));
+            }
+        };
+
+        self.stream_active.store(true, Ordering::Release);
+        self.touch_activity();
+        info!("Native Apple live transcription started (model '{model_id}')");
+
+        let started = Instant::now();
+        let mut pending_audio = Vec::with_capacity(APPLE_STREAM_CHUNK_SAMPLES * 2);
+        let mut streamed_samples = 0usize;
+        let mut last_revision = 0u64;
+        let mut last_poll = Instant::now();
+
+        loop {
+            let command = rx.recv_timeout(APPLE_STREAM_POLL_INTERVAL);
+            let mut should_poll = false;
+
+            match command {
+                Ok(StreamCmd::Feed(pcm)) => {
+                    streamed_samples += pcm.len();
+                    pending_audio.extend_from_slice(&pcm);
+                    if pending_audio.len() >= APPLE_STREAM_CHUNK_SAMPLES {
+                        let chunk = std::mem::take(&mut pending_audio);
+                        if let Err(error) = stream.feed(&chunk) {
+                            error!("SpeechAnalyzer stream feed failed: {error}");
+                            let _ = stream.cancel();
+                            return wait_for_stream_finalize(rx).map(|reply| (reply, None));
+                        }
+                        pending_audio.reserve(APPLE_STREAM_CHUNK_SAMPLES * 2);
+                        self.touch_activity();
+                        should_poll = true;
+                    }
+                }
+                Ok(StreamCmd::Finalize(reply)) => {
+                    if !pending_audio.is_empty() {
+                        if let Err(error) = stream.feed(&pending_audio) {
+                            error!("SpeechAnalyzer final stream feed failed: {error}");
+                            let _ = stream.cancel();
+                            return Some((reply, None));
+                        }
+                    }
+
+                    let result = match stream.finish() {
+                        Ok(text) => {
+                            info!(
+                                "Native Apple live transcription finalized in {:.2}s for {:.2}s of audio ({} chars)",
+                                started.elapsed().as_secs_f64(),
+                                streamed_samples as f64 / 16_000.0,
+                                text.len()
+                            );
+                            Some(text)
+                        }
+                        Err(error) => {
+                            error!(
+                                "SpeechAnalyzer stream finalize failed: {error}; falling back to batch transcription"
+                            );
+                            None
+                        }
+                    };
+                    return Some((reply, result));
+                }
+                Ok(StreamCmd::Cancel) => {
+                    if let Err(error) = stream.cancel() {
+                        warn!("Failed to cancel SpeechAnalyzer stream: {error}");
+                    }
+                    return None;
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    // Flush a short trailing callback even if it has not reached
+                    // the preferred 100 ms chunk size, then poll for result
+                    // revisions while the speaker pauses.
+                    if !pending_audio.is_empty() {
+                        let chunk = std::mem::take(&mut pending_audio);
+                        if let Err(error) = stream.feed(&chunk) {
+                            error!("SpeechAnalyzer stream feed failed: {error}");
+                            let _ = stream.cancel();
+                            return wait_for_stream_finalize(rx).map(|reply| (reply, None));
+                        }
+                        pending_audio.reserve(APPLE_STREAM_CHUNK_SAMPLES * 2);
+                    }
+                    should_poll = true;
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    let _ = stream.cancel();
+                    return None;
+                }
+            }
+
+            if should_poll && last_poll.elapsed() >= APPLE_STREAM_POLL_INTERVAL {
+                match stream.snapshot() {
+                    Ok(snapshot) => {
+                        for event in &snapshot.events {
+                            debug!(
+                                "Apple live result: revision={} analyzer_elapsed={}ms audio_received={:.2}s final={} chars={} text={:?}",
+                                event.revision,
+                                event.elapsed_ms,
+                                streamed_samples as f64 / 16_000.0,
+                                event.is_final,
+                                event.text.chars().count(),
+                                event.text
+                            );
+                        }
+                        if snapshot.revision != last_revision {
+                            last_revision = snapshot.revision;
+                            debug!(
+                                "Apple live overlay snapshot: committed_chars={} tentative_chars={}",
+                                snapshot.committed.chars().count(),
+                                snapshot.tentative.chars().count()
+                            );
+                            self.emit_stream_text(&snapshot.committed, &snapshot.tentative);
+                        }
+                    }
+                    Err(error) => {
+                        error!("SpeechAnalyzer stream result polling failed: {error}");
+                        let _ = stream.cancel();
+                        return wait_for_stream_finalize(rx).map(|reply| (reply, None));
+                    }
+                }
+                last_poll = Instant::now();
+            }
+        }
     }
 
     /// Return the leased engine to the mutex, unless the model was switched or
@@ -1682,6 +1836,19 @@ fn cpp_translation_task(
     } else {
         (Task::Transcribe, None)
     }
+}
+
+/// Ignore queued audio after a native stream failure, retaining the finalize
+/// reply so the worker can return its engine before requesting batch fallback.
+fn wait_for_stream_finalize(rx: mpsc::Receiver<StreamCmd>) -> Option<mpsc::Sender<Option<String>>> {
+    while let Ok(command) = rx.recv() {
+        match command {
+            StreamCmd::Feed(_) => {}
+            StreamCmd::Finalize(reply) => return Some(reply),
+            StreamCmd::Cancel => return None,
+        }
+    }
+    None
 }
 
 /// Drain a stream command channel, ignoring fed audio, until the caller

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -675,11 +675,12 @@ impl TranscriptionManager {
                 let settings = get_settings(&self.app_handle);
                 let locale =
                     effective_language_for_model(&settings, self.model_manager.as_ref(), model_id);
-                let engine = SpeechAnalyzerEngine::load(&locale).map_err(|e| {
-                    let error_msg = format!("Failed to load SpeechAnalyzer: {}", e);
-                    emit_loading_failed(&error_msg);
-                    anyhow::anyhow!(error_msg)
-                })?;
+                let engine = SpeechAnalyzerEngine::load(&locale, self.app_handle.clone(), model_id)
+                    .map_err(|e| {
+                        let error_msg = format!("Failed to load SpeechAnalyzer: {}", e);
+                        emit_loading_failed(&error_msg);
+                        anyhow::anyhow!(error_msg)
+                    })?;
                 LoadedEngine::SpeechAnalyzer(engine)
             }
         };

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -1076,6 +1076,7 @@ impl TranscriptionManager {
             Ok(stream) => stream,
             Err(error) => {
                 error!("Failed to begin SpeechAnalyzer stream: {error}");
+                self.router.clear();
                 return wait_for_stream_finalize(rx).map(|reply| (reply, None));
             }
         };
@@ -1103,6 +1104,7 @@ impl TranscriptionManager {
                         if let Err(error) = stream.feed(&chunk) {
                             error!("SpeechAnalyzer stream feed failed: {error}");
                             let _ = stream.cancel();
+                            self.router.clear();
                             return wait_for_stream_finalize(rx).map(|reply| (reply, None));
                         }
                         pending_audio.reserve(APPLE_STREAM_CHUNK_SAMPLES * 2);
@@ -1153,6 +1155,7 @@ impl TranscriptionManager {
                         if let Err(error) = stream.feed(&chunk) {
                             error!("SpeechAnalyzer stream feed failed: {error}");
                             let _ = stream.cancel();
+                            self.router.clear();
                             return wait_for_stream_finalize(rx).map(|reply| (reply, None));
                         }
                         pending_audio.reserve(APPLE_STREAM_CHUNK_SAMPLES * 2);
@@ -1170,13 +1173,12 @@ impl TranscriptionManager {
                     Ok(snapshot) => {
                         for event in &snapshot.events {
                             debug!(
-                                "Apple live result: revision={} analyzer_elapsed={}ms audio_received={:.2}s final={} chars={} text={:?}",
+                                "Apple live result: revision={} analyzer_elapsed={}ms audio_received={:.2}s final={} chars={}",
                                 event.revision,
                                 event.elapsed_ms,
                                 streamed_samples as f64 / 16_000.0,
                                 event.is_final,
-                                event.text.chars().count(),
-                                event.text
+                                event.text.chars().count()
                             );
                         }
                         if snapshot.revision != last_revision {
@@ -1192,6 +1194,7 @@ impl TranscriptionManager {
                     Err(error) => {
                         error!("SpeechAnalyzer stream result polling failed: {error}");
                         let _ = stream.cancel();
+                        self.router.clear();
                         return wait_for_stream_finalize(rx).map(|reply| (reply, None));
                     }
                 }
@@ -1856,15 +1859,8 @@ fn wait_for_stream_finalize(rx: mpsc::Receiver<StreamCmd>) -> Option<mpsc::Sende
 /// loaded / not streaming-capable) so the finalize handshake still completes
 /// and the caller falls back to batch transcription.
 fn drain_until_finalize(rx: mpsc::Receiver<StreamCmd>) {
-    while let Ok(cmd) = rx.recv() {
-        match cmd {
-            StreamCmd::Feed(_) => {}
-            StreamCmd::Finalize(reply) => {
-                let _ = reply.send(None);
-                break;
-            }
-            StreamCmd::Cancel => break,
-        }
+    if let Some(reply) = wait_for_stream_finalize(rx) {
+        let _ = reply.send(None);
     }
 }
 

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -5,6 +5,7 @@ use crate::settings::{
     get_settings, AppSettings, ModelUnloadTimeout, OrtAcceleratorSetting,
     TranscribeAcceleratorSetting,
 };
+use crate::speech_analyzer::SpeechAnalyzerEngine;
 use anyhow::Result;
 use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
@@ -168,6 +169,9 @@ enum LoadedEngine {
     GigaAM(GigaAMModel),
     Canary(CanaryModel),
     Cohere(CohereModel),
+    /// Apple's on-device SpeechAnalyzer (macOS 26+); the OS holds the actual
+    /// model, so this only carries the locale.
+    SpeechAnalyzer(SpeechAnalyzerEngine),
 }
 
 /// RAII guard that clears the `is_loading` flag and notifies waiters on drop.
@@ -497,7 +501,12 @@ impl TranscriptionManager {
             return Err(anyhow::anyhow!(error_msg));
         }
 
-        let model_path = self.model_manager.get_model_path(model_id)?;
+        // SpeechAnalyzer has no model file; the OS manages its assets.
+        let model_path = if matches!(model_info.engine_type, EngineType::SpeechAnalyzer) {
+            std::path::PathBuf::new()
+        } else {
+            self.model_manager.get_model_path(model_id)?
+        };
 
         // Drop the current engine BEFORE building the new one so transcribe-cpp
         // frees the previous native context first — avoids holding two models at
@@ -659,6 +668,20 @@ impl TranscriptionManager {
                 })?;
                 LoadedEngine::Cohere(engine)
             }
+            EngineType::SpeechAnalyzer => {
+                // Resolve the user's language intent to a locale now so asset
+                // installation (OS-managed download) happens during load, not
+                // on the first dictation.
+                let settings = get_settings(&self.app_handle);
+                let locale =
+                    effective_language_for_model(&settings, self.model_manager.as_ref(), model_id);
+                let engine = SpeechAnalyzerEngine::load(&locale).map_err(|e| {
+                    let error_msg = format!("Failed to load SpeechAnalyzer: {}", e);
+                    emit_loading_failed(&error_msg);
+                    anyhow::anyhow!(error_msg)
+                })?;
+                LoadedEngine::SpeechAnalyzer(engine)
+            }
         };
 
         // Update the current engine and model ID
@@ -739,6 +762,7 @@ impl TranscriptionManager {
             Some(LoadedEngine::TranscribeCpp(session)) => {
                 Some(session.model().backend().to_string())
             }
+            Some(LoadedEngine::SpeechAnalyzer(_)) => Some("speechanalyzer".to_string()),
             Some(_) => Some("onnx".to_string()),
             None => None,
         }
@@ -1336,6 +1360,18 @@ impl TranscriptionManager {
                             .transcribe(&audio, &options)
                             .map(|r| r.text)
                             .map_err(|e| anyhow::anyhow!("Cohere transcription failed: {}", e))
+                    }
+                    LoadedEngine::SpeechAnalyzer(speech_analyzer_engine) => {
+                        let lang = if validated_language == "auto" {
+                            None
+                        } else {
+                            Some(validated_language.as_str())
+                        };
+                        speech_analyzer_engine
+                            .transcribe(&audio, lang)
+                            .map_err(|e| {
+                                anyhow::anyhow!("SpeechAnalyzer transcription failed: {}", e)
+                            })
                     }
                 }
             }));

--- a/src-tauri/src/speech_analyzer.rs
+++ b/src-tauri/src/speech_analyzer.rs
@@ -190,7 +190,7 @@ impl SpeechAnalyzerEngine {
     pub fn load(locale: &str, app_handle: AppHandle, model_id: &str) -> Result<Self, String> {
         if !ffi::available() {
             return Err(
-                "SpeechTranscriber requires a compatible Apple Silicon Mac running macOS 26 or newer."
+                "Apple speech recognition requires a compatible Apple Silicon Mac running macOS 26 or newer."
                     .to_string(),
             );
         }
@@ -220,6 +220,67 @@ impl SpeechAnalyzerEngine {
             .locale
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner()) = locale.clone();
-        ffi::transcribe(samples, &locale)
+        ffi::transcribe(samples, &locale).map(|text| capitalize_sentence_starts(&text))
+    }
+}
+
+/// SpeechTranscriber punctuates well but leaves sentence starts lowercase
+/// (its `TranscriptionOption` set has no casing knob), so uppercase the first
+/// letter of the text and of each sentence after `.`, `!`, `?`, or `…`.
+/// A no-op for uncased scripts and for already-capitalized letters.
+fn capitalize_sentence_starts(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut at_sentence_start = true;
+    let mut chars = text.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if at_sentence_start && c.is_alphabetic() {
+            result.extend(c.to_uppercase());
+            at_sentence_start = false;
+            continue;
+        }
+        // Punctuation counts as a sentence end only when followed by
+        // whitespace (or end of text) so decimals like "3.5" stay intact.
+        // Quotes and brackets pass through without consuming the sentence
+        // start; anything else (digits, mid-sentence letters) consumes it.
+        if matches!(c, '.' | '!' | '?' | '…')
+            && chars.peek().is_none_or(|next| next.is_whitespace())
+        {
+            at_sentence_start = true;
+        } else if !c.is_whitespace() && !matches!(c, '"' | '\'' | '“' | '”' | '(' | '[') {
+            at_sentence_start = false;
+        }
+        result.push(c);
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::capitalize_sentence_starts;
+
+    #[test]
+    fn capitalizes_first_letter_and_after_sentence_punctuation() {
+        assert_eq!(
+            capitalize_sentence_starts("hello there. how are you? great! okay"),
+            "Hello there. How are you? Great! Okay"
+        );
+    }
+
+    #[test]
+    fn ignores_decimals_and_leaves_numbers_alone() {
+        assert_eq!(
+            capitalize_sentence_starts("it costs 3.5 dollars. 6 people paid"),
+            "It costs 3.5 dollars. 6 people paid"
+        );
+    }
+
+    #[test]
+    fn capitalizes_through_opening_quotes() {
+        assert_eq!(
+            capitalize_sentence_starts("she said. \"hello world\""),
+            "She said. \"Hello world\""
+        );
     }
 }

--- a/src-tauri/src/speech_analyzer.rs
+++ b/src-tauri/src/speech_analyzer.rs
@@ -2,13 +2,15 @@
 //! The Swift side is compiled by build.rs (see swift/speech_analyzer.swift);
 //! on unsupported platforms every call reports unavailable.
 
+use serde::Deserialize;
+use std::ffi::c_void;
 use std::sync::Mutex;
 
 pub const MODEL_ID: &str = "apple-speechanalyzer";
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 mod ffi {
-    use std::ffi::{c_char, c_float, c_int, CStr, CString};
+    use std::ffi::{c_char, c_float, c_int, c_void, CStr, CString};
 
     #[repr(C)]
     pub struct SpeechAnalyzerResponse {
@@ -26,6 +28,19 @@ mod ffi {
             sample_count: c_int,
             locale_id: *const c_char,
         ) -> *mut SpeechAnalyzerResponse;
+        fn speech_analyzer_stream_start(
+            locale_id: *const c_char,
+            stream_out: *mut *mut c_void,
+        ) -> *mut SpeechAnalyzerResponse;
+        fn speech_analyzer_stream_feed(
+            stream: *mut c_void,
+            samples: *const c_float,
+            sample_count: c_int,
+        ) -> *mut SpeechAnalyzerResponse;
+        fn speech_analyzer_stream_snapshot(stream: *mut c_void) -> *mut SpeechAnalyzerResponse;
+        fn speech_analyzer_stream_finish(stream: *mut c_void) -> *mut SpeechAnalyzerResponse;
+        fn speech_analyzer_stream_cancel(stream: *mut c_void) -> *mut SpeechAnalyzerResponse;
+        fn free_speech_analyzer_stream(stream: *mut c_void);
         fn free_speech_analyzer_response(response: *mut SpeechAnalyzerResponse);
     }
 
@@ -85,10 +100,47 @@ mod ffi {
             unsafe { speech_analyzer_transcribe(samples.as_ptr(), count, locale_cstr.as_ptr()) };
         consume_response(ptr)
     }
+
+    pub fn stream_start(locale: &str) -> Result<*mut c_void, String> {
+        let locale_cstr = CString::new(locale).map_err(|e| e.to_string())?;
+        let mut stream = std::ptr::null_mut();
+        let response = unsafe { speech_analyzer_stream_start(locale_cstr.as_ptr(), &mut stream) };
+        consume_response(response)?;
+        if stream.is_null() {
+            Err("SpeechAnalyzer returned a null stream".to_string())
+        } else {
+            Ok(stream)
+        }
+    }
+
+    pub fn stream_feed(stream: *mut c_void, samples: &[f32]) -> Result<(), String> {
+        let count = c_int::try_from(samples.len())
+            .map_err(|_| "Audio chunk too long for SpeechAnalyzer bridge".to_string())?;
+        let response = unsafe { speech_analyzer_stream_feed(stream, samples.as_ptr(), count) };
+        consume_response(response).map(|_| ())
+    }
+
+    pub fn stream_snapshot(stream: *mut c_void) -> Result<String, String> {
+        consume_response(unsafe { speech_analyzer_stream_snapshot(stream) })
+    }
+
+    pub fn stream_finish(stream: *mut c_void) -> Result<String, String> {
+        consume_response(unsafe { speech_analyzer_stream_finish(stream) })
+    }
+
+    pub fn stream_cancel(stream: *mut c_void) -> Result<(), String> {
+        consume_response(unsafe { speech_analyzer_stream_cancel(stream) }).map(|_| ())
+    }
+
+    pub unsafe fn stream_free(stream: *mut c_void) {
+        unsafe { free_speech_analyzer_stream(stream) };
+    }
 }
 
 #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
 mod ffi {
+    use std::ffi::c_void;
+
     pub fn available() -> bool {
         false
     }
@@ -104,6 +156,28 @@ mod ffi {
     pub fn transcribe(_samples: &[f32], _locale: &str) -> Result<String, String> {
         Err("SpeechAnalyzer is only available on Apple Silicon macOS".to_string())
     }
+
+    pub fn stream_start(_locale: &str) -> Result<*mut c_void, String> {
+        Err("SpeechAnalyzer is only available on Apple Silicon macOS".to_string())
+    }
+
+    pub fn stream_feed(_stream: *mut c_void, _samples: &[f32]) -> Result<(), String> {
+        Err("SpeechAnalyzer is only available on Apple Silicon macOS".to_string())
+    }
+
+    pub fn stream_snapshot(_stream: *mut c_void) -> Result<String, String> {
+        Err("SpeechAnalyzer is only available on Apple Silicon macOS".to_string())
+    }
+
+    pub fn stream_finish(_stream: *mut c_void) -> Result<String, String> {
+        Err("SpeechAnalyzer is only available on Apple Silicon macOS".to_string())
+    }
+
+    pub fn stream_cancel(_stream: *mut c_void) -> Result<(), String> {
+        Err("SpeechAnalyzer is only available on Apple Silicon macOS".to_string())
+    }
+
+    pub unsafe fn stream_free(_stream: *mut c_void) {}
 }
 
 pub fn is_available() -> bool {
@@ -114,9 +188,68 @@ pub fn supported_locales() -> Result<Vec<String>, String> {
     ffi::supported_locales()
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpeechAnalyzerStreamResultEvent {
+    pub revision: u64,
+    pub elapsed_ms: u64,
+    pub is_final: bool,
+    pub text: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SpeechAnalyzerStreamSnapshot {
+    pub revision: u64,
+    pub committed: String,
+    pub tentative: String,
+    pub events: Vec<SpeechAnalyzerStreamResultEvent>,
+}
+
+pub struct SpeechAnalyzerStream {
+    handle: *mut c_void,
+    finished: bool,
+}
+
+impl SpeechAnalyzerStream {
+    pub fn feed(&mut self, samples: &[f32]) -> Result<(), String> {
+        ffi::stream_feed(self.handle, samples)
+    }
+
+    pub fn snapshot(&self) -> Result<SpeechAnalyzerStreamSnapshot, String> {
+        let json = ffi::stream_snapshot(self.handle)?;
+        serde_json::from_str(&json)
+            .map_err(|error| format!("Invalid SpeechAnalyzer stream snapshot: {error}"))
+    }
+
+    pub fn finish(&mut self) -> Result<String, String> {
+        let result = ffi::stream_finish(self.handle);
+        self.finished = true;
+        result
+    }
+
+    pub fn cancel(&mut self) -> Result<(), String> {
+        let result = ffi::stream_cancel(self.handle);
+        self.finished = true;
+        result
+    }
+}
+
+impl Drop for SpeechAnalyzerStream {
+    fn drop(&mut self) {
+        if self.handle.is_null() {
+            return;
+        }
+        if !self.finished {
+            let _ = ffi::stream_cancel(self.handle);
+        }
+        unsafe { ffi::stream_free(self.handle) };
+        self.handle = std::ptr::null_mut();
+    }
+}
+
 /// Handle held by the transcription manager while the SpeechAnalyzer "model"
-/// is loaded. The Swift side is stateless per call, so this only carries the
-/// resolved locale.
+/// is loaded. Batch calls create short-lived analyzers; live transcription
+/// creates a separate [`SpeechAnalyzerStream`] while retaining this locale.
 pub struct SpeechAnalyzerEngine {
     locale: Mutex<String>,
 }
@@ -138,97 +271,44 @@ impl SpeechAnalyzerEngine {
         })
     }
 
-    /// Transcribe 16 kHz mono f32 PCM. `language` overrides the load-time
-    /// locale when the user changed it between load and dictation.
-    pub fn transcribe(&self, samples: &[f32], language: Option<&str>) -> Result<String, String> {
-        let locale = language.map(str::to_string).unwrap_or_else(|| {
+    fn resolve_locale(&self, language: Option<&str>) -> String {
+        language.map(str::to_string).unwrap_or_else(|| {
             self.locale
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .clone()
-        });
+        })
+    }
 
+    fn prepare_locale(&self, locale: &str) -> Result<(), String> {
         // AssetInventory may retire an unused asset between runs, and the user
         // may have changed languages since load. Rechecking is cheap when the
         // asset is installed and re-downloads it when the OS evicted it.
-        ffi::prepare(&locale)?;
+        ffi::prepare(locale)?;
         *self
             .locale
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner()) = locale.clone();
-        ffi::transcribe(samples, &locale).map(|text| capitalize_sentence_starts(&text))
-    }
-}
-
-/// SpeechTranscriber punctuates well but leaves sentence starts lowercase
-/// (its `TranscriptionOption` set has no casing knob), so uppercase the first
-/// letter of the text and of each sentence after `.`, `!`, `?`, or `…`.
-/// A no-op for uncased scripts and for already-capitalized letters.
-fn capitalize_sentence_starts(text: &str) -> String {
-    let mut result = String::with_capacity(text.len());
-    let mut at_sentence_start = true;
-    let mut chars = text.chars().peekable();
-
-    while let Some(c) = chars.next() {
-        if at_sentence_start && c.is_alphabetic() {
-            result.extend(c.to_uppercase());
-            at_sentence_start = false;
-            continue;
-        }
-        // Punctuation counts as a sentence end only when followed by
-        // whitespace (or end of text) so decimals like "3.5" stay intact.
-        // Quotes and brackets pass through without consuming the sentence
-        // start; anything else (digits, mid-sentence letters) consumes it.
-        if matches!(c, '.' | '!' | '?' | '…')
-            && chars.peek().is_none_or(|next| next.is_whitespace())
-        {
-            at_sentence_start = true;
-        } else if !c.is_whitespace() && !matches!(c, '"' | '\'' | '“' | '”' | '(' | '[') {
-            at_sentence_start = false;
-        }
-        result.push(c);
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = locale.to_string();
+        Ok(())
     }
 
-    result
-}
-
-#[cfg(test)]
-mod tests {
-    use super::capitalize_sentence_starts;
-
-    #[test]
-    fn capitalizes_first_letter_and_after_sentence_punctuation() {
-        assert_eq!(
-            capitalize_sentence_starts("hello there. how are you? great! okay"),
-            "Hello there. How are you? Great! Okay"
-        );
+    /// Transcribe 16 kHz mono f32 PCM. `language` overrides the load-time
+    /// locale when the user changed it between load and dictation.
+    pub fn transcribe(&self, samples: &[f32], language: Option<&str>) -> Result<String, String> {
+        let locale = self.resolve_locale(language);
+        self.prepare_locale(&locale)?;
+        ffi::transcribe(samples, &locale)
     }
 
-    #[test]
-    fn ignores_decimals_and_leaves_numbers_alone() {
-        assert_eq!(
-            capitalize_sentence_starts("it costs 3.5 dollars. 6 people paid"),
-            "It costs 3.5 dollars. 6 people paid"
-        );
-    }
-
-    #[test]
-    fn capitalizes_through_opening_quotes() {
-        assert_eq!(
-            capitalize_sentence_starts("she said. \"hello world\""),
-            "She said. \"Hello world\""
-        );
-    }
-
-    #[test]
-    fn treats_ellipsis_as_sentence_end() {
-        // `…` is in the sentence-end matcher alongside `.!?` — SpeechTranscriber
-        // emits it for trailing-off speech. Pinned separately because it's the
-        // one member of that set a rewrite of the matcher would most plausibly
-        // drop (it's easy to forget it's a single char, not three dots).
-        assert_eq!(
-            capitalize_sentence_starts("well… maybe tomorrow"),
-            "Well… Maybe tomorrow"
-        );
+    /// Start a long-lived analyzer session that accepts incremental audio and
+    /// exposes final plus volatile transcription snapshots.
+    pub fn start_stream(&self, language: Option<&str>) -> Result<SpeechAnalyzerStream, String> {
+        let locale = self.resolve_locale(language);
+        self.prepare_locale(&locale)?;
+        let handle = ffi::stream_start(&locale)?;
+        Ok(SpeechAnalyzerStream {
+            handle,
+            finished: false,
+        })
     }
 }

--- a/src-tauri/src/speech_analyzer.rs
+++ b/src-tauri/src/speech_analyzer.rs
@@ -2,18 +2,13 @@
 //! The Swift side is compiled by build.rs (see swift/speech_analyzer.swift);
 //! on unsupported platforms every call reports unavailable.
 
-use crate::managers::model::DownloadProgress;
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Mutex,
-};
-use tauri::{AppHandle, Emitter};
+use std::sync::Mutex;
 
 pub const MODEL_ID: &str = "apple-speechanalyzer";
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 mod ffi {
-    use std::ffi::{c_char, c_double, c_float, c_int, c_void, CStr, CString};
+    use std::ffi::{c_char, c_float, c_int, CStr, CString};
 
     #[repr(C)]
     pub struct SpeechAnalyzerResponse {
@@ -22,26 +17,10 @@ mod ffi {
         pub error_message: *mut c_char,
     }
 
-    type ProgressCallback = unsafe extern "C" fn(c_double, *mut c_void);
-
-    struct ProgressContext<'a> {
-        callback: &'a (dyn Fn(f64) + Sync),
-    }
-
-    unsafe extern "C" fn report_progress(fraction: c_double, context: *mut c_void) {
-        if let Some(context) = (context as *const ProgressContext<'_>).as_ref() {
-            (context.callback)(fraction);
-        }
-    }
-
     extern "C" {
         fn is_speech_analyzer_available() -> c_int;
         fn speech_analyzer_supported_locales() -> *mut SpeechAnalyzerResponse;
-        fn speech_analyzer_prepare(
-            locale_id: *const c_char,
-            progress_callback: Option<ProgressCallback>,
-            progress_context: *mut c_void,
-        ) -> *mut SpeechAnalyzerResponse;
+        fn speech_analyzer_prepare(locale_id: *const c_char) -> *mut SpeechAnalyzerResponse;
         fn speech_analyzer_transcribe(
             samples: *const c_float,
             sample_count: c_int,
@@ -92,18 +71,9 @@ mod ffi {
         result
     }
 
-    pub fn prepare(locale: &str, progress_callback: &(dyn Fn(f64) + Sync)) -> Result<(), String> {
+    pub fn prepare(locale: &str) -> Result<(), String> {
         let locale_cstr = CString::new(locale).map_err(|e| e.to_string())?;
-        let context = ProgressContext {
-            callback: progress_callback,
-        };
-        let ptr = unsafe {
-            speech_analyzer_prepare(
-                locale_cstr.as_ptr(),
-                Some(report_progress),
-                (&context as *const ProgressContext<'_>).cast_mut().cast(),
-            )
-        };
+        let ptr = unsafe { speech_analyzer_prepare(locale_cstr.as_ptr()) };
         consume_response(ptr).map(|_| ())
     }
 
@@ -127,7 +97,7 @@ mod ffi {
         Err("SpeechAnalyzer is only available on Apple Silicon macOS".to_string())
     }
 
-    pub fn prepare(_locale: &str, _progress_callback: &(dyn Fn(f64) + Sync)) -> Result<(), String> {
+    pub fn prepare(_locale: &str) -> Result<(), String> {
         Err("SpeechAnalyzer is only available on Apple Silicon macOS".to_string())
     }
 
@@ -149,56 +119,22 @@ pub fn supported_locales() -> Result<Vec<String>, String> {
 /// resolved locale.
 pub struct SpeechAnalyzerEngine {
     locale: Mutex<String>,
-    app_handle: AppHandle,
-    model_id: String,
 }
 
 impl SpeechAnalyzerEngine {
-    fn prepare_assets(app_handle: &AppHandle, model_id: &str, locale: &str) -> Result<(), String> {
-        let installation_started = AtomicBool::new(false);
-        let report_progress = |fraction: f64| {
-            installation_started.store(true, Ordering::Release);
-            let total = 1_000_u64;
-            let downloaded = (fraction.clamp(0.0, 1.0) * total as f64).round() as u64;
-            let _ = app_handle.emit(
-                "model-download-progress",
-                DownloadProgress {
-                    model_id: model_id.to_string(),
-                    downloaded,
-                    total,
-                    percentage: fraction.clamp(0.0, 1.0) * 100.0,
-                },
-            );
-        };
-
-        let result = ffi::prepare(locale, &report_progress);
-        if installation_started.load(Ordering::Acquire) {
-            match &result {
-                Ok(()) => {
-                    let _ = app_handle.emit("model-preparation-complete", model_id);
-                }
-                Err(_) => {
-                    let _ = app_handle.emit("model-preparation-failed", model_id);
-                }
-            }
-        }
-        result
-    }
-
     /// Verify availability and trigger the OS-managed asset download for the
-    /// locale so the first transcription doesn't stall on it.
-    pub fn load(locale: &str, app_handle: AppHandle, model_id: &str) -> Result<Self, String> {
+    /// locale (blocking; the model card shows its loading state meanwhile) so
+    /// the first transcription doesn't stall on it.
+    pub fn load(locale: &str) -> Result<Self, String> {
         if !ffi::available() {
             return Err(
                 "Apple speech recognition requires a compatible Apple Silicon Mac running macOS 26 or newer."
                     .to_string(),
             );
         }
-        Self::prepare_assets(&app_handle, model_id, locale)?;
+        ffi::prepare(locale)?;
         Ok(Self {
             locale: Mutex::new(locale.to_string()),
-            app_handle,
-            model_id: model_id.to_string(),
         })
     }
 
@@ -214,8 +150,8 @@ impl SpeechAnalyzerEngine {
 
         // AssetInventory may retire an unused asset between runs, and the user
         // may have changed languages since load. Rechecking is cheap when the
-        // asset is installed and gives progress when the OS needs to fetch it.
-        Self::prepare_assets(&self.app_handle, &self.model_id, &locale)?;
+        // asset is installed and re-downloads it when the OS evicted it.
+        ffi::prepare(&locale)?;
         *self
             .locale
             .lock()

--- a/src-tauri/src/speech_analyzer.rs
+++ b/src-tauri/src/speech_analyzer.rs
@@ -1,0 +1,119 @@
+//! FFI wrapper for Apple's SpeechAnalyzer API (Speech framework, macOS 26+).
+//! The Swift side is compiled by build.rs (see swift/speech_analyzer.swift);
+//! on unsupported platforms every call reports unavailable.
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+mod ffi {
+    use std::ffi::{c_char, c_float, c_int, CStr, CString};
+
+    #[repr(C)]
+    pub struct SpeechAnalyzerResponse {
+        pub text: *mut c_char,
+        pub success: c_int,
+        pub error_message: *mut c_char,
+    }
+
+    extern "C" {
+        fn is_speech_analyzer_available() -> c_int;
+        fn speech_analyzer_prepare(locale_id: *const c_char) -> *mut SpeechAnalyzerResponse;
+        fn speech_analyzer_transcribe(
+            samples: *const c_float,
+            sample_count: c_int,
+            locale_id: *const c_char,
+        ) -> *mut SpeechAnalyzerResponse;
+        fn free_speech_analyzer_response(response: *mut SpeechAnalyzerResponse);
+    }
+
+    pub fn available() -> bool {
+        unsafe { is_speech_analyzer_available() == 1 }
+    }
+
+    /// Consume a Swift-allocated response into a Result, always freeing it.
+    fn consume_response(ptr: *mut SpeechAnalyzerResponse) -> Result<String, String> {
+        if ptr.is_null() {
+            return Err("Null response from SpeechAnalyzer".to_string());
+        }
+        let response = unsafe { &*ptr };
+        let result = if response.success == 1 {
+            if response.text.is_null() {
+                Ok(String::new())
+            } else {
+                Ok(unsafe { CStr::from_ptr(response.text) }
+                    .to_string_lossy()
+                    .into_owned())
+            }
+        } else {
+            let error = if response.error_message.is_null() {
+                "Unknown SpeechAnalyzer error".to_string()
+            } else {
+                unsafe { CStr::from_ptr(response.error_message) }
+                    .to_string_lossy()
+                    .into_owned()
+            };
+            Err(error)
+        };
+        unsafe { free_speech_analyzer_response(ptr) };
+        result
+    }
+
+    pub fn prepare(locale: &str) -> Result<(), String> {
+        let locale_cstr = CString::new(locale).map_err(|e| e.to_string())?;
+        let ptr = unsafe { speech_analyzer_prepare(locale_cstr.as_ptr()) };
+        consume_response(ptr).map(|_| ())
+    }
+
+    pub fn transcribe(samples: &[f32], locale: &str) -> Result<String, String> {
+        let locale_cstr = CString::new(locale).map_err(|e| e.to_string())?;
+        let count = c_int::try_from(samples.len())
+            .map_err(|_| "Audio too long for SpeechAnalyzer bridge".to_string())?;
+        let ptr =
+            unsafe { speech_analyzer_transcribe(samples.as_ptr(), count, locale_cstr.as_ptr()) };
+        consume_response(ptr)
+    }
+}
+
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+mod ffi {
+    pub fn available() -> bool {
+        false
+    }
+
+    pub fn prepare(_locale: &str) -> Result<(), String> {
+        Err("SpeechAnalyzer is only available on Apple Silicon macOS".to_string())
+    }
+
+    pub fn transcribe(_samples: &[f32], _locale: &str) -> Result<String, String> {
+        Err("SpeechAnalyzer is only available on Apple Silicon macOS".to_string())
+    }
+}
+
+pub fn is_available() -> bool {
+    ffi::available()
+}
+
+/// Handle held by the transcription manager while the SpeechAnalyzer "model"
+/// is loaded. The Swift side is stateless per call, so this only carries the
+/// resolved locale.
+pub struct SpeechAnalyzerEngine {
+    locale: String,
+}
+
+impl SpeechAnalyzerEngine {
+    /// Verify availability and trigger the OS-managed asset download for the
+    /// locale so the first transcription doesn't stall on it.
+    pub fn load(locale: &str) -> Result<Self, String> {
+        if !ffi::available() {
+            return Err("SpeechAnalyzer requires macOS 26 or newer.".to_string());
+        }
+        ffi::prepare(locale)?;
+        Ok(Self {
+            locale: locale.to_string(),
+        })
+    }
+
+    /// Transcribe 16 kHz mono f32 PCM. `language` overrides the load-time
+    /// locale when the user changed it between load and dictation.
+    pub fn transcribe(&self, samples: &[f32], language: Option<&str>) -> Result<String, String> {
+        ffi::transcribe(samples, language.unwrap_or(&self.locale))
+    }
+}

--- a/src-tauri/src/speech_analyzer.rs
+++ b/src-tauri/src/speech_analyzer.rs
@@ -2,9 +2,18 @@
 //! The Swift side is compiled by build.rs (see swift/speech_analyzer.swift);
 //! on unsupported platforms every call reports unavailable.
 
+use crate::managers::model::DownloadProgress;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Mutex,
+};
+use tauri::{AppHandle, Emitter};
+
+pub const MODEL_ID: &str = "apple-speechanalyzer";
+
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 mod ffi {
-    use std::ffi::{c_char, c_float, c_int, CStr, CString};
+    use std::ffi::{c_char, c_double, c_float, c_int, c_void, CStr, CString};
 
     #[repr(C)]
     pub struct SpeechAnalyzerResponse {
@@ -13,9 +22,26 @@ mod ffi {
         pub error_message: *mut c_char,
     }
 
+    type ProgressCallback = unsafe extern "C" fn(c_double, *mut c_void);
+
+    struct ProgressContext<'a> {
+        callback: &'a (dyn Fn(f64) + Sync),
+    }
+
+    unsafe extern "C" fn report_progress(fraction: c_double, context: *mut c_void) {
+        if let Some(context) = (context as *const ProgressContext<'_>).as_ref() {
+            (context.callback)(fraction);
+        }
+    }
+
     extern "C" {
         fn is_speech_analyzer_available() -> c_int;
-        fn speech_analyzer_prepare(locale_id: *const c_char) -> *mut SpeechAnalyzerResponse;
+        fn speech_analyzer_supported_locales() -> *mut SpeechAnalyzerResponse;
+        fn speech_analyzer_prepare(
+            locale_id: *const c_char,
+            progress_callback: Option<ProgressCallback>,
+            progress_context: *mut c_void,
+        ) -> *mut SpeechAnalyzerResponse;
         fn speech_analyzer_transcribe(
             samples: *const c_float,
             sample_count: c_int,
@@ -26,6 +52,16 @@ mod ffi {
 
     pub fn available() -> bool {
         unsafe { is_speech_analyzer_available() == 1 }
+    }
+
+    pub fn supported_locales() -> Result<Vec<String>, String> {
+        let response = consume_response(unsafe { speech_analyzer_supported_locales() })?;
+        Ok(response
+            .lines()
+            .map(str::trim)
+            .filter(|locale| !locale.is_empty())
+            .map(str::to_string)
+            .collect())
     }
 
     /// Consume a Swift-allocated response into a Result, always freeing it.
@@ -56,9 +92,18 @@ mod ffi {
         result
     }
 
-    pub fn prepare(locale: &str) -> Result<(), String> {
+    pub fn prepare(locale: &str, progress_callback: &(dyn Fn(f64) + Sync)) -> Result<(), String> {
         let locale_cstr = CString::new(locale).map_err(|e| e.to_string())?;
-        let ptr = unsafe { speech_analyzer_prepare(locale_cstr.as_ptr()) };
+        let context = ProgressContext {
+            callback: progress_callback,
+        };
+        let ptr = unsafe {
+            speech_analyzer_prepare(
+                locale_cstr.as_ptr(),
+                Some(report_progress),
+                (&context as *const ProgressContext<'_>).cast_mut().cast(),
+            )
+        };
         consume_response(ptr).map(|_| ())
     }
 
@@ -78,7 +123,11 @@ mod ffi {
         false
     }
 
-    pub fn prepare(_locale: &str) -> Result<(), String> {
+    pub fn supported_locales() -> Result<Vec<String>, String> {
+        Err("SpeechAnalyzer is only available on Apple Silicon macOS".to_string())
+    }
+
+    pub fn prepare(_locale: &str, _progress_callback: &(dyn Fn(f64) + Sync)) -> Result<(), String> {
         Err("SpeechAnalyzer is only available on Apple Silicon macOS".to_string())
     }
 
@@ -91,29 +140,86 @@ pub fn is_available() -> bool {
     ffi::available()
 }
 
+pub fn supported_locales() -> Result<Vec<String>, String> {
+    ffi::supported_locales()
+}
+
 /// Handle held by the transcription manager while the SpeechAnalyzer "model"
 /// is loaded. The Swift side is stateless per call, so this only carries the
 /// resolved locale.
 pub struct SpeechAnalyzerEngine {
-    locale: String,
+    locale: Mutex<String>,
+    app_handle: AppHandle,
+    model_id: String,
 }
 
 impl SpeechAnalyzerEngine {
+    fn prepare_assets(app_handle: &AppHandle, model_id: &str, locale: &str) -> Result<(), String> {
+        let installation_started = AtomicBool::new(false);
+        let report_progress = |fraction: f64| {
+            installation_started.store(true, Ordering::Release);
+            let total = 1_000_u64;
+            let downloaded = (fraction.clamp(0.0, 1.0) * total as f64).round() as u64;
+            let _ = app_handle.emit(
+                "model-download-progress",
+                DownloadProgress {
+                    model_id: model_id.to_string(),
+                    downloaded,
+                    total,
+                    percentage: fraction.clamp(0.0, 1.0) * 100.0,
+                },
+            );
+        };
+
+        let result = ffi::prepare(locale, &report_progress);
+        if installation_started.load(Ordering::Acquire) {
+            match &result {
+                Ok(()) => {
+                    let _ = app_handle.emit("model-preparation-complete", model_id);
+                }
+                Err(_) => {
+                    let _ = app_handle.emit("model-preparation-failed", model_id);
+                }
+            }
+        }
+        result
+    }
+
     /// Verify availability and trigger the OS-managed asset download for the
     /// locale so the first transcription doesn't stall on it.
-    pub fn load(locale: &str) -> Result<Self, String> {
+    pub fn load(locale: &str, app_handle: AppHandle, model_id: &str) -> Result<Self, String> {
         if !ffi::available() {
-            return Err("SpeechAnalyzer requires macOS 26 or newer.".to_string());
+            return Err(
+                "SpeechTranscriber requires a compatible Apple Silicon Mac running macOS 26 or newer."
+                    .to_string(),
+            );
         }
-        ffi::prepare(locale)?;
+        Self::prepare_assets(&app_handle, model_id, locale)?;
         Ok(Self {
-            locale: locale.to_string(),
+            locale: Mutex::new(locale.to_string()),
+            app_handle,
+            model_id: model_id.to_string(),
         })
     }
 
     /// Transcribe 16 kHz mono f32 PCM. `language` overrides the load-time
     /// locale when the user changed it between load and dictation.
     pub fn transcribe(&self, samples: &[f32], language: Option<&str>) -> Result<String, String> {
-        ffi::transcribe(samples, language.unwrap_or(&self.locale))
+        let locale = language.map(str::to_string).unwrap_or_else(|| {
+            self.locale
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone()
+        });
+
+        // AssetInventory may retire an unused asset between runs, and the user
+        // may have changed languages since load. Rechecking is cheap when the
+        // asset is installed and gives progress when the OS needs to fetch it.
+        Self::prepare_assets(&self.app_handle, &self.model_id, &locale)?;
+        *self
+            .locale
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = locale.clone();
+        ffi::transcribe(samples, &locale)
     }
 }

--- a/src-tauri/src/speech_analyzer.rs
+++ b/src-tauri/src/speech_analyzer.rs
@@ -219,4 +219,16 @@ mod tests {
             "She said. \"Hello world\""
         );
     }
+
+    #[test]
+    fn treats_ellipsis_as_sentence_end() {
+        // `…` is in the sentence-end matcher alongside `.!?` — SpeechTranscriber
+        // emits it for trailing-off speech. Pinned separately because it's the
+        // one member of that set a rewrite of the matcher would most plausibly
+        // drop (it's easy to forget it's a single char, not three dots).
+        assert_eq!(
+            capitalize_sentence_starts("well… maybe tomorrow"),
+            "Well… Maybe tomorrow"
+        );
+    }
 }

--- a/src-tauri/src/speech_analyzer.rs
+++ b/src-tauri/src/speech_analyzer.rs
@@ -86,10 +86,12 @@ mod ffi {
         result
     }
 
-    pub fn prepare(locale: &str) -> Result<(), String> {
+    /// On success the response text is an optional diagnostic notice from the
+    /// bridge (empty when there is nothing to report).
+    pub fn prepare(locale: &str) -> Result<String, String> {
         let locale_cstr = CString::new(locale).map_err(|e| e.to_string())?;
         let ptr = unsafe { speech_analyzer_prepare(locale_cstr.as_ptr()) };
-        consume_response(ptr).map(|_| ())
+        consume_response(ptr)
     }
 
     pub fn transcribe(samples: &[f32], locale: &str) -> Result<String, String> {
@@ -149,7 +151,7 @@ mod ffi {
         Err("SpeechAnalyzer is only available on Apple Silicon macOS".to_string())
     }
 
-    pub fn prepare(_locale: &str) -> Result<(), String> {
+    pub fn prepare(_locale: &str) -> Result<String, String> {
         Err("SpeechAnalyzer is only available on Apple Silicon macOS".to_string())
     }
 
@@ -247,6 +249,18 @@ impl Drop for SpeechAnalyzerStream {
     }
 }
 
+/// Prepare assets for the locale and surface any diagnostic notice the bridge
+/// returns — currently the analyzer preferring a different audio format than
+/// Handy's 16 kHz mono Float32 feed, which engages per-chunk conversion on the
+/// Swift side and should never happen in practice.
+fn prepare_with_notice(locale: &str) -> Result<(), String> {
+    let notice = ffi::prepare(locale)?;
+    if !notice.is_empty() {
+        log::warn!("SpeechAnalyzer: {notice}");
+    }
+    Ok(())
+}
+
 /// Handle held by the transcription manager while the SpeechAnalyzer "model"
 /// is loaded. Batch calls create short-lived analyzers; live transcription
 /// creates a separate [`SpeechAnalyzerStream`] while retaining this locale.
@@ -265,7 +279,7 @@ impl SpeechAnalyzerEngine {
                     .to_string(),
             );
         }
-        ffi::prepare(locale)?;
+        prepare_with_notice(locale)?;
         Ok(Self {
             locale: Mutex::new(locale.to_string()),
         })
@@ -284,7 +298,7 @@ impl SpeechAnalyzerEngine {
         // AssetInventory may retire an unused asset between runs, and the user
         // may have changed languages since load. Rechecking is cheap when the
         // asset is installed and re-downloads it when the OS evicted it.
-        ffi::prepare(locale)?;
+        prepare_with_notice(locale)?;
         *self
             .locale
             .lock()

--- a/src-tauri/swift/speech_analyzer.swift
+++ b/src-tauri/swift/speech_analyzer.swift
@@ -31,6 +31,241 @@ private final class ResultBox: @unchecked Sendable {
     var error: String?
 }
 
+@available(macOS 26.0, *)
+private final class StreamBox: @unchecked Sendable {
+    var session: StreamingSession?
+}
+
+private struct StreamResultEvent: Codable {
+    let revision: UInt64
+    let elapsedMs: UInt64
+    let isFinal: Bool
+    let text: String
+}
+
+private struct StreamSnapshot: Codable {
+    let revision: UInt64
+    let committed: String
+    let tentative: String
+    let events: [StreamResultEvent]
+}
+
+/// Result state shared between SpeechTranscriber's AsyncSequence consumer and
+/// the synchronous FFI polling calls made by Rust's streaming worker.
+private final class StreamingResultState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var revision: UInt64 = 0
+    private let startedAt = ProcessInfo.processInfo.systemUptime
+    private var committed = ""
+    private var tentative = ""
+    private var pendingEvents: [StreamResultEvent] = []
+    private var error: String?
+
+    func apply(text: String, isFinal: Bool) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if isFinal {
+            committed += text
+            tentative = ""
+        } else {
+            // Volatile results repeatedly replace the same not-yet-final audio
+            // range. Only one volatile suffix follows the committed prefix.
+            tentative = text
+        }
+        revision &+= 1
+        pendingEvents.append(
+            StreamResultEvent(
+                revision: revision,
+                elapsedMs: UInt64(
+                    max(0, (ProcessInfo.processInfo.systemUptime - startedAt) * 1000)),
+                isFinal: isFinal,
+                text: text
+            ))
+    }
+
+    func record(error: Error) {
+        lock.lock()
+        self.error = error.localizedDescription
+        lock.unlock()
+    }
+
+    func snapshot() throws -> StreamSnapshot {
+        lock.lock()
+        defer { lock.unlock() }
+        if let error {
+            throw NSError(
+                domain: "SpeechAnalyzerBridge", code: 10,
+                userInfo: [NSLocalizedDescriptionKey: error])
+        }
+        let events = pendingEvents
+        pendingEvents.removeAll(keepingCapacity: true)
+        return StreamSnapshot(
+            revision: revision,
+            committed: committed,
+            tentative: tentative,
+            events: events
+        )
+    }
+}
+
+/// A long-lived SpeechAnalyzer session. Audio arrives incrementally through the
+/// AsyncStream while final and volatile transcription results are consumed on a
+/// separate task. Chunk boundaries transport audio; they do not reset model
+/// context because every buffer belongs to this one analyzer session.
+@available(macOS 26.0, *)
+private final class StreamingSession: @unchecked Sendable {
+    private let analyzer: SpeechAnalyzer
+    private let continuation: AsyncStream<AnalyzerInput>.Continuation
+    private let resultsTask: Task<String, Error>
+    private let resultState: StreamingResultState
+    private let inputFormat: AVAudioFormat
+    private let analyzerFormat: AVAudioFormat?
+    private var isFinished = false
+
+    private init(
+        analyzer: SpeechAnalyzer,
+        continuation: AsyncStream<AnalyzerInput>.Continuation,
+        resultsTask: Task<String, Error>,
+        resultState: StreamingResultState,
+        inputFormat: AVAudioFormat,
+        analyzerFormat: AVAudioFormat?
+    ) {
+        self.analyzer = analyzer
+        self.continuation = continuation
+        self.resultsTask = resultsTask
+        self.resultState = resultState
+        self.inputFormat = inputFormat
+        self.analyzerFormat = analyzerFormat
+    }
+
+    static func start(localeId: String) async throws -> StreamingSession {
+        let locale = try await resolveLocale(localeId)
+        let transcriber = SpeechTranscriber(
+            locale: locale,
+            transcriptionOptions: [],
+            // Request revisable live text while retaining the full-context,
+            // highest-quality transcription path. Apple controls when these
+            // volatile revisions are delivered.
+            reportingOptions: [.volatileResults],
+            attributeOptions: []
+        )
+        let analyzer = SpeechAnalyzer(modules: [transcriber])
+        guard
+            let inputFormat = AVAudioFormat(
+                commonFormat: .pcmFormatFloat32,
+                sampleRate: 16000,
+                channels: 1,
+                interleaved: false)
+        else {
+            throw NSError(
+                domain: "SpeechAnalyzerBridge", code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to create input audio format."])
+        }
+        let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(
+            compatibleWith: [transcriber], considering: inputFormat)
+        let (inputSequence, continuation) = AsyncStream.makeStream(of: AnalyzerInput.self)
+        let resultState = StreamingResultState()
+        let resultsTask = Task<String, Error> {
+            do {
+                var finalText = ""
+                for try await result in transcriber.results {
+                    let text = String(result.text.characters)
+                    resultState.apply(text: text, isFinal: result.isFinal)
+                    if result.isFinal {
+                        finalText += text
+                    }
+                }
+                return finalText
+            } catch {
+                resultState.record(error: error)
+                throw error
+            }
+        }
+
+        do {
+            try await analyzer.start(inputSequence: inputSequence)
+        } catch {
+            continuation.finish()
+            resultsTask.cancel()
+            _ = try? await resultsTask.value
+            throw error
+        }
+
+        return StreamingSession(
+            analyzer: analyzer,
+            continuation: continuation,
+            resultsTask: resultsTask,
+            resultState: resultState,
+            inputFormat: inputFormat,
+            analyzerFormat: analyzerFormat
+        )
+    }
+
+    func feed(_ samples: [Float]) throws {
+        guard !isFinished else {
+            throw NSError(
+                domain: "SpeechAnalyzerBridge", code: 11,
+                userInfo: [NSLocalizedDescriptionKey: "SpeechAnalyzer stream is already finished."])
+        }
+        guard !samples.isEmpty else { return }
+
+        let inputBuffer = try makeAudioBuffer(samples, format: inputFormat)
+        let buffer: AVAudioPCMBuffer
+        if let analyzerFormat, analyzerFormat != inputFormat {
+            buffer = try convert(inputBuffer, to: analyzerFormat)
+        } else {
+            buffer = inputBuffer
+        }
+
+        if case .terminated = continuation.yield(AnalyzerInput(buffer: buffer)) {
+            throw NSError(
+                domain: "SpeechAnalyzerBridge", code: 12,
+                userInfo: [NSLocalizedDescriptionKey: "SpeechAnalyzer input stream terminated."])
+        }
+    }
+
+    func snapshotJSON() throws -> String {
+        let data = try JSONEncoder().encode(resultState.snapshot())
+        guard let json = String(data: data, encoding: .utf8) else {
+            throw NSError(
+                domain: "SpeechAnalyzerBridge", code: 13,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to encode stream snapshot."])
+        }
+        return json
+    }
+
+    func finish() async throws -> String {
+        guard !isFinished else {
+            throw NSError(
+                domain: "SpeechAnalyzerBridge", code: 14,
+                userInfo: [NSLocalizedDescriptionKey: "SpeechAnalyzer stream is already finished."])
+        }
+        isFinished = true
+        continuation.finish()
+
+        do {
+            try await analyzer.finalizeAndFinishThroughEndOfInput()
+            return try await resultsTask.value
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        } catch {
+            resultsTask.cancel()
+            await analyzer.cancelAndFinishNow()
+            _ = try? await resultsTask.value
+            throw error
+        }
+    }
+
+    func cancel() async {
+        guard !isFinished else { return }
+        isFinished = true
+        continuation.finish()
+        resultsTask.cancel()
+        await analyzer.cancelAndFinishNow()
+        _ = try? await resultsTask.value
+    }
+}
+
 /// Run an async operation to completion on the calling (FFI) thread.
 private func runBlocking(_ operation: @escaping @Sendable () async throws -> String)
     -> ResponsePointer
@@ -124,16 +359,31 @@ private func ensureAssets(
     }
 }
 
+private let batchChunkFrames = 16_000 // One second at Handy's 16 kHz input rate.
+
+@available(macOS 26.0, *)
+private func makeAudioBuffer(_ samples: [Float], format: AVAudioFormat) throws -> AVAudioPCMBuffer {
+    guard
+        let buffer = AVAudioPCMBuffer(
+            pcmFormat: format, frameCapacity: AVAudioFrameCount(samples.count))
+    else {
+        throw NSError(
+            domain: "SpeechAnalyzerBridge", code: 3,
+            userInfo: [NSLocalizedDescriptionKey: "Failed to allocate audio buffer."])
+    }
+    buffer.frameLength = AVAudioFrameCount(samples.count)
+    samples.withUnsafeBufferPointer { source in
+        buffer.floatChannelData![0].update(from: source.baseAddress!, count: samples.count)
+    }
+    return buffer
+}
+
 @available(macOS 26.0, *)
 private func transcribeSamples(_ samples: [Float], localeId: String) async throws -> String {
-    let locale = try await resolveLocale(localeId)
-    let transcriber = SpeechTranscriber(
-        locale: locale,
-        transcriptionOptions: [],
-        reportingOptions: [],
-        attributeOptions: []
-    )
+    guard !samples.isEmpty else { return "" }
 
+    let locale = try await resolveLocale(localeId)
+    let transcriber = SpeechTranscriber(locale: locale, preset: .transcription)
     let analyzer = SpeechAnalyzer(modules: [transcriber])
 
     guard
@@ -144,30 +394,11 @@ private func transcribeSamples(_ samples: [Float], localeId: String) async throw
             domain: "SpeechAnalyzerBridge", code: 2,
             userInfo: [NSLocalizedDescriptionKey: "Failed to create input audio format."])
     }
-    guard
-        let inputBuffer = AVAudioPCMBuffer(
-            pcmFormat: inputFormat, frameCapacity: AVAudioFrameCount(samples.count))
-    else {
-        throw NSError(
-            domain: "SpeechAnalyzerBridge", code: 3,
-            userInfo: [NSLocalizedDescriptionKey: "Failed to allocate audio buffer."])
-    }
-    inputBuffer.frameLength = AVAudioFrameCount(samples.count)
-    samples.withUnsafeBufferPointer { src in
-        inputBuffer.floatChannelData![0].update(from: src.baseAddress!, count: samples.count)
-    }
+    let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(
+        compatibleWith: [transcriber], considering: inputFormat)
 
-    // The analyzer dictates the audio format; convert our 16 kHz mono input to it.
-    let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: [transcriber])
-    let buffer: AVAudioPCMBuffer
-    if let analyzerFormat = analyzerFormat, analyzerFormat != inputFormat {
-        buffer = try convert(inputBuffer, to: analyzerFormat)
-    } else {
-        buffer = inputBuffer
-    }
-
-    // Collect final results concurrently while the analyzer consumes the input.
-    let resultsTask = Task {
+    // Consume final results concurrently while the analyzer processes the input.
+    let resultsTask = Task<String, Error> {
         var text = ""
         for try await result in transcriber.results where result.isFinal {
             text += String(result.text.characters)
@@ -176,16 +407,41 @@ private func transcribeSamples(_ samples: [Float], localeId: String) async throw
     }
 
     let (inputSequence, inputBuilder) = AsyncStream.makeStream(of: AnalyzerInput.self)
-    inputBuilder.yield(AnalyzerInput(buffer: buffer))
-    inputBuilder.finish()
 
     do {
+        // Start the autonomous consumer before producing input so a long batch
+        // does not accumulate a second complete copy in AsyncStream's queue.
         try await analyzer.start(inputSequence: inputSequence)
+
+        // Feed manageable buffers into one analyzer session. Supplying a
+        // multi-minute recording as one AVAudioPCMBuffer causes SpeechAnalyzer
+        // to silently omit early audio; sequence chunking preserves the complete
+        // recording without resetting model context between chunks.
+        var offset = 0
+        while offset < samples.count {
+            let end = min(offset + batchChunkFrames, samples.count)
+            let sourceBuffer = try makeAudioBuffer(
+                Array(samples[offset..<end]), format: inputFormat)
+            let buffer: AVAudioPCMBuffer
+            if let analyzerFormat, analyzerFormat != inputFormat {
+                buffer = try convert(sourceBuffer, to: analyzerFormat)
+            } else {
+                buffer = sourceBuffer
+            }
+            if case .terminated = inputBuilder.yield(AnalyzerInput(buffer: buffer)) {
+                throw NSError(
+                    domain: "SpeechAnalyzerBridge", code: 12,
+                    userInfo: [NSLocalizedDescriptionKey: "SpeechAnalyzer input stream terminated."])
+            }
+            offset = end
+        }
+        inputBuilder.finish()
         try await analyzer.finalizeAndFinishThroughEndOfInput()
 
         return try await resultsTask.value
             .trimmingCharacters(in: .whitespacesAndNewlines)
     } catch {
+        inputBuilder.finish()
         resultsTask.cancel()
         await analyzer.cancelAndFinishNow()
         _ = try? await resultsTask.value
@@ -211,7 +467,7 @@ private func convert(_ input: AVAudioPCMBuffer, to format: AVAudioFormat) throws
 
     var fed = false
     var conversionError: NSError?
-    converter.convert(to: output, error: &conversionError) { _, outStatus in
+    let status = converter.convert(to: output, error: &conversionError) { _, outStatus in
         if fed {
             outStatus.pointee = .endOfStream
             return nil
@@ -220,8 +476,13 @@ private func convert(_ input: AVAudioPCMBuffer, to format: AVAudioFormat) throws
         outStatus.pointee = .haveData
         return input
     }
-    if let conversionError = conversionError {
+    if let conversionError {
         throw conversionError
+    }
+    if status == .error {
+        throw NSError(
+            domain: "SpeechAnalyzerBridge", code: 6,
+            userInfo: [NSLocalizedDescriptionKey: "Audio conversion failed."])
     }
     return output
 }
@@ -309,6 +570,108 @@ public func speechAnalyzerTranscribe(
     return runBlocking {
         try await transcribeSamples(sampleArray, localeId: swiftLocaleId)
     }
+}
+
+@_cdecl("speech_analyzer_stream_start")
+public func speechAnalyzerStreamStart(
+    _ localeId: UnsafePointer<CChar>,
+    _ streamOut: UnsafeMutablePointer<UnsafeMutableRawPointer?>
+) -> UnsafeMutablePointer<SpeechAnalyzerResponse> {
+    streamOut.pointee = nil
+    let swiftLocaleId = String(cString: localeId)
+    guard #available(macOS 26.0, *) else {
+        let responsePtr = makeResponse()
+        responsePtr.pointee.error_message = duplicateCString(
+            "SpeechAnalyzer requires macOS 26 or newer.")
+        return responsePtr
+    }
+    guard SpeechTranscriber.isAvailable else {
+        let responsePtr = makeResponse()
+        responsePtr.pointee.error_message = duplicateCString(
+            "SpeechTranscriber is not available on this device.")
+        return responsePtr
+    }
+
+    let box = StreamBox()
+    let response = runBlocking {
+        box.session = try await StreamingSession.start(localeId: swiftLocaleId)
+        return ""
+    }
+    if response.pointee.success == 1, let session = box.session {
+        streamOut.pointee = Unmanaged.passRetained(session).toOpaque()
+    }
+    return response
+}
+
+@_cdecl("speech_analyzer_stream_feed")
+public func speechAnalyzerStreamFeed(
+    _ stream: UnsafeMutableRawPointer?,
+    _ samples: UnsafePointer<Float>,
+    _ sampleCount: Int32
+) -> UnsafeMutablePointer<SpeechAnalyzerResponse> {
+    guard #available(macOS 26.0, *), let stream else {
+        let responsePtr = makeResponse()
+        responsePtr.pointee.error_message = duplicateCString("Invalid SpeechAnalyzer stream.")
+        return responsePtr
+    }
+    let session = Unmanaged<StreamingSession>.fromOpaque(stream).takeUnretainedValue()
+    let sampleArray = Array(UnsafeBufferPointer(start: samples, count: Int(sampleCount)))
+    return runBlocking {
+        try session.feed(sampleArray)
+        return ""
+    }
+}
+
+@_cdecl("speech_analyzer_stream_snapshot")
+public func speechAnalyzerStreamSnapshot(
+    _ stream: UnsafeMutableRawPointer?
+) -> UnsafeMutablePointer<SpeechAnalyzerResponse> {
+    guard #available(macOS 26.0, *), let stream else {
+        let responsePtr = makeResponse()
+        responsePtr.pointee.error_message = duplicateCString("Invalid SpeechAnalyzer stream.")
+        return responsePtr
+    }
+    let session = Unmanaged<StreamingSession>.fromOpaque(stream).takeUnretainedValue()
+    return runBlocking {
+        try session.snapshotJSON()
+    }
+}
+
+@_cdecl("speech_analyzer_stream_finish")
+public func speechAnalyzerStreamFinish(
+    _ stream: UnsafeMutableRawPointer?
+) -> UnsafeMutablePointer<SpeechAnalyzerResponse> {
+    guard #available(macOS 26.0, *), let stream else {
+        let responsePtr = makeResponse()
+        responsePtr.pointee.error_message = duplicateCString("Invalid SpeechAnalyzer stream.")
+        return responsePtr
+    }
+    let session = Unmanaged<StreamingSession>.fromOpaque(stream).takeUnretainedValue()
+    return runBlocking {
+        try await session.finish()
+    }
+}
+
+@_cdecl("speech_analyzer_stream_cancel")
+public func speechAnalyzerStreamCancel(
+    _ stream: UnsafeMutableRawPointer?
+) -> UnsafeMutablePointer<SpeechAnalyzerResponse> {
+    guard #available(macOS 26.0, *), let stream else {
+        let responsePtr = makeResponse()
+        responsePtr.pointee.error_message = duplicateCString("Invalid SpeechAnalyzer stream.")
+        return responsePtr
+    }
+    let session = Unmanaged<StreamingSession>.fromOpaque(stream).takeUnretainedValue()
+    return runBlocking {
+        await session.cancel()
+        return ""
+    }
+}
+
+@_cdecl("free_speech_analyzer_stream")
+public func freeSpeechAnalyzerStream(_ stream: UnsafeMutableRawPointer?) {
+    guard #available(macOS 26.0, *), let stream else { return }
+    Unmanaged<StreamingSession>.fromOpaque(stream).release()
 }
 
 @_cdecl("free_speech_analyzer_response")

--- a/src-tauri/swift/speech_analyzer.swift
+++ b/src-tauri/swift/speech_analyzer.swift
@@ -1,0 +1,260 @@
+import AVFoundation
+import Dispatch
+import Foundation
+import Speech
+
+// MARK: - Swift implementation for Apple SpeechAnalyzer transcription
+// This file is compiled via Cargo build script for Apple Silicon targets.
+// Mirrors the apple_intelligence.swift bridge: blocking @_cdecl entry points
+// that run the async SpeechAnalyzer API on a detached task.
+
+private typealias ResponsePointer = UnsafeMutablePointer<SpeechAnalyzerResponse>
+
+private func duplicateCString(_ text: String) -> UnsafeMutablePointer<CChar>? {
+    return text.withCString { basePointer in
+        guard let duplicated = strdup(basePointer) else {
+            return nil
+        }
+        return duplicated
+    }
+}
+
+private func makeResponse() -> ResponsePointer {
+    let responsePtr = ResponsePointer.allocate(capacity: 1)
+    responsePtr.initialize(to: SpeechAnalyzerResponse(text: nil, success: 0, error_message: nil))
+    return responsePtr
+}
+
+// Thread-safe container to pass results from async task back to calling thread
+private final class ResultBox: @unchecked Sendable {
+    var text: String?
+    var error: String?
+}
+
+/// Run an async operation to completion on the calling (FFI) thread.
+private func runBlocking(_ operation: @escaping @Sendable () async throws -> String)
+    -> ResponsePointer
+{
+    let responsePtr = makeResponse()
+    let semaphore = DispatchSemaphore(value: 0)
+    let box = ResultBox()
+
+    Task.detached(priority: .userInitiated) {
+        defer { semaphore.signal() }
+        do {
+            box.text = try await operation()
+        } catch {
+            box.error = error.localizedDescription
+        }
+    }
+
+    semaphore.wait()
+
+    if let text = box.text {
+        responsePtr.pointee.text = duplicateCString(text)
+        responsePtr.pointee.success = 1
+    } else {
+        responsePtr.pointee.error_message = duplicateCString(box.error ?? "Unknown error")
+    }
+    return responsePtr
+}
+
+@available(macOS 26.0, *)
+private func resolveLocale(_ identifier: String) async throws -> Locale {
+    let requested = Locale(identifier: identifier)
+    let supported = await SpeechTranscriber.supportedLocales
+    if let match = supported.first(where: {
+        $0.identifier(.bcp47) == requested.identifier(.bcp47)
+    }) {
+        return match
+    }
+    // Bare language codes ("en"): prefer the system's own region variant so a
+    // US user gets en-US spelling, then fall back to any same-language locale.
+    let sameLanguage = supported.filter {
+        $0.language.languageCode == requested.language.languageCode
+    }
+    if let match = sameLanguage.first(where: { $0.region == Locale.current.region }) {
+        return match
+    }
+    if let match = sameLanguage.first {
+        return match
+    }
+    throw NSError(
+        domain: "SpeechAnalyzerBridge", code: 1,
+        userInfo: [
+            NSLocalizedDescriptionKey:
+                "Locale \(identifier) is not supported by SpeechTranscriber."
+        ])
+}
+
+/// Download and install the on-device assets for the transcriber if missing.
+@available(macOS 26.0, *)
+private func ensureAssets(for transcriber: SpeechTranscriber) async throws {
+    if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
+        try await request.downloadAndInstall()
+    }
+}
+
+@available(macOS 26.0, *)
+private func transcribeSamples(_ samples: [Float], localeId: String) async throws -> String {
+    let locale = try await resolveLocale(localeId)
+    let transcriber = SpeechTranscriber(
+        locale: locale,
+        transcriptionOptions: [],
+        reportingOptions: [],
+        attributeOptions: []
+    )
+    try await ensureAssets(for: transcriber)
+
+    let analyzer = SpeechAnalyzer(modules: [transcriber])
+
+    guard
+        let inputFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32, sampleRate: 16000, channels: 1, interleaved: false)
+    else {
+        throw NSError(
+            domain: "SpeechAnalyzerBridge", code: 2,
+            userInfo: [NSLocalizedDescriptionKey: "Failed to create input audio format."])
+    }
+    guard
+        let inputBuffer = AVAudioPCMBuffer(
+            pcmFormat: inputFormat, frameCapacity: AVAudioFrameCount(samples.count))
+    else {
+        throw NSError(
+            domain: "SpeechAnalyzerBridge", code: 3,
+            userInfo: [NSLocalizedDescriptionKey: "Failed to allocate audio buffer."])
+    }
+    inputBuffer.frameLength = AVAudioFrameCount(samples.count)
+    samples.withUnsafeBufferPointer { src in
+        inputBuffer.floatChannelData![0].update(from: src.baseAddress!, count: samples.count)
+    }
+
+    // The analyzer dictates the audio format; convert our 16 kHz mono input to it.
+    let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: [transcriber])
+    let buffer: AVAudioPCMBuffer
+    if let analyzerFormat = analyzerFormat, analyzerFormat != inputFormat {
+        buffer = try convert(inputBuffer, to: analyzerFormat)
+    } else {
+        buffer = inputBuffer
+    }
+
+    // Collect final results concurrently while the analyzer consumes the input.
+    let resultsTask = Task {
+        var text = ""
+        for try await result in transcriber.results where result.isFinal {
+            text += String(result.text.characters)
+        }
+        return text
+    }
+
+    let (inputSequence, inputBuilder) = AsyncStream.makeStream(of: AnalyzerInput.self)
+    inputBuilder.yield(AnalyzerInput(buffer: buffer))
+    inputBuilder.finish()
+
+    try await analyzer.start(inputSequence: inputSequence)
+    try await analyzer.finalizeAndFinishThroughEndOfInput()
+
+    return try await resultsTask.value
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+@available(macOS 26.0, *)
+private func convert(_ input: AVAudioPCMBuffer, to format: AVAudioFormat) throws -> AVAudioPCMBuffer
+{
+    guard let converter = AVAudioConverter(from: input.format, to: format) else {
+        throw NSError(
+            domain: "SpeechAnalyzerBridge", code: 4,
+            userInfo: [NSLocalizedDescriptionKey: "Failed to create audio converter."])
+    }
+    let ratio = format.sampleRate / input.format.sampleRate
+    let capacity = AVAudioFrameCount(Double(input.frameLength) * ratio) + 1024
+    guard let output = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: capacity) else {
+        throw NSError(
+            domain: "SpeechAnalyzerBridge", code: 5,
+            userInfo: [NSLocalizedDescriptionKey: "Failed to allocate conversion buffer."])
+    }
+
+    var fed = false
+    var conversionError: NSError?
+    converter.convert(to: output, error: &conversionError) { _, outStatus in
+        if fed {
+            outStatus.pointee = .endOfStream
+            return nil
+        }
+        fed = true
+        outStatus.pointee = .haveData
+        return input
+    }
+    if let conversionError = conversionError {
+        throw conversionError
+    }
+    return output
+}
+
+@_cdecl("is_speech_analyzer_available")
+public func isSpeechAnalyzerAvailable() -> Int32 {
+    guard #available(macOS 26.0, *) else {
+        return 0
+    }
+    return 1
+}
+
+@_cdecl("speech_analyzer_prepare")
+public func speechAnalyzerPrepare(
+    _ localeId: UnsafePointer<CChar>
+) -> UnsafeMutablePointer<SpeechAnalyzerResponse> {
+    let swiftLocaleId = String(cString: localeId)
+    guard #available(macOS 26.0, *) else {
+        let responsePtr = makeResponse()
+        responsePtr.pointee.error_message = duplicateCString(
+            "SpeechAnalyzer requires macOS 26 or newer.")
+        return responsePtr
+    }
+    return runBlocking {
+        let locale = try await resolveLocale(swiftLocaleId)
+        let transcriber = SpeechTranscriber(
+            locale: locale,
+            transcriptionOptions: [],
+            reportingOptions: [],
+            attributeOptions: []
+        )
+        try await ensureAssets(for: transcriber)
+        return ""
+    }
+}
+
+@_cdecl("speech_analyzer_transcribe")
+public func speechAnalyzerTranscribe(
+    _ samples: UnsafePointer<Float>,
+    _ sampleCount: Int32,
+    _ localeId: UnsafePointer<CChar>
+) -> UnsafeMutablePointer<SpeechAnalyzerResponse> {
+    let swiftLocaleId = String(cString: localeId)
+    guard #available(macOS 26.0, *) else {
+        let responsePtr = makeResponse()
+        responsePtr.pointee.error_message = duplicateCString(
+            "SpeechAnalyzer requires macOS 26 or newer.")
+        return responsePtr
+    }
+    let sampleArray = Array(UnsafeBufferPointer(start: samples, count: Int(sampleCount)))
+    return runBlocking {
+        try await transcribeSamples(sampleArray, localeId: swiftLocaleId)
+    }
+}
+
+@_cdecl("free_speech_analyzer_response")
+public func freeSpeechAnalyzerResponse(
+    _ response: UnsafeMutablePointer<SpeechAnalyzerResponse>?
+) {
+    guard let response = response else { return }
+
+    if let textStr = response.pointee.text {
+        free(UnsafeMutablePointer(mutating: textStr))
+    }
+
+    if let errorStr = response.pointee.error_message {
+        free(UnsafeMutablePointer(mutating: errorStr))
+    }
+
+    response.deallocate()
+}

--- a/src-tauri/swift/speech_analyzer.swift
+++ b/src-tauri/swift/speech_analyzer.swift
@@ -543,7 +543,26 @@ public func speechAnalyzerPrepare(
             attributeOptions: []
         )
         try await ensureAssets(for: transcriber, locale: locale)
-        return ""
+
+        // Success text doubles as a diagnostic notice for the Rust side to
+        // log. Handy always feeds 16 kHz mono Float32; if the analyzer ever
+        // prefers a different format, the transcribe/stream paths convert
+        // per-chunk with independent converters, which is only safe while
+        // this never actually engages — so leave a trace when it does.
+        guard
+            let inputFormat = AVAudioFormat(
+                commonFormat: .pcmFormatFloat32, sampleRate: 16000, channels: 1,
+                interleaved: false),
+            let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(
+                compatibleWith: [transcriber], considering: inputFormat),
+            analyzerFormat != inputFormat
+        else {
+            return ""
+        }
+        return
+            "analyzer prefers \(Int(analyzerFormat.sampleRate)) Hz, "
+            + "\(analyzerFormat.channelCount) ch, commonFormat \(analyzerFormat.commonFormat.rawValue) "
+            + "over the 16 kHz mono Float32 feed; per-chunk audio conversion is engaged"
     }
 }
 

--- a/src-tauri/swift/speech_analyzer.swift
+++ b/src-tauri/swift/speech_analyzer.swift
@@ -31,23 +31,6 @@ private final class ResultBox: @unchecked Sendable {
     var error: String?
 }
 
-/// Keeps the C callback and its Rust-owned context together while an async
-/// installation request is running. The blocking FFI entry point guarantees
-/// that the context outlives every report.
-private final class ProgressReporter: @unchecked Sendable {
-    private let callback: SpeechAnalyzerProgressCallback?
-    private let context: UnsafeMutableRawPointer?
-
-    init(callback: SpeechAnalyzerProgressCallback?, context: UnsafeMutableRawPointer?) {
-        self.callback = callback
-        self.context = context
-    }
-
-    func report(_ fraction: Double) {
-        callback?(min(max(fraction, 0), 1), context)
-    }
-}
-
 /// Run an async operation to completion on the calling (FFI) thread.
 private func runBlocking(_ operation: @escaping @Sendable () async throws -> String)
     -> ResponsePointer
@@ -105,13 +88,12 @@ private func reservation(_ reservedLocale: Locale, matches selectedLocale: Local
 }
 
 /// Ensure there is a reservation slot for the locale, then download and install
-/// its on-device assets if missing. Installation progress is forwarded to Rust
-/// so the existing model progress UI can display it.
+/// its on-device assets if missing. Blocks until the OS finishes; Handy's model
+/// loading state covers the wait in the UI.
 @available(macOS 26.0, *)
 private func ensureAssets(
     for transcriber: SpeechTranscriber,
-    locale: Locale,
-    reporter: ProgressReporter
+    locale: Locale
 ) async throws {
     let selectedIdentifier = locale.identifier(.bcp47)
     let reservedLocales = await AssetInventory.reservedLocales
@@ -138,29 +120,7 @@ private func ensureAssets(
     }
 
     if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
-        reporter.report(0)
-        let progressTask = Task.detached(priority: .utility) {
-            while !Task.isCancelled {
-                reporter.report(request.progress.fractionCompleted)
-                do {
-                    try await Task.sleep(nanoseconds: 100_000_000)
-                } catch {
-                    return
-                }
-            }
-        }
-        do {
-            try await request.downloadAndInstall()
-            progressTask.cancel()
-            await progressTask.value
-            reporter.report(1)
-        } catch {
-            // Await the polling task before unwinding through the FFI boundary;
-            // its callback context is owned by the blocked Rust stack frame.
-            progressTask.cancel()
-            await progressTask.value
-            throw error
-        }
+        try await request.downloadAndInstall()
     }
 }
 
@@ -298,12 +258,9 @@ public func speechAnalyzerSupportedLocales() -> UnsafeMutablePointer<SpeechAnaly
 
 @_cdecl("speech_analyzer_prepare")
 public func speechAnalyzerPrepare(
-    _ localeId: UnsafePointer<CChar>,
-    _ progressCallback: SpeechAnalyzerProgressCallback?,
-    _ progressContext: UnsafeMutableRawPointer?
+    _ localeId: UnsafePointer<CChar>
 ) -> UnsafeMutablePointer<SpeechAnalyzerResponse> {
     let swiftLocaleId = String(cString: localeId)
-    let reporter = ProgressReporter(callback: progressCallback, context: progressContext)
     guard #available(macOS 26.0, *) else {
         let responsePtr = makeResponse()
         responsePtr.pointee.error_message = duplicateCString(
@@ -324,7 +281,7 @@ public func speechAnalyzerPrepare(
             reportingOptions: [],
             attributeOptions: []
         )
-        try await ensureAssets(for: transcriber, locale: locale, reporter: reporter)
+        try await ensureAssets(for: transcriber, locale: locale)
         return ""
     }
 }

--- a/src-tauri/swift/speech_analyzer.swift
+++ b/src-tauri/swift/speech_analyzer.swift
@@ -31,6 +31,23 @@ private final class ResultBox: @unchecked Sendable {
     var error: String?
 }
 
+/// Keeps the C callback and its Rust-owned context together while an async
+/// installation request is running. The blocking FFI entry point guarantees
+/// that the context outlives every report.
+private final class ProgressReporter: @unchecked Sendable {
+    private let callback: SpeechAnalyzerProgressCallback?
+    private let context: UnsafeMutableRawPointer?
+
+    init(callback: SpeechAnalyzerProgressCallback?, context: UnsafeMutableRawPointer?) {
+        self.callback = callback
+        self.context = context
+    }
+
+    func report(_ fraction: Double) {
+        callback?(min(max(fraction, 0), 1), context)
+    }
+}
+
 /// Run an async operation to completion on the calling (FFI) thread.
 private func runBlocking(_ operation: @escaping @Sendable () async throws -> String)
     -> ResponsePointer
@@ -62,21 +79,7 @@ private func runBlocking(_ operation: @escaping @Sendable () async throws -> Str
 @available(macOS 26.0, *)
 private func resolveLocale(_ identifier: String) async throws -> Locale {
     let requested = Locale(identifier: identifier)
-    let supported = await SpeechTranscriber.supportedLocales
-    if let match = supported.first(where: {
-        $0.identifier(.bcp47) == requested.identifier(.bcp47)
-    }) {
-        return match
-    }
-    // Bare language codes ("en"): prefer the system's own region variant so a
-    // US user gets en-US spelling, then fall back to any same-language locale.
-    let sameLanguage = supported.filter {
-        $0.language.languageCode == requested.language.languageCode
-    }
-    if let match = sameLanguage.first(where: { $0.region == Locale.current.region }) {
-        return match
-    }
-    if let match = sameLanguage.first {
+    if let match = await SpeechTranscriber.supportedLocale(equivalentTo: requested) {
         return match
     }
     throw NSError(
@@ -87,11 +90,77 @@ private func resolveLocale(_ identifier: String) async throws -> Locale {
         ])
 }
 
-/// Download and install the on-device assets for the transcriber if missing.
 @available(macOS 26.0, *)
-private func ensureAssets(for transcriber: SpeechTranscriber) async throws {
+private func reservation(_ reservedLocale: Locale, matches selectedLocale: Locale) async -> Bool {
+    let selectedIdentifier = selectedLocale.identifier(.bcp47)
+    if reservedLocale.identifier(.bcp47) == selectedIdentifier {
+        return true
+    }
+
+    // Apple may return a canonical variant rather than the identifier supplied
+    // when the reservation was created. Compare through SpeechTranscriber's
+    // own equivalence resolver before deciding that the slot belongs elsewhere.
+    return await SpeechTranscriber.supportedLocale(equivalentTo: reservedLocale)?
+        .identifier(.bcp47) == selectedIdentifier
+}
+
+/// Ensure there is a reservation slot for the locale, then download and install
+/// its on-device assets if missing. Installation progress is forwarded to Rust
+/// so the existing model progress UI can display it.
+@available(macOS 26.0, *)
+private func ensureAssets(
+    for transcriber: SpeechTranscriber,
+    locale: Locale,
+    reporter: ProgressReporter
+) async throws {
+    let selectedIdentifier = locale.identifier(.bcp47)
+    let reservedLocales = await AssetInventory.reservedLocales
+    var selectedIsReserved = false
+    for reservedLocale in reservedLocales {
+        if await reservation(reservedLocale, matches: locale) {
+            selectedIsReserved = true
+            break
+        }
+    }
+
+    // AssetInstallationRequest reserves automatically, but throws when the app
+    // has used every slot. Release non-selected reservations only until a slot
+    // is free; retaining spare reservations avoids needless language churn.
+    if !selectedIsReserved && reservedLocales.count >= AssetInventory.maximumReservedLocales {
+        var reservationCount = reservedLocales.count
+        for reservedLocale in reservedLocales
+        where reservedLocale.identifier(.bcp47) != selectedIdentifier {
+            guard reservationCount >= AssetInventory.maximumReservedLocales else { break }
+            if await AssetInventory.release(reservedLocale: reservedLocale) {
+                reservationCount -= 1
+            }
+        }
+    }
+
     if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
-        try await request.downloadAndInstall()
+        reporter.report(0)
+        let progressTask = Task.detached(priority: .utility) {
+            while !Task.isCancelled {
+                reporter.report(request.progress.fractionCompleted)
+                do {
+                    try await Task.sleep(nanoseconds: 100_000_000)
+                } catch {
+                    return
+                }
+            }
+        }
+        do {
+            try await request.downloadAndInstall()
+            progressTask.cancel()
+            await progressTask.value
+            reporter.report(1)
+        } catch {
+            // Await the polling task before unwinding through the FFI boundary;
+            // its callback context is owned by the blocked Rust stack frame.
+            progressTask.cancel()
+            await progressTask.value
+            throw error
+        }
     }
 }
 
@@ -104,7 +173,6 @@ private func transcribeSamples(_ samples: [Float], localeId: String) async throw
         reportingOptions: [],
         attributeOptions: []
     )
-    try await ensureAssets(for: transcriber)
 
     let analyzer = SpeechAnalyzer(modules: [transcriber])
 
@@ -151,11 +219,18 @@ private func transcribeSamples(_ samples: [Float], localeId: String) async throw
     inputBuilder.yield(AnalyzerInput(buffer: buffer))
     inputBuilder.finish()
 
-    try await analyzer.start(inputSequence: inputSequence)
-    try await analyzer.finalizeAndFinishThroughEndOfInput()
+    do {
+        try await analyzer.start(inputSequence: inputSequence)
+        try await analyzer.finalizeAndFinishThroughEndOfInput()
 
-    return try await resultsTask.value
-        .trimmingCharacters(in: .whitespacesAndNewlines)
+        return try await resultsTask.value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    } catch {
+        resultsTask.cancel()
+        await analyzer.cancelAndFinishNow()
+        _ = try? await resultsTask.value
+        throw error
+    }
 }
 
 @available(macOS 26.0, *)
@@ -196,18 +271,49 @@ public func isSpeechAnalyzerAvailable() -> Int32 {
     guard #available(macOS 26.0, *) else {
         return 0
     }
-    return 1
+    return SpeechTranscriber.isAvailable ? 1 : 0
 }
 
-@_cdecl("speech_analyzer_prepare")
-public func speechAnalyzerPrepare(
-    _ localeId: UnsafePointer<CChar>
-) -> UnsafeMutablePointer<SpeechAnalyzerResponse> {
-    let swiftLocaleId = String(cString: localeId)
+@_cdecl("speech_analyzer_supported_locales")
+public func speechAnalyzerSupportedLocales() -> UnsafeMutablePointer<SpeechAnalyzerResponse> {
     guard #available(macOS 26.0, *) else {
         let responsePtr = makeResponse()
         responsePtr.pointee.error_message = duplicateCString(
             "SpeechAnalyzer requires macOS 26 or newer.")
+        return responsePtr
+    }
+    guard SpeechTranscriber.isAvailable else {
+        let responsePtr = makeResponse()
+        responsePtr.pointee.error_message = duplicateCString(
+            "SpeechTranscriber is not available on this device.")
+        return responsePtr
+    }
+    return runBlocking {
+        let locales = await SpeechTranscriber.supportedLocales
+            .map { $0.identifier(.bcp47) }
+            .sorted()
+        return locales.joined(separator: "\n")
+    }
+}
+
+@_cdecl("speech_analyzer_prepare")
+public func speechAnalyzerPrepare(
+    _ localeId: UnsafePointer<CChar>,
+    _ progressCallback: SpeechAnalyzerProgressCallback?,
+    _ progressContext: UnsafeMutableRawPointer?
+) -> UnsafeMutablePointer<SpeechAnalyzerResponse> {
+    let swiftLocaleId = String(cString: localeId)
+    let reporter = ProgressReporter(callback: progressCallback, context: progressContext)
+    guard #available(macOS 26.0, *) else {
+        let responsePtr = makeResponse()
+        responsePtr.pointee.error_message = duplicateCString(
+            "SpeechAnalyzer requires macOS 26 or newer.")
+        return responsePtr
+    }
+    guard SpeechTranscriber.isAvailable else {
+        let responsePtr = makeResponse()
+        responsePtr.pointee.error_message = duplicateCString(
+            "SpeechTranscriber is not available on this device.")
         return responsePtr
     }
     return runBlocking {
@@ -218,7 +324,7 @@ public func speechAnalyzerPrepare(
             reportingOptions: [],
             attributeOptions: []
         )
-        try await ensureAssets(for: transcriber)
+        try await ensureAssets(for: transcriber, locale: locale, reporter: reporter)
         return ""
     }
 }
@@ -234,6 +340,12 @@ public func speechAnalyzerTranscribe(
         let responsePtr = makeResponse()
         responsePtr.pointee.error_message = duplicateCString(
             "SpeechAnalyzer requires macOS 26 or newer.")
+        return responsePtr
+    }
+    guard SpeechTranscriber.isAvailable else {
+        let responsePtr = makeResponse()
+        responsePtr.pointee.error_message = duplicateCString(
+            "SpeechTranscriber is not available on this device.")
         return responsePtr
     }
     let sampleArray = Array(UnsafeBufferPointer(start: samples, count: Int(sampleCount)))

--- a/src-tauri/swift/speech_analyzer_bridge.h
+++ b/src-tauri/swift/speech_analyzer_bridge.h
@@ -13,9 +13,6 @@ typedef struct {
     char* error_message; // Only valid when success = 0
 } SpeechAnalyzerResponse;
 
-// Receives asset-installation progress as a fraction from 0.0 through 1.0.
-typedef void (*SpeechAnalyzerProgressCallback)(double fraction_completed, void* context);
-
 // Check if the SpeechAnalyzer API is available on this device (macOS 26+)
 int is_speech_analyzer_available(void);
 
@@ -24,11 +21,7 @@ SpeechAnalyzerResponse* speech_analyzer_supported_locales(void);
 
 // Ensure the on-device speech assets for the locale are installed
 // (triggers an OS-managed download if needed). Blocks until done.
-SpeechAnalyzerResponse* speech_analyzer_prepare(
-    const char* locale_id,
-    SpeechAnalyzerProgressCallback progress_callback,
-    void* progress_context
-);
+SpeechAnalyzerResponse* speech_analyzer_prepare(const char* locale_id);
 
 // Transcribe 16 kHz mono f32 PCM. Blocks until transcription completes.
 SpeechAnalyzerResponse* speech_analyzer_transcribe(const float* samples, int sample_count, const char* locale_id);

--- a/src-tauri/swift/speech_analyzer_bridge.h
+++ b/src-tauri/swift/speech_analyzer_bridge.h
@@ -21,6 +21,8 @@ SpeechAnalyzerResponse* speech_analyzer_supported_locales(void);
 
 // Ensure the on-device speech assets for the locale are installed
 // (triggers an OS-managed download if needed). Blocks until done.
+// On success, text optionally carries a diagnostic notice worth logging
+// (empty when there is nothing to report).
 SpeechAnalyzerResponse* speech_analyzer_prepare(const char* locale_id);
 
 // Transcribe 16 kHz mono f32 PCM. Blocks until transcription completes.

--- a/src-tauri/swift/speech_analyzer_bridge.h
+++ b/src-tauri/swift/speech_analyzer_bridge.h
@@ -13,12 +13,22 @@ typedef struct {
     char* error_message; // Only valid when success = 0
 } SpeechAnalyzerResponse;
 
+// Receives asset-installation progress as a fraction from 0.0 through 1.0.
+typedef void (*SpeechAnalyzerProgressCallback)(double fraction_completed, void* context);
+
 // Check if the SpeechAnalyzer API is available on this device (macOS 26+)
 int is_speech_analyzer_available(void);
 
+// Return the device's supported BCP-47 locales, separated by newlines.
+SpeechAnalyzerResponse* speech_analyzer_supported_locales(void);
+
 // Ensure the on-device speech assets for the locale are installed
 // (triggers an OS-managed download if needed). Blocks until done.
-SpeechAnalyzerResponse* speech_analyzer_prepare(const char* locale_id);
+SpeechAnalyzerResponse* speech_analyzer_prepare(
+    const char* locale_id,
+    SpeechAnalyzerProgressCallback progress_callback,
+    void* progress_context
+);
 
 // Transcribe 16 kHz mono f32 PCM. Blocks until transcription completes.
 SpeechAnalyzerResponse* speech_analyzer_transcribe(const float* samples, int sample_count, const char* locale_id);

--- a/src-tauri/swift/speech_analyzer_bridge.h
+++ b/src-tauri/swift/speech_analyzer_bridge.h
@@ -26,6 +26,16 @@ SpeechAnalyzerResponse* speech_analyzer_prepare(const char* locale_id);
 // Transcribe 16 kHz mono f32 PCM. Blocks until transcription completes.
 SpeechAnalyzerResponse* speech_analyzer_transcribe(const float* samples, int sample_count, const char* locale_id);
 
+// Long-lived streaming session. Audio buffers are fed incrementally into one
+// SpeechAnalyzer context; snapshots contain JSON with committed/tentative text.
+typedef void* SpeechAnalyzerStreamHandle;
+SpeechAnalyzerResponse* speech_analyzer_stream_start(const char* locale_id, SpeechAnalyzerStreamHandle* stream_out);
+SpeechAnalyzerResponse* speech_analyzer_stream_feed(SpeechAnalyzerStreamHandle stream, const float* samples, int sample_count);
+SpeechAnalyzerResponse* speech_analyzer_stream_snapshot(SpeechAnalyzerStreamHandle stream);
+SpeechAnalyzerResponse* speech_analyzer_stream_finish(SpeechAnalyzerStreamHandle stream);
+SpeechAnalyzerResponse* speech_analyzer_stream_cancel(SpeechAnalyzerStreamHandle stream);
+void free_speech_analyzer_stream(SpeechAnalyzerStreamHandle stream);
+
 // Free memory allocated by the response
 void free_speech_analyzer_response(SpeechAnalyzerResponse* response);
 

--- a/src-tauri/swift/speech_analyzer_bridge.h
+++ b/src-tauri/swift/speech_analyzer_bridge.h
@@ -1,0 +1,33 @@
+#ifndef speech_analyzer_bridge_h
+#define speech_analyzer_bridge_h
+
+// C-compatible function declarations for the SpeechAnalyzer Swift bridge
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    char* text;
+    int success; // 0 for failure, 1 for success
+    char* error_message; // Only valid when success = 0
+} SpeechAnalyzerResponse;
+
+// Check if the SpeechAnalyzer API is available on this device (macOS 26+)
+int is_speech_analyzer_available(void);
+
+// Ensure the on-device speech assets for the locale are installed
+// (triggers an OS-managed download if needed). Blocks until done.
+SpeechAnalyzerResponse* speech_analyzer_prepare(const char* locale_id);
+
+// Transcribe 16 kHz mono f32 PCM. Blocks until transcription completes.
+SpeechAnalyzerResponse* speech_analyzer_transcribe(const float* samples, int sample_count, const char* locale_id);
+
+// Free memory allocated by the response
+void free_speech_analyzer_response(SpeechAnalyzerResponse* response);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* speech_analyzer_bridge_h */

--- a/src-tauri/swift/speech_analyzer_stub.swift
+++ b/src-tauri/swift/speech_analyzer_stub.swift
@@ -40,6 +40,53 @@ public func speechAnalyzerTranscribe(
         "SpeechAnalyzer is not available in this build (SDK requirement not met).")
 }
 
+@_cdecl("speech_analyzer_stream_start")
+public func speechAnalyzerStreamStart(
+    _ localeId: UnsafePointer<CChar>,
+    _ streamOut: UnsafeMutablePointer<UnsafeMutableRawPointer?>
+) -> UnsafeMutablePointer<SpeechAnalyzerResponse> {
+    streamOut.pointee = nil
+    return failureResponse(
+        "SpeechAnalyzer is not available in this build (SDK requirement not met).")
+}
+
+@_cdecl("speech_analyzer_stream_feed")
+public func speechAnalyzerStreamFeed(
+    _ stream: UnsafeMutableRawPointer?,
+    _ samples: UnsafePointer<Float>,
+    _ sampleCount: Int32
+) -> UnsafeMutablePointer<SpeechAnalyzerResponse> {
+    return failureResponse(
+        "SpeechAnalyzer is not available in this build (SDK requirement not met).")
+}
+
+@_cdecl("speech_analyzer_stream_snapshot")
+public func speechAnalyzerStreamSnapshot(
+    _ stream: UnsafeMutableRawPointer?
+) -> UnsafeMutablePointer<SpeechAnalyzerResponse> {
+    return failureResponse(
+        "SpeechAnalyzer is not available in this build (SDK requirement not met).")
+}
+
+@_cdecl("speech_analyzer_stream_finish")
+public func speechAnalyzerStreamFinish(
+    _ stream: UnsafeMutableRawPointer?
+) -> UnsafeMutablePointer<SpeechAnalyzerResponse> {
+    return failureResponse(
+        "SpeechAnalyzer is not available in this build (SDK requirement not met).")
+}
+
+@_cdecl("speech_analyzer_stream_cancel")
+public func speechAnalyzerStreamCancel(
+    _ stream: UnsafeMutableRawPointer?
+) -> UnsafeMutablePointer<SpeechAnalyzerResponse> {
+    return failureResponse(
+        "SpeechAnalyzer is not available in this build (SDK requirement not met).")
+}
+
+@_cdecl("free_speech_analyzer_stream")
+public func freeSpeechAnalyzerStream(_ stream: UnsafeMutableRawPointer?) {}
+
 @_cdecl("free_speech_analyzer_response")
 public func freeSpeechAnalyzerResponse(
     _ response: UnsafeMutablePointer<SpeechAnalyzerResponse>?

--- a/src-tauri/swift/speech_analyzer_stub.swift
+++ b/src-tauri/swift/speech_analyzer_stub.swift
@@ -24,9 +24,7 @@ public func speechAnalyzerSupportedLocales() -> UnsafeMutablePointer<SpeechAnaly
 
 @_cdecl("speech_analyzer_prepare")
 public func speechAnalyzerPrepare(
-    _ localeId: UnsafePointer<CChar>,
-    _ progressCallback: SpeechAnalyzerProgressCallback?,
-    _ progressContext: UnsafeMutableRawPointer?
+    _ localeId: UnsafePointer<CChar>
 ) -> UnsafeMutablePointer<SpeechAnalyzerResponse> {
     return failureResponse(
         "SpeechAnalyzer is not available in this build (SDK requirement not met).")

--- a/src-tauri/swift/speech_analyzer_stub.swift
+++ b/src-tauri/swift/speech_analyzer_stub.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+// Stub implementation when the SpeechAnalyzer API is not available in the
+// build environment (SDK older than macOS 26). Compiled via Cargo build
+// script as a fallback so the exported symbols always exist.
+
+private func failureResponse(_ message: String) -> UnsafeMutablePointer<SpeechAnalyzerResponse> {
+    let responsePtr = UnsafeMutablePointer<SpeechAnalyzerResponse>.allocate(capacity: 1)
+    responsePtr.initialize(to: SpeechAnalyzerResponse(text: nil, success: 0, error_message: nil))
+    responsePtr.pointee.error_message = strdup(message)
+    return responsePtr
+}
+
+@_cdecl("is_speech_analyzer_available")
+public func isSpeechAnalyzerAvailable() -> Int32 {
+    return 0
+}
+
+@_cdecl("speech_analyzer_prepare")
+public func speechAnalyzerPrepare(
+    _ localeId: UnsafePointer<CChar>
+) -> UnsafeMutablePointer<SpeechAnalyzerResponse> {
+    return failureResponse(
+        "SpeechAnalyzer is not available in this build (SDK requirement not met).")
+}
+
+@_cdecl("speech_analyzer_transcribe")
+public func speechAnalyzerTranscribe(
+    _ samples: UnsafePointer<Float>,
+    _ sampleCount: Int32,
+    _ localeId: UnsafePointer<CChar>
+) -> UnsafeMutablePointer<SpeechAnalyzerResponse> {
+    return failureResponse(
+        "SpeechAnalyzer is not available in this build (SDK requirement not met).")
+}
+
+@_cdecl("free_speech_analyzer_response")
+public func freeSpeechAnalyzerResponse(
+    _ response: UnsafeMutablePointer<SpeechAnalyzerResponse>?
+) {
+    guard let response = response else { return }
+
+    if let textStr = response.pointee.text {
+        free(UnsafeMutablePointer(mutating: textStr))
+    }
+
+    if let errorStr = response.pointee.error_message {
+        free(UnsafeMutablePointer(mutating: errorStr))
+    }
+
+    response.deallocate()
+}

--- a/src-tauri/swift/speech_analyzer_stub.swift
+++ b/src-tauri/swift/speech_analyzer_stub.swift
@@ -16,9 +16,17 @@ public func isSpeechAnalyzerAvailable() -> Int32 {
     return 0
 }
 
+@_cdecl("speech_analyzer_supported_locales")
+public func speechAnalyzerSupportedLocales() -> UnsafeMutablePointer<SpeechAnalyzerResponse> {
+    return failureResponse(
+        "SpeechAnalyzer is not available in this build (SDK requirement not met).")
+}
+
 @_cdecl("speech_analyzer_prepare")
 public func speechAnalyzerPrepare(
-    _ localeId: UnsafePointer<CChar>
+    _ localeId: UnsafePointer<CChar>,
+    _ progressCallback: SpeechAnalyzerProgressCallback?,
+    _ progressContext: UnsafeMutableRawPointer?
 ) -> UnsafeMutablePointer<SpeechAnalyzerResponse> {
     return failureResponse(
         "SpeechAnalyzer is not available in this build (SDK requirement not met).")

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -924,7 +924,12 @@ export type EngineType =
  * Voxtral, Qwen3-ASR, Nemotron, …). The architecture is auto-detected from
  * the file, so this one variant covers the whole transcribe-cpp family.
  */
-"TranscribeCpp" | "Parakeet" | "Moonshine" | "MoonshineStreaming" | "SenseVoice" | "GigaAM" | "Canary" | "Cohere"
+"TranscribeCpp" | "Parakeet" | "Moonshine" | "MoonshineStreaming" | "SenseVoice" | "GigaAM" | "Canary" | "Cohere" | 
+/**
+ * Apple's on-device SpeechAnalyzer API (macOS 26+). The OS manages the
+ * model assets; there is no file for Handy to download or load.
+ */
+"SpeechAnalyzer"
 export type GpuDeviceOption = { id: number; name: string; total_vram_mb: number }
 export type HistoryEntry = { id: number; file_name: string; timestamp: number; saved: boolean; title: string; transcription_text: string; post_processed_text: string | null; post_process_prompt: string | null; post_process_requested: boolean }
 export type HistoryUpdatePayload = { action: "added"; entry: HistoryEntry } | { action: "updated"; entry: HistoryEntry } | { action: "deleted"; id: number } | { action: "toggled"; id: number }

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -969,7 +969,7 @@ sha256: string | null } } |
  * Already present on disk — a user-provided custom model, or one discovered
  * in a shared cache. Nothing to download.
  */
-"Local" |
+"Local" | 
 /**
  * Supplied and managed by the operating system. There is no Handy-owned
  * model file to download, resolve, or delete.

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -969,7 +969,12 @@ sha256: string | null } } |
  * Already present on disk — a user-provided custom model, or one discovered
  * in a shared cache. Nothing to download.
  */
-"Local"
+"Local" |
+/**
+ * Supplied and managed by the operating system. There is no Handy-owned
+ * model file to download, resolve, or delete.
+ */
+"System"
 export type ModelUnloadTimeout = "never" | "immediately" | "min_2" | "min_5" | "min_10" | "min_15" | "hour_1" | "sec_15"
 export type OrtAcceleratorSetting = "auto" | "cpu" | "cuda" | "directml" | "rocm"
 export type OverlayPosition = "top" | "bottom"

--- a/src/components/onboarding/ModelCard.tsx
+++ b/src/components/onboarding/ModelCard.tsx
@@ -45,8 +45,7 @@ const getLanguageDisplayText = (
 export const isLegacySource = (model: ModelInfo): boolean =>
   typeof model.source === "object" && "Url" in model.source;
 
-export const isSystemSource = (model: ModelInfo): boolean =>
-  model.source === "System";
+const isSystemSource = (model: ModelInfo): boolean => model.source === "System";
 
 // Extract a GGUF quantization label from a filename, if present (e.g. "Q8_0").
 const getQuantLabel = (filename: string): string | null => {

--- a/src/components/onboarding/ModelCard.tsx
+++ b/src/components/onboarding/ModelCard.tsx
@@ -267,7 +267,7 @@ const ModelCard: React.FC<ModelCardProps> = ({
         {isSystemManaged && (
           <span className="flex items-center gap-1.5 ms-auto text-xs text-text/50">
             <Cpu className="w-3.5 h-3.5" />
-            <span>{t("theme.options.system")}</span>
+            <span>{t("modelSelector.system")}</span>
           </span>
         )}
         {showModelSize && (

--- a/src/components/onboarding/ModelCard.tsx
+++ b/src/components/onboarding/ModelCard.tsx
@@ -298,49 +298,46 @@ const ModelCard: React.FC<ModelCardProps> = ({
       </div>
 
       {/* Download/extract progress */}
-      {(status === "downloading" ||
-        status === "switching" ||
-        (isSystemManaged && status === "active")) &&
-        downloadProgress !== undefined && (
-          <div className="w-full mt-3">
-            <div className="w-full h-1.5 bg-mid-gray/20 rounded-full overflow-hidden">
-              <div
-                className="h-full bg-logo-primary rounded-full transition-all duration-300"
-                style={{ width: `${downloadProgress}%` }}
-              />
-            </div>
-            <div className="flex items-center justify-between text-xs mt-1">
-              <span className="text-text/50">
-                {t("modelSelector.downloading", {
-                  percentage: Math.round(downloadProgress),
-                })}
-              </span>
-              <div className="flex items-center gap-2">
-                {downloadSpeed !== undefined && downloadSpeed > 0 && (
-                  <span className="tabular-nums text-text/50">
-                    {t("modelSelector.downloadSpeed", {
-                      speed: downloadSpeed.toFixed(1),
-                    })}
-                  </span>
-                )}
-                {status === "downloading" && onCancel && (
-                  <Button
-                    variant="danger-ghost"
-                    size="sm"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      onCancel(model.id);
-                    }}
-                    aria-label={t("modelSelector.cancelDownload")}
-                  >
-                    {t("modelSelector.cancel")}
-                  </Button>
-                )}
-              </div>
+      {status === "downloading" && downloadProgress !== undefined && (
+        <div className="w-full mt-3">
+          <div className="w-full h-1.5 bg-mid-gray/20 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-logo-primary rounded-full transition-all duration-300"
+              style={{ width: `${downloadProgress}%` }}
+            />
+          </div>
+          <div className="flex items-center justify-between text-xs mt-1">
+            <span className="text-text/50">
+              {t("modelSelector.downloading", {
+                percentage: Math.round(downloadProgress),
+              })}
+            </span>
+            <div className="flex items-center gap-2">
+              {downloadSpeed !== undefined && downloadSpeed > 0 && (
+                <span className="tabular-nums text-text/50">
+                  {t("modelSelector.downloadSpeed", {
+                    speed: downloadSpeed.toFixed(1),
+                  })}
+                </span>
+              )}
+              {onCancel && (
+                <Button
+                  variant="danger-ghost"
+                  size="sm"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onCancel(model.id);
+                  }}
+                  aria-label={t("modelSelector.cancelDownload")}
+                >
+                  {t("modelSelector.cancel")}
+                </Button>
+              )}
             </div>
           </div>
-        )}
+        </div>
+      )}
       {status === "verifying" && (
         <div className="w-full mt-3">
           <div className="w-full h-1.5 bg-mid-gray/20 rounded-full overflow-hidden">

--- a/src/components/onboarding/ModelCard.tsx
+++ b/src/components/onboarding/ModelCard.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import {
   AudioLines,
   Check,
+  Cpu,
   Download,
   Globe,
   HardDrive,
@@ -43,6 +44,9 @@ const getLanguageDisplayText = (
 // advertised download (catalog GGUFs supersede it).
 export const isLegacySource = (model: ModelInfo): boolean =>
   typeof model.source === "object" && "Url" in model.source;
+
+export const isSystemSource = (model: ModelInfo): boolean =>
+  model.source === "System";
 
 // Extract a GGUF quantization label from a filename, if present (e.g. "Q8_0").
 const getQuantLabel = (filename: string): string | null => {
@@ -98,8 +102,12 @@ const ModelCard: React.FC<ModelCardProps> = ({
   // Get translated model name and description
   const displayName = getTranslatedModelName(model, t);
   const displayDescription = getTranslatedModelDescription(model, t);
+  const isSystemManaged = isSystemSource(model);
   const showModelSize =
-    status === "downloadable" || status === "available" || status === "active";
+    !isSystemManaged &&
+    (status === "downloadable" ||
+      status === "available" ||
+      status === "active");
   const formattedModelSize = formatModelSize(Number(model.size_mb));
   const quantLabel = getQuantLabel(model.filename);
   const capabilityLanguages = getUniqueCapabilityLanguages(
@@ -256,6 +264,12 @@ const ModelCard: React.FC<ModelCardProps> = ({
             <span>{t("modelSelector.streaming")}</span>
           </div>
         )}
+        {isSystemManaged && (
+          <span className="flex items-center gap-1.5 ms-auto text-xs text-text/50">
+            <Cpu className="w-3.5 h-3.5" />
+            <span>{t("theme.options.system")}</span>
+          </span>
+        )}
         {showModelSize && (
           <span className="flex items-center gap-1.5 ms-auto text-xs text-text/50">
             {status === "downloadable" ? (
@@ -267,61 +281,66 @@ const ModelCard: React.FC<ModelCardProps> = ({
             {quantLabel && <span className="text-text/40">{quantLabel}</span>}
           </span>
         )}
-        {onDelete && (status === "available" || status === "active") && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleDelete}
-            title={t("modelSelector.deleteModel", { modelName: displayName })}
-            className="flex items-center gap-1.5 text-logo-primary/85 hover:text-logo-primary hover:bg-logo-primary/10"
-          >
-            <Trash2 className="w-3.5 h-3.5" />
-            <span>{t("common.delete")}</span>
-          </Button>
-        )}
+        {onDelete &&
+          !isSystemManaged &&
+          (status === "available" || status === "active") && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleDelete}
+              title={t("modelSelector.deleteModel", { modelName: displayName })}
+              className="flex items-center gap-1.5 text-logo-primary/85 hover:text-logo-primary hover:bg-logo-primary/10"
+            >
+              <Trash2 className="w-3.5 h-3.5" />
+              <span>{t("common.delete")}</span>
+            </Button>
+          )}
       </div>
 
       {/* Download/extract progress */}
-      {status === "downloading" && downloadProgress !== undefined && (
-        <div className="w-full mt-3">
-          <div className="w-full h-1.5 bg-mid-gray/20 rounded-full overflow-hidden">
-            <div
-              className="h-full bg-logo-primary rounded-full transition-all duration-300"
-              style={{ width: `${downloadProgress}%` }}
-            />
-          </div>
-          <div className="flex items-center justify-between text-xs mt-1">
-            <span className="text-text/50">
-              {t("modelSelector.downloading", {
-                percentage: Math.round(downloadProgress),
-              })}
-            </span>
-            <div className="flex items-center gap-2">
-              {downloadSpeed !== undefined && downloadSpeed > 0 && (
-                <span className="tabular-nums text-text/50">
-                  {t("modelSelector.downloadSpeed", {
-                    speed: downloadSpeed.toFixed(1),
-                  })}
-                </span>
-              )}
-              {onCancel && (
-                <Button
-                  variant="danger-ghost"
-                  size="sm"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    onCancel(model.id);
-                  }}
-                  aria-label={t("modelSelector.cancelDownload")}
-                >
-                  {t("modelSelector.cancel")}
-                </Button>
-              )}
+      {(status === "downloading" ||
+        status === "switching" ||
+        (isSystemManaged && status === "active")) &&
+        downloadProgress !== undefined && (
+          <div className="w-full mt-3">
+            <div className="w-full h-1.5 bg-mid-gray/20 rounded-full overflow-hidden">
+              <div
+                className="h-full bg-logo-primary rounded-full transition-all duration-300"
+                style={{ width: `${downloadProgress}%` }}
+              />
+            </div>
+            <div className="flex items-center justify-between text-xs mt-1">
+              <span className="text-text/50">
+                {t("modelSelector.downloading", {
+                  percentage: Math.round(downloadProgress),
+                })}
+              </span>
+              <div className="flex items-center gap-2">
+                {downloadSpeed !== undefined && downloadSpeed > 0 && (
+                  <span className="tabular-nums text-text/50">
+                    {t("modelSelector.downloadSpeed", {
+                      speed: downloadSpeed.toFixed(1),
+                    })}
+                  </span>
+                )}
+                {status === "downloading" && onCancel && (
+                  <Button
+                    variant="danger-ghost"
+                    size="sm"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      onCancel(model.id);
+                    }}
+                    aria-label={t("modelSelector.cancelDownload")}
+                  >
+                    {t("modelSelector.cancel")}
+                  </Button>
+                )}
+              </div>
             </div>
           </div>
-        </div>
-      )}
+        )}
       {status === "verifying" && (
         <div className="w-full mt-3">
           <div className="w-full h-1.5 bg-mid-gray/20 rounded-full overflow-hidden">

--- a/src/components/onboarding/Onboarding.tsx
+++ b/src/components/onboarding/Onboarding.tsx
@@ -170,6 +170,8 @@ const Onboarding: React.FC<OnboardingProps> = ({ onModelSelected }) => {
                     status={getExistingModelStatus(model.id)}
                     disabled={isBusy}
                     onSelect={handleSelectExistingModel}
+                    downloadProgress={getModelDownloadProgress(model.id)}
+                    downloadSpeed={getModelDownloadSpeed(model.id)}
                     showRecommended={false}
                   />
                 ))}

--- a/src/components/onboarding/Onboarding.tsx
+++ b/src/components/onboarding/Onboarding.tsx
@@ -170,8 +170,6 @@ const Onboarding: React.FC<OnboardingProps> = ({ onModelSelected }) => {
                     status={getExistingModelStatus(model.id)}
                     disabled={isBusy}
                     onSelect={handleSelectExistingModel}
-                    downloadProgress={getModelDownloadProgress(model.id)}
-                    downloadSpeed={getModelDownloadSpeed(model.id)}
                     showRecommended={false}
                   />
                 ))}

--- a/src/components/onboarding/index.ts
+++ b/src/components/onboarding/index.ts
@@ -1,4 +1,5 @@
 export { default } from "./Onboarding";
 export { default as AccessibilityOnboarding } from "./AccessibilityOnboarding";
 export { default as ModelCard } from "./ModelCard";
+export { isSystemSource } from "./ModelCard";
 export type { ModelCardStatus } from "./ModelCard";

--- a/src/components/onboarding/index.ts
+++ b/src/components/onboarding/index.ts
@@ -1,5 +1,4 @@
 export { default } from "./Onboarding";
 export { default as AccessibilityOnboarding } from "./AccessibilityOnboarding";
 export { default as ModelCard } from "./ModelCard";
-export { isSystemSource } from "./ModelCard";
 export type { ModelCardStatus } from "./ModelCard";

--- a/src/components/settings/models/ModelsSettings.tsx
+++ b/src/components/settings/models/ModelsSettings.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { ask } from "@tauri-apps/plugin-dialog";
 import { ChevronDown, Globe, RefreshCw, Search } from "lucide-react";
 import type { ModelCardStatus } from "@/components/onboarding";
-import { ModelCard } from "@/components/onboarding";
+import { isSystemSource, ModelCard } from "@/components/onboarding";
 import { useModelStore } from "@/stores/modelStore";
 import {
   getLanguageLabel,
@@ -181,13 +181,18 @@ export const ModelsSettings: React.FC = () => {
     });
   }, [models, languageFilter, searchQuery]);
 
-  // Split filtered models into downloaded (including custom) and available sections
-  const { downloadedModels, availableModels } = useMemo(() => {
+  // Keep operating-system-managed models separate from Handy's downloadable
+  // catalog so the UI does not imply that their assets live in Handy's model
+  // directory or can be deleted here.
+  const { systemModels, downloadedModels, availableModels } = useMemo(() => {
+    const system: ModelInfo[] = [];
     const downloaded: ModelInfo[] = [];
     const available: ModelInfo[] = [];
 
     for (const model of filteredModels) {
-      if (
+      if (isSystemSource(model)) {
+        system.push(model);
+      } else if (
         model.is_custom ||
         model.is_downloaded ||
         model.id in downloadingModels ||
@@ -208,6 +213,7 @@ export const ModelsSettings: React.FC = () => {
     });
 
     return {
+      systemModels: system,
       downloadedModels: downloaded,
       availableModels: available,
     };
@@ -248,6 +254,24 @@ export const ModelsSettings: React.FC = () => {
 
       {filteredModels.length > 0 ? (
         <div className="space-y-6">
+          {systemModels.length > 0 && (
+            <div className="space-y-3">
+              <h2 className="text-sm font-medium text-text/60">
+                {t("theme.options.system")}
+              </h2>
+              {systemModels.map((model: ModelInfo) => (
+                <ModelCard
+                  key={model.id}
+                  model={model}
+                  status={getModelStatus(model.id)}
+                  onSelect={handleModelSelect}
+                  downloadProgress={getDownloadProgress(model.id)}
+                  showRecommended={false}
+                />
+              ))}
+            </div>
+          )}
+
           {/* Downloaded Models Section — header always visible so filter stays accessible */}
           <div className="space-y-3">
             <div className="flex items-center justify-between">

--- a/src/components/settings/models/ModelsSettings.tsx
+++ b/src/components/settings/models/ModelsSettings.tsx
@@ -265,7 +265,6 @@ export const ModelsSettings: React.FC = () => {
                   model={model}
                   status={getModelStatus(model.id)}
                   onSelect={handleModelSelect}
-                  downloadProgress={getDownloadProgress(model.id)}
                   showRecommended={false}
                 />
               ))}

--- a/src/components/settings/models/ModelsSettings.tsx
+++ b/src/components/settings/models/ModelsSettings.tsx
@@ -257,7 +257,7 @@ export const ModelsSettings: React.FC = () => {
           {systemModels.length > 0 && (
             <div className="space-y-3">
               <h2 className="text-sm font-medium text-text/60">
-                {t("theme.options.system")}
+                {t("settings.models.systemModels")}
               </h2>
               {systemModels.map((model: ModelInfo) => (
                 <ModelCard

--- a/src/components/settings/models/ModelsSettings.tsx
+++ b/src/components/settings/models/ModelsSettings.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { ask } from "@tauri-apps/plugin-dialog";
 import { ChevronDown, Globe, RefreshCw, Search } from "lucide-react";
 import type { ModelCardStatus } from "@/components/onboarding";
-import { isSystemSource, ModelCard } from "@/components/onboarding";
+import { ModelCard } from "@/components/onboarding";
 import { useModelStore } from "@/stores/modelStore";
 import {
   getLanguageLabel,
@@ -181,18 +181,14 @@ export const ModelsSettings: React.FC = () => {
     });
   }, [models, languageFilter, searchQuery]);
 
-  // Keep operating-system-managed models separate from Handy's downloadable
-  // catalog so the UI does not imply that their assets live in Handy's model
-  // directory or can be deleted here.
-  const { systemModels, downloadedModels, availableModels } = useMemo(() => {
-    const system: ModelInfo[] = [];
+  // Split filtered models into downloaded/selectable (including custom and
+  // system-managed models) and available-to-download sections.
+  const { downloadedModels, availableModels } = useMemo(() => {
     const downloaded: ModelInfo[] = [];
     const available: ModelInfo[] = [];
 
     for (const model of filteredModels) {
-      if (isSystemSource(model)) {
-        system.push(model);
-      } else if (
+      if (
         model.is_custom ||
         model.is_downloaded ||
         model.id in downloadingModels ||
@@ -213,7 +209,6 @@ export const ModelsSettings: React.FC = () => {
     });
 
     return {
-      systemModels: system,
       downloadedModels: downloaded,
       availableModels: available,
     };
@@ -254,23 +249,6 @@ export const ModelsSettings: React.FC = () => {
 
       {filteredModels.length > 0 ? (
         <div className="space-y-6">
-          {systemModels.length > 0 && (
-            <div className="space-y-3">
-              <h2 className="text-sm font-medium text-text/60">
-                {t("settings.models.systemModels")}
-              </h2>
-              {systemModels.map((model: ModelInfo) => (
-                <ModelCard
-                  key={model.id}
-                  model={model}
-                  status={getModelStatus(model.id)}
-                  onSelect={handleModelSelect}
-                  showRecommended={false}
-                />
-              ))}
-            </div>
-          )}
-
           {/* Downloaded Models Section — header always visible so filter stays accessible */}
           <div className="space-y-3">
             <div className="flex items-center justify-between">

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -93,6 +93,10 @@
       "cohere-int8": {
         "name": "Cohere",
         "description": "نموذج كبير وأبطأ، لكنه دقيق جداً ومتعدد اللغات."
+      },
+      "apple-speechanalyzer": {
+        "name": "Apple Speech",
+        "description": "محرك SpeechAnalyzer الجديد من Apple الذي يعمل على الجهاز (macOS 26 والأحدث). يتولى macOS تنزيل موارد التعرف على الكلام وإدارتها."
       }
     },
     "errors": {
@@ -122,6 +126,7 @@
   "modelSelector": {
     "custom": "مخصص",
     "streaming": "البث",
+    "system": "النظام",
     "active": "نشط",
     "noModelsAvailable": "لا توجد نماذج متاحة",
     "verifying": "جارٍ التحقق من {{modelName}}...",

--- a/src/i18n/locales/bg/translation.json
+++ b/src/i18n/locales/bg/translation.json
@@ -93,6 +93,10 @@
       "cohere-int8": {
         "name": "Cohere",
         "description": "Голям, по-бавен, но много точен многоезичен модел."
+      },
+      "apple-speechanalyzer": {
+        "name": "Apple Speech",
+        "description": "Новият вграден в устройството двигател SpeechAnalyzer на Apple (macOS 26+). Гласовите ресурси се изтеглят и управляват от macOS."
       }
     },
     "errors": {
@@ -122,6 +126,7 @@
   "modelSelector": {
     "custom": "Персонализиран",
     "streaming": "Стрийминг",
+    "system": "Системен",
     "active": "Активен",
     "switching": "Превключване...",
     "noModelsAvailable": "Няма налични модели",

--- a/src/i18n/locales/cs/translation.json
+++ b/src/i18n/locales/cs/translation.json
@@ -93,6 +93,10 @@
       "cohere-int8": {
         "name": "Cohere",
         "description": "Velký, pomalejší, ale velmi přesný vícejazyčný model."
+      },
+      "apple-speechanalyzer": {
+        "name": "Apple Speech",
+        "description": "Nový engine SpeechAnalyzer od Applu běžící přímo v zařízení (macOS 26+). Hlasové soubory stahuje a spravuje macOS."
       }
     },
     "errors": {
@@ -122,6 +126,7 @@
   "modelSelector": {
     "custom": "Vlastní",
     "streaming": "Streaming",
+    "system": "Systémový",
     "active": "Aktivní",
     "noModelsAvailable": "Nejsou dostupné žádné modely",
     "verifying": "Ověřování {{modelName}}...",

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -93,6 +93,10 @@
       "cohere-int8": {
         "name": "Cohere",
         "description": "Ein großes, langsameres, aber sehr genaues mehrsprachiges Modell."
+      },
+      "apple-speechanalyzer": {
+        "name": "Apple Speech",
+        "description": "Apples neue geräteinterne SpeechAnalyzer-Engine (macOS 26+). Sprachressourcen werden von macOS heruntergeladen und verwaltet."
       }
     },
     "errors": {
@@ -122,6 +126,7 @@
   "modelSelector": {
     "custom": "Benutzerdefiniert",
     "streaming": "Streaming",
+    "system": "System",
     "active": "Aktiv",
     "switching": "Wechseln...",
     "noModelsAvailable": "Keine Modelle verfügbar",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -209,7 +209,6 @@
       "searchPlaceholder": "Search models by name…",
       "yourModels": "Downloaded Models",
       "availableModels": "Available to Download",
-      "systemModels": "System Models",
       "deleteConfirm": "Are you sure you want to delete {{modelName}}? You will need to download it again to use it.",
       "deleteActiveConfirm": "{{modelName}} is your active model. Deleting it will stop transcriptions until you select a new model. Are you sure?",
       "deleteTitle": "Delete Model",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -96,7 +96,7 @@
       },
       "apple-speechanalyzer": {
         "name": "Apple Speech",
-        "description": "Apple's built-in on-device speech recognition (macOS 26+). Speech assets are downloaded by macOS on first use."
+        "description": "Apple's new on-device SpeechAnalyzer engine (macOS 26+). Speech assets are downloaded and managed by macOS."
       }
     },
     "errors": {

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -96,7 +96,7 @@
       },
       "apple-speechanalyzer": {
         "name": "Apple Speech",
-        "description": "Apple's built-in on-device speech recognition (macOS 26+)."
+        "description": "Apple's built-in on-device speech recognition (macOS 26+). Speech assets are downloaded by macOS on first use."
       }
     },
     "errors": {

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -93,6 +93,10 @@
       "cohere-int8": {
         "name": "Cohere",
         "description": "A large, slower, but very accurate multilingual model."
+      },
+      "apple-speechanalyzer": {
+        "name": "Apple Speech",
+        "description": "Apple's built-in on-device speech recognition (macOS 26+)."
       }
     },
     "errors": {
@@ -123,6 +127,7 @@
     "custom": "Custom",
     "legacy": "Legacy",
     "streaming": "Streaming",
+    "system": "System",
     "active": "Active",
     "switching": "Switching...",
     "noModelsAvailable": "No models available",
@@ -204,6 +209,7 @@
       "searchPlaceholder": "Search models by name…",
       "yourModels": "Downloaded Models",
       "availableModels": "Available to Download",
+      "systemModels": "System Models",
       "deleteConfirm": "Are you sure you want to delete {{modelName}}? You will need to download it again to use it.",
       "deleteActiveConfirm": "{{modelName}} is your active model. Deleting it will stop transcriptions until you select a new model. Are you sure?",
       "deleteTitle": "Delete Model",

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -93,6 +93,10 @@
       "cohere-int8": {
         "name": "Cohere",
         "description": "Un modelo grande, más lento, pero muy preciso y multilingüe."
+      },
+      "apple-speechanalyzer": {
+        "name": "Apple Speech",
+        "description": "El nuevo motor SpeechAnalyzer de Apple integrado en el dispositivo (macOS 26+). macOS descarga y gestiona los recursos de voz."
       }
     },
     "errors": {
@@ -122,6 +126,7 @@
   "modelSelector": {
     "custom": "Personalizado",
     "streaming": "Streaming",
+    "system": "Sistema",
     "active": "Activo",
     "switching": "Cambiando...",
     "noModelsAvailable": "No hay modelos disponibles",

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -93,6 +93,10 @@
       "cohere-int8": {
         "name": "Cohere",
         "description": "Un modèle volumineux, plus lent, mais très précis et multilingue."
+      },
+      "apple-speechanalyzer": {
+        "name": "Apple Speech",
+        "description": "Le nouveau moteur SpeechAnalyzer d'Apple intégré à l'appareil (macOS 26+). Les ressources vocales sont téléchargées et gérées par macOS."
       }
     },
     "errors": {
@@ -122,6 +126,7 @@
   "modelSelector": {
     "custom": "Personnalisé",
     "streaming": "Streaming",
+    "system": "Système",
     "active": "Actif",
     "switching": "Changement...",
     "noModelsAvailable": "Aucun modèle disponible",

--- a/src/i18n/locales/he/translation.json
+++ b/src/i18n/locales/he/translation.json
@@ -93,6 +93,10 @@
       "cohere-int8": {
         "name": "Cohere",
         "description": "מודל גדול, איטי יותר, אך מדויק מאוד ורב-לשוני."
+      },
+      "apple-speechanalyzer": {
+        "name": "Apple Speech",
+        "description": "מנוע SpeechAnalyzer החדש של Apple הפועל על המכשיר (macOS 26 ואילך). משאבי הדיבור מורדים ומנוהלים על ידי macOS."
       }
     },
     "errors": {
@@ -122,6 +126,7 @@
   "modelSelector": {
     "custom": "מותאם אישית",
     "streaming": "סטרימינג",
+    "system": "מערכת",
     "active": "פעיל",
     "switching": "מחליף...",
     "noModelsAvailable": "אין מודלים זמינים",

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -93,6 +93,10 @@
       "cohere-int8": {
         "name": "Cohere",
         "description": "Un modello grande, più lento, ma molto accurato e multilingue."
+      },
+      "apple-speechanalyzer": {
+        "name": "Apple Speech",
+        "description": "Il nuovo motore SpeechAnalyzer di Apple integrato nel dispositivo (macOS 26+). Le risorse vocali vengono scaricate e gestite da macOS."
       }
     },
     "errors": {
@@ -122,6 +126,7 @@
   "modelSelector": {
     "custom": "Personalizzato",
     "streaming": "Streaming",
+    "system": "Sistema",
     "active": "Attivo",
     "switching": "Cambio...",
     "noModelsAvailable": "Nessun modello disponibile",

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -93,6 +93,10 @@
       "cohere-int8": {
         "name": "Cohere",
         "description": "大型で低速ですが、非常に高精度な多言語モデル。"
+      },
+      "apple-speechanalyzer": {
+        "name": "Apple Speech",
+        "description": "Appleの新しいオンデバイスSpeechAnalyzerエンジン（macOS 26以降）。音声アセットはmacOSがダウンロードして管理します。"
       }
     },
     "errors": {
@@ -122,6 +126,7 @@
   "modelSelector": {
     "custom": "カスタム",
     "streaming": "ストリーミング",
+    "system": "システム",
     "active": "アクティブ",
     "switching": "切替中…",
     "noModelsAvailable": "利用可能なモデルがありません",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -93,6 +93,10 @@
       "cohere-int8": {
         "name": "Cohere",
         "description": "크고 느리지만 매우 정확한 다국어 모델."
+      },
+      "apple-speechanalyzer": {
+        "name": "Apple Speech",
+        "description": "Apple의 새로운 온디바이스 SpeechAnalyzer 엔진(macOS 26 이상). 음성 에셋은 macOS가 다운로드하고 관리합니다."
       }
     },
     "errors": {
@@ -122,6 +126,7 @@
   "modelSelector": {
     "custom": "사용자 정의",
     "streaming": "스트리밍",
+    "system": "시스템",
     "active": "활성",
     "switching": "전환 중...",
     "noModelsAvailable": "사용 가능한 모델이 없습니다",

--- a/src/i18n/locales/ne/translation.json
+++ b/src/i18n/locales/ne/translation.json
@@ -93,6 +93,10 @@
       "cohere-int8": {
         "name": "Cohere",
         "description": "ठूलो, अलि ढिलो, तर धेरै सटीक बहुभाषिक मोडेल।"
+      },
+      "apple-speechanalyzer": {
+        "name": "Apple Speech",
+        "description": "Apple को नयाँ अन-डिभाइस SpeechAnalyzer इन्जिन (macOS 26+)। स्पिच एसेटहरू macOS ले डाउनलोड र व्यवस्थापन गर्छ।"
       }
     },
     "errors": {
@@ -123,6 +127,7 @@
     "custom": "कस्टम",
     "legacy": "लिगेसी",
     "streaming": "स्ट्रिमिङ",
+    "system": "सिस्टम",
     "active": "सक्रिय",
     "switching": "बदलिँदैछ...",
     "noModelsAvailable": "कुनै मोडेल उपलब्ध छैन",

--- a/src/i18n/locales/nl/translation.json
+++ b/src/i18n/locales/nl/translation.json
@@ -93,6 +93,10 @@
       "cohere-int8": {
         "name": "Cohere",
         "description": "Een groot, trager, maar zeer nauwkeurig meertalig model."
+      },
+      "apple-speechanalyzer": {
+        "name": "Apple Speech",
+        "description": "Apples nieuwe SpeechAnalyzer-engine op het apparaat (macOS 26+). Spraakbestanden worden gedownload en beheerd door macOS."
       }
     },
     "errors": {
@@ -123,6 +127,7 @@
     "custom": "Aangepast",
     "legacy": "Klassiek",
     "streaming": "Streaming",
+    "system": "Systeem",
     "active": "Actief",
     "switching": "Wisselen...",
     "noModelsAvailable": "Geen modellen beschikbaar",

--- a/src/i18n/locales/pl/translation.json
+++ b/src/i18n/locales/pl/translation.json
@@ -93,6 +93,10 @@
       "cohere-int8": {
         "name": "Cohere",
         "description": "Duży, wolniejszy, ale bardzo dokładny model wielojęzyczny."
+      },
+      "apple-speechanalyzer": {
+        "name": "Apple Speech",
+        "description": "Nowy silnik SpeechAnalyzer firmy Apple działający na urządzeniu (macOS 26+). Zasoby mowy są pobierane i zarządzane przez macOS."
       }
     },
     "errors": {
@@ -122,6 +126,7 @@
   "modelSelector": {
     "custom": "Własny",
     "streaming": "Streaming",
+    "system": "Systemowy",
     "active": "Aktywny",
     "switching": "Przełączanie...",
     "noModelsAvailable": "Brak dostępnych modeli",

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -93,6 +93,10 @@
       "cohere-int8": {
         "name": "Cohere",
         "description": "Um modelo grande, mais lento, mas muito preciso e multilíngue."
+      },
+      "apple-speechanalyzer": {
+        "name": "Apple Speech",
+        "description": "O novo mecanismo SpeechAnalyzer da Apple no dispositivo (macOS 26+). Os recursos de voz são baixados e gerenciados pelo macOS."
       }
     },
     "errors": {
@@ -122,6 +126,7 @@
   "modelSelector": {
     "custom": "Personalizado",
     "streaming": "Streaming",
+    "system": "Sistema",
     "active": "Ativo",
     "noModelsAvailable": "Nenhum modelo disponível",
     "verifying": "Verificando {{modelName}}...",

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -93,6 +93,10 @@
       "cohere-int8": {
         "name": "Cohere",
         "description": "Большая, медленная, но очень точная многоязычная модель."
+      },
+      "apple-speechanalyzer": {
+        "name": "Apple Speech",
+        "description": "Новый движок SpeechAnalyzer от Apple, работающий на устройстве (macOS 26+). Речевые ресурсы загружаются и управляются macOS."
       }
     },
     "errors": {
@@ -122,6 +126,7 @@
   "modelSelector": {
     "custom": "Пользовательская",
     "streaming": "Потоковый",
+    "system": "Системная",
     "active": "Активный",
     "switching": "Переключение...",
     "noModelsAvailable": "Нет доступных моделей",

--- a/src/i18n/locales/sv/translation.json
+++ b/src/i18n/locales/sv/translation.json
@@ -93,6 +93,10 @@
       "cohere-int8": {
         "name": "Cohere",
         "description": "En stor, långsammare, men mycket noggrann flerspråkig modell."
+      },
+      "apple-speechanalyzer": {
+        "name": "Apple Speech",
+        "description": "Apples nya SpeechAnalyzer-motor på enheten (macOS 26+). Talresurser hämtas och hanteras av macOS."
       }
     },
     "errors": {
@@ -122,6 +126,7 @@
   "modelSelector": {
     "custom": "Anpassad",
     "streaming": "Streaming",
+    "system": "System",
     "active": "Aktiv",
     "switching": "Byter...",
     "noModelsAvailable": "Inga modeller tillgängliga",

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -93,6 +93,10 @@
       "cohere-int8": {
         "name": "Cohere",
         "description": "Büyük, daha yavaş, ancak çok doğru çok dilli bir model."
+      },
+      "apple-speechanalyzer": {
+        "name": "Apple Speech",
+        "description": "Apple'ın cihaz üzerinde çalışan yeni SpeechAnalyzer motoru (macOS 26+). Konuşma varlıkları macOS tarafından indirilir ve yönetilir."
       }
     },
     "errors": {
@@ -122,6 +126,7 @@
   "modelSelector": {
     "custom": "Özel",
     "streaming": "Akış",
+    "system": "Sistem",
     "active": "Aktif",
     "noModelsAvailable": "Kullanılabilir model yok",
     "verifying": "{{modelName}} doğrulanıyor...",

--- a/src/i18n/locales/uk/translation.json
+++ b/src/i18n/locales/uk/translation.json
@@ -93,6 +93,10 @@
       "cohere-int8": {
         "name": "Cohere",
         "description": "Велика, повільніша, але дуже точна багатомовна модель."
+      },
+      "apple-speechanalyzer": {
+        "name": "Apple Speech",
+        "description": "Новий рушій SpeechAnalyzer від Apple, що працює на пристрої (macOS 26+). Мовні ресурси завантажуються та керуються macOS."
       }
     },
     "errors": {
@@ -122,6 +126,7 @@
   "modelSelector": {
     "custom": "Користувацька",
     "streaming": "Потокове",
+    "system": "Системна",
     "active": "Активна",
     "noModelsAvailable": "Немає доступних моделей",
     "verifying": "Перевірка {{modelName}}...",

--- a/src/i18n/locales/vi/translation.json
+++ b/src/i18n/locales/vi/translation.json
@@ -93,6 +93,10 @@
       "cohere-int8": {
         "name": "Cohere",
         "description": "Mô hình lớn, chậm hơn, nhưng rất chính xác và đa ngôn ngữ."
+      },
+      "apple-speechanalyzer": {
+        "name": "Apple Speech",
+        "description": "Công cụ SpeechAnalyzer mới của Apple chạy ngay trên thiết bị (macOS 26+). Tài nguyên giọng nói được macOS tải xuống và quản lý."
       }
     },
     "errors": {
@@ -122,6 +126,7 @@
   "modelSelector": {
     "custom": "Tùy chỉnh",
     "streaming": "Truyền trực tiếp",
+    "system": "Hệ thống",
     "active": "Đang hoạt động",
     "switching": "Đang chuyển...",
     "noModelsAvailable": "Không có mô hình nào",

--- a/src/i18n/locales/zh-TW/translation.json
+++ b/src/i18n/locales/zh-TW/translation.json
@@ -93,6 +93,10 @@
       "cohere-int8": {
         "name": "Cohere",
         "description": "大型模型，速度較慢，但多語言辨識非常準確。"
+      },
+      "apple-speechanalyzer": {
+        "name": "Apple Speech",
+        "description": "Apple 全新的裝置端 SpeechAnalyzer 引擎（macOS 26+）。語音資源由 macOS 下載與管理。"
       }
     },
     "errors": {
@@ -122,6 +126,7 @@
   "modelSelector": {
     "custom": "自訂",
     "streaming": "串流",
+    "system": "系統",
     "active": "使用中",
     "switching": "切換中...",
     "noModelsAvailable": "沒有可用的模型",

--- a/src/i18n/locales/zh/translation.json
+++ b/src/i18n/locales/zh/translation.json
@@ -93,6 +93,10 @@
       "cohere-int8": {
         "name": "Cohere",
         "description": "大型模型，速度较慢，但多语言识别非常准确。"
+      },
+      "apple-speechanalyzer": {
+        "name": "Apple Speech",
+        "description": "Apple 全新的设备端 SpeechAnalyzer 引擎（macOS 26+）。语音资源由 macOS 下载和管理。"
       }
     },
     "errors": {
@@ -122,6 +126,7 @@
   "modelSelector": {
     "custom": "自定义",
     "streaming": "流式",
+    "system": "系统",
     "active": "活跃",
     "switching": "切换中...",
     "noModelsAvailable": "没有可用的模型",

--- a/src/stores/modelStore.ts
+++ b/src/stores/modelStore.ts
@@ -332,26 +332,6 @@ export const useModelStore = create<ModelsStore>()(
         get().loadModels();
       });
 
-      // System-managed models reuse the download progress UI while the OS
-      // prepares assets, but completion must not trigger the catalog download
-      // behavior (notably ModelSelector's automatic model selection).
-      const clearModelPreparationProgress = (modelId: string) => {
-        set(
-          produce((state) => {
-            delete state.downloadProgress[modelId];
-            delete state.downloadStats[modelId];
-          }),
-        );
-      };
-
-      listen<string>("model-preparation-complete", (event) => {
-        clearModelPreparationProgress(event.payload);
-      });
-
-      listen<string>("model-preparation-failed", (event) => {
-        clearModelPreparationProgress(event.payload);
-      });
-
       listen<{ model_id: string; error: string }>(
         "model-download-failed",
         (event) => {

--- a/src/stores/modelStore.ts
+++ b/src/stores/modelStore.ts
@@ -332,6 +332,26 @@ export const useModelStore = create<ModelsStore>()(
         get().loadModels();
       });
 
+      // System-managed models reuse the download progress UI while the OS
+      // prepares assets, but completion must not trigger the catalog download
+      // behavior (notably ModelSelector's automatic model selection).
+      const clearModelPreparationProgress = (modelId: string) => {
+        set(
+          produce((state) => {
+            delete state.downloadProgress[modelId];
+            delete state.downloadStats[modelId];
+          }),
+        );
+      };
+
+      listen<string>("model-preparation-complete", (event) => {
+        clearModelPreparationProgress(event.payload);
+      });
+
+      listen<string>("model-preparation-failed", (event) => {
+        clearModelPreparationProgress(event.payload);
+      });
+
       listen<{ model_id: string; error: string }>(
         "model-download-failed",
         (event) => {


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md) <!-- TODO(alex): confirm and check -->

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

Adds an "Apple Speech" model backed by the SpeechAnalyzer API on macOS 26+ (Apple Silicon). It shows up in a separate "System Models" section since the OS owns the model assets. There's nothing for Handy to download, store, or delete, it's all managed by the OS. This deviates from the existing pathway for how models are downloaded and deleted on user's command, and adds a new type of model to the system in its own section. The change is inspired by [this article](https://get-inscribe.com/blog/apple-speech-api-benchmark.html).

The Swift bridge follows the same pattern as the existing Apple Intelligence bridge: compiled by build.rs, with a stub fallback when the SDK is older than macOS 26 (you need the Xcode 26 SDK to build the real thing).

One quirk worth knowing: SpeechTranscriber punctuates well but starts every sentence lowercase and has no API option to change that, so there's a small post-processing pass that capitalizes sentence starts (unit-tested).

Caveats: Apple Silicon + macOS 26 only, and building it requires the Xcode 26 SDK (older toolchains compile a stub and the model simply doesn't appear).

## Related Issues/Discussions

Discussion: https://github.com/cjpais/Handy/discussions/1031 (Native Apple Speech)
Also related: https://github.com/cjpais/Handy/discussions/1244 (user asking for exactly this)

No existing PR implements this. I searched open/closed/merged PRs for SpeechAnalyzer, Apple Speech, native speech, dictation, etc. (the existing "apple" PRs are all about Apple Intelligence post-processing).

## Community Feedback

Requested in [#1031](https://github.com/cjpais/Handy/discussions/1031) and [#1244](https://github.com/cjpais/Handy/discussions/1244). @cjpais invited this PR in #1031: "You can open a PR for this I'll pull it in."

## Testing

- Daily-driving it for real dictation on an M-series Mac (macOS 26): accuracy is good, punctuation lands where you'd expect.
- Quick 5x benchmark against a 34s recording of my voice:

  | | Apple Speech | Parakeet V3 |
  | -- | -- | -- |
  | Best of 5 runs | 513 ms | 1,035 ms |
  | Mean of 5 runs | 591 ms | 1,069 ms |
  | Real-time factor | 67x | 33x |
  | Model load time | 11 ms | 601 ms |

- Unit tests cover the sentence-capitalization pass and the language/locale invariants the backend relies on.
- Verified the model is correctly hidden on unsupported environments (tested in a macOS 26 VM, where `SpeechTranscriber.isAvailable` is false).

## Screenshots/Videos (if applicable)

**Onboarding with no access to the API:**

<img width="948" height="790" alt="CleanShot 2026-07-14 at 00 18 18@2x" src="https://github.com/user-attachments/assets/97c7d437-e7f6-429c-99ad-d7e0983d1ec2" />

**Onboarding with access to the API:**

<img width="1446" height="1644" alt="CleanShot 2026-07-14 at 00 16 12@2x" src="https://github.com/user-attachments/assets/2e24e9bd-487d-4795-b14e-b29c73cb7ed2" />

_Note: it would be neat to clarify what exactly the pink background means on that UI page, I wasn't sure if pink meant those were the suggested defaults, or if those models were already downloaded, or if that was a pre-selected bundle I needed to download all at once._

**App's main screen after onboarding, when the API is available on the system:**

<img width="1386" height="1906" alt="Apple Speech model card in Handy settings" src="https://github.com/user-attachments/assets/c934d5ce-be4c-468f-b139-dc5ab3578eab" />

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

Codex 5.6 Sol on Extra High and Claude Code (Fable 5) on High. Heavily assisted on the code; I reviewed, tested, and have been running it all day for my own usage. Some of the changes go beyond my expertise, so feedback is very welcome. Everything added already had an existing pattern in the codebase that the agent could piggyback off of without having to get creative.