### PR TITLE
Declutter model cards (only show quantization label on modelcard in debug mode)

### DIFF
--- a/src/components/onboarding/ModelCard.tsx
+++ b/src/components/onboarding/ModelCard.tsx
@@ -22,6 +22,7 @@ import {
 } from "../../lib/constants/languages";
 import Badge from "../ui/Badge";
 import { Button } from "../ui/Button";
+import { useSettingsStore } from "@/stores/settingsStore";
 
 // Get display text for model's language support
 const getLanguageDisplayText = (
@@ -74,6 +75,7 @@ interface ModelCardProps {
   downloadProgress?: number;
   downloadSpeed?: number; // MB/s
   showRecommended?: boolean;
+  isOnboarding?: boolean;
 }
 
 const ModelCard: React.FC<ModelCardProps> = ({
@@ -89,8 +91,12 @@ const ModelCard: React.FC<ModelCardProps> = ({
   downloadProgress,
   downloadSpeed,
   showRecommended = true,
+  isOnboarding = false,
 }) => {
   const { t } = useTranslation();
+  const debugMode = useSettingsStore(
+    (state) => state.settings?.debug_mode ?? false,
+  );
   const isFeatured = variant === "featured";
   const isClickable =
     status === "available" || status === "active" || status === "downloadable";
@@ -264,7 +270,9 @@ const ModelCard: React.FC<ModelCardProps> = ({
               <HardDrive className="w-3.5 h-3.5" />
             )}
             <span>{formattedModelSize}</span>
-            {quantLabel && <span className="text-text/40">{quantLabel}</span>}
+            {!isOnboarding && debugMode && quantLabel && (
+              <span className="text-text/40">{quantLabel}</span>
+            )}
           </span>
         )}
         {onDelete && (status === "available" || status === "active") && (

--- a/src/components/onboarding/ModelCard.tsx
+++ b/src/components/onboarding/ModelCard.tsx
@@ -75,7 +75,6 @@ interface ModelCardProps {
   downloadProgress?: number;
   downloadSpeed?: number; // MB/s
   showRecommended?: boolean;
-  isOnboarding?: boolean;
 }
 
 const ModelCard: React.FC<ModelCardProps> = ({
@@ -91,7 +90,6 @@ const ModelCard: React.FC<ModelCardProps> = ({
   downloadProgress,
   downloadSpeed,
   showRecommended = true,
-  isOnboarding = false,
 }) => {
   const { t } = useTranslation();
   const debugMode = useSettingsStore(
@@ -270,7 +268,7 @@ const ModelCard: React.FC<ModelCardProps> = ({
               <HardDrive className="w-3.5 h-3.5" />
             )}
             <span>{formattedModelSize}</span>
-            {!isOnboarding && debugMode && quantLabel && (
+            {debugMode && quantLabel && (
               <span className="text-text/40">{quantLabel}</span>
             )}
           </span>

--- a/src/components/onboarding/Onboarding.tsx
+++ b/src/components/onboarding/Onboarding.tsx
@@ -171,7 +171,6 @@ const Onboarding: React.FC<OnboardingProps> = ({ onModelSelected }) => {
                     disabled={isBusy}
                     onSelect={handleSelectExistingModel}
                     showRecommended={false}
-                    isOnboarding={true}
                   />
                 ))}
             </div>
@@ -198,7 +197,6 @@ const Onboarding: React.FC<OnboardingProps> = ({ onModelSelected }) => {
                   downloadProgress={getModelDownloadProgress(model.id)}
                   downloadSpeed={getModelDownloadSpeed(model.id)}
                   showRecommended={false}
-                  isOnboarding={true}
                 />
               ))}
 
@@ -214,7 +212,6 @@ const Onboarding: React.FC<OnboardingProps> = ({ onModelSelected }) => {
                   downloadProgress={getModelDownloadProgress(model.id)}
                   downloadSpeed={getModelDownloadSpeed(model.id)}
                   showRecommended={false}
-                  isOnboarding={true}
                 />
               ))}
 
@@ -250,7 +247,6 @@ const Onboarding: React.FC<OnboardingProps> = ({ onModelSelected }) => {
                     downloadProgress={getModelDownloadProgress(model.id)}
                     downloadSpeed={getModelDownloadSpeed(model.id)}
                     showRecommended={false}
-                    isOnboarding={true}
                   />
                 ))}
             </div>

--- a/src/components/onboarding/Onboarding.tsx
+++ b/src/components/onboarding/Onboarding.tsx
@@ -171,6 +171,7 @@ const Onboarding: React.FC<OnboardingProps> = ({ onModelSelected }) => {
                     disabled={isBusy}
                     onSelect={handleSelectExistingModel}
                     showRecommended={false}
+                    isOnboarding={true}
                   />
                 ))}
             </div>
@@ -197,6 +198,7 @@ const Onboarding: React.FC<OnboardingProps> = ({ onModelSelected }) => {
                   downloadProgress={getModelDownloadProgress(model.id)}
                   downloadSpeed={getModelDownloadSpeed(model.id)}
                   showRecommended={false}
+                  isOnboarding={true}
                 />
               ))}
 
@@ -212,6 +214,7 @@ const Onboarding: React.FC<OnboardingProps> = ({ onModelSelected }) => {
                   downloadProgress={getModelDownloadProgress(model.id)}
                   downloadSpeed={getModelDownloadSpeed(model.id)}
                   showRecommended={false}
+                  isOnboarding={true}
                 />
               ))}
 
@@ -247,6 +250,7 @@ const Onboarding: React.FC<OnboardingProps> = ({ onModelSelected }) => {
                     downloadProgress={getModelDownloadProgress(model.id)}
                     downloadSpeed={getModelDownloadSpeed(model.id)}
                     showRecommended={false}
+                    isOnboarding={true}
                   />
                 ))}
             </div>


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

Right now, the model download cards display the specific quantization format next to the file size (e.g., Q8_0). This pr makes it so that label is only shown in debug mode. This makes it less overwhelming for 'standard' users.

## Related Issues/Discussions

Fixes #
Discussion: #1676 

## Testing
Made an test-build to check if everything was working. 
[https://github.com/MikaKrul/Handy/actions/runs/29341448695](url)

I have tested it on Windows **10/11**.

## Screenshots/Videos (if applicable)
The header elements look different across the screenshots because I tested the build on win 10...

Before:
<img width="683" height="608" alt="before" src="https://github.com/user-attachments/assets/eb77c30f-d932-4ba8-9731-d4b33d682b4d" />

After:
<img width="854" height="752" alt="after" src="https://github.com/user-attachments/assets/e8e25eb1-3b8e-4818-8b5f-452a3b97c815" />

(in debug mode)
<img width="851" height="749" alt="in debug mode" src="https://github.com/user-attachments/assets/60d3972c-0965-4129-87d9-9e3e6c1e609c" />


## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenCode
- How extensively: helped with reviewen code and finding what to change.
