### PR TITLE
fix(audio): move blocking cpal work off the main thread + lock-free is_recording

### DIFF
--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -151,21 +151,26 @@ pub fn open_microphone_privacy_settings() -> Result<(), String> {
 
 #[tauri::command]
 #[specta::specta]
-pub fn update_microphone_mode(app: AppHandle, always_on: bool) -> Result<(), String> {
-    // Update settings
+pub async fn update_microphone_mode(app: AppHandle, always_on: bool) -> Result<(), String> {
+    // Update settings (fast, stays inline)
     let mut settings = get_settings(&app);
     settings.always_on_microphone = always_on;
     write_settings(&app, settings);
 
-    // Update the audio manager mode
-    let rm = app.state::<Arc<AudioRecordingManager>>();
+    // Update the audio manager mode. update_mode can stop/start the cpal stream
+    // (blocking CoreAudio) and takes the manager std mutexes — run it on a
+    // blocking thread, NOT inline on the webview/main run loop (a slow device
+    // open/close would freeze the UI).
+    let rm = app.state::<Arc<AudioRecordingManager>>().inner().clone();
     let new_mode = if always_on {
         MicrophoneMode::AlwaysOn
     } else {
         MicrophoneMode::OnDemand
     };
 
-    rm.update_mode(new_mode)
+    tokio::task::spawn_blocking(move || rm.update_mode(new_mode))
+        .await
+        .map_err(|e| format!("audio task join failed: {}", e))?
         .map_err(|e| format!("Failed to update microphone mode: {}", e))
 }
 
@@ -178,28 +183,33 @@ pub fn get_microphone_mode(app: AppHandle) -> Result<bool, String> {
 
 #[tauri::command]
 #[specta::specta]
-pub fn get_available_microphones() -> Result<Vec<AudioDevice>, String> {
-    let devices =
-        list_input_devices().map_err(|e| format!("Failed to list audio devices: {}", e))?;
+pub async fn get_available_microphones() -> Result<Vec<AudioDevice>, String> {
+    // cpal device enumeration can stall — run it off the webview/main run loop.
+    tokio::task::spawn_blocking(|| {
+        let devices =
+            list_input_devices().map_err(|e| format!("Failed to list audio devices: {}", e))?;
 
-    let mut result = vec![AudioDevice {
-        index: "default".to_string(),
-        name: "Default".to_string(),
-        is_default: true,
-    }];
+        let mut result = vec![AudioDevice {
+            index: "default".to_string(),
+            name: "Default".to_string(),
+            is_default: true,
+        }];
 
-    result.extend(devices.into_iter().map(|d| AudioDevice {
-        index: d.index,
-        name: d.name,
-        is_default: false, // The explicit default is handled separately
-    }));
+        result.extend(devices.into_iter().map(|d| AudioDevice {
+            index: d.index,
+            name: d.name,
+            is_default: false, // The explicit default is handled separately
+        }));
 
-    Ok(result)
+        Ok::<_, String>(result)
+    })
+    .await
+    .map_err(|e| format!("audio task join failed: {}", e))?
 }
 
 #[tauri::command]
 #[specta::specta]
-pub fn set_selected_microphone(app: AppHandle, device_name: String) -> Result<(), String> {
+pub async fn set_selected_microphone(app: AppHandle, device_name: String) -> Result<(), String> {
     let mut settings = get_settings(&app);
     settings.selected_microphone = if device_name == "default" {
         None
@@ -208,12 +218,14 @@ pub fn set_selected_microphone(app: AppHandle, device_name: String) -> Result<()
     };
     write_settings(&app, settings);
 
-    // Update the audio manager to use the new device
-    let rm = app.state::<Arc<AudioRecordingManager>>();
-    rm.update_selected_device()
-        .map_err(|e| format!("Failed to update selected device: {}", e))?;
-
-    Ok(())
+    // Update the audio manager to use the new device. update_selected_device
+    // can restart the cpal stream (blocking CoreAudio) — run it on a blocking
+    // thread, not inline on the webview/main run loop.
+    let rm = app.state::<Arc<AudioRecordingManager>>().inner().clone();
+    tokio::task::spawn_blocking(move || rm.update_selected_device())
+        .await
+        .map_err(|e| format!("audio task join failed: {}", e))?
+        .map_err(|e| format!("Failed to update selected device: {}", e))
 }
 
 #[tauri::command]
@@ -227,23 +239,28 @@ pub fn get_selected_microphone(app: AppHandle) -> Result<String, String> {
 
 #[tauri::command]
 #[specta::specta]
-pub fn get_available_output_devices() -> Result<Vec<AudioDevice>, String> {
-    let devices =
-        list_output_devices().map_err(|e| format!("Failed to list output devices: {}", e))?;
+pub async fn get_available_output_devices() -> Result<Vec<AudioDevice>, String> {
+    // cpal device enumeration can stall — run it off the webview/main run loop.
+    tokio::task::spawn_blocking(|| {
+        let devices =
+            list_output_devices().map_err(|e| format!("Failed to list output devices: {}", e))?;
 
-    let mut result = vec![AudioDevice {
-        index: "default".to_string(),
-        name: "Default".to_string(),
-        is_default: true,
-    }];
+        let mut result = vec![AudioDevice {
+            index: "default".to_string(),
+            name: "Default".to_string(),
+            is_default: true,
+        }];
 
-    result.extend(devices.into_iter().map(|d| AudioDevice {
-        index: d.index,
-        name: d.name,
-        is_default: false, // The explicit default is handled separately
-    }));
+        result.extend(devices.into_iter().map(|d| AudioDevice {
+            index: d.index,
+            name: d.name,
+            is_default: false, // The explicit default is handled separately
+        }));
 
-    Ok(result)
+        Ok::<_, String>(result)
+    })
+    .await
+    .map_err(|e| format!("audio task join failed: {}", e))?
 }
 
 #[tauri::command]

--- a/src-tauri/src/managers/audio.rs
+++ b/src-tauri/src/managers/audio.rs
@@ -12,7 +12,7 @@ use crate::settings::{get_settings, AppSettings};
 use crate::utils;
 use log::{debug, error, info, warn};
 use std::path::Path;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tauri::Manager;
@@ -186,6 +186,12 @@ pub struct AudioRecordingManager {
     close_generation: Arc<AtomicU64>,
     cancel_generation: Arc<AtomicU64>,
     stream_router: Arc<StreamRouter>,
+    /// Lock-free mirror of "is the state in {Recording, Stopping}", flipped
+    /// exactly at the state transitions that change that membership. The
+    /// hot-path `is_recording()` reads THIS instead of the std `state` mutex,
+    /// so a UI poll can no longer deadlock the main/webview thread when a
+    /// worker holds `state` across a slow CoreAudio open/close.
+    recording_active: Arc<AtomicBool>,
     /// Resolution of a *named* microphone (selected or clamshell) to its cpal
     /// device, cached so on-demand recording starts skip the full device
     /// enumeration (~40-110ms). Keyed by the resolved name, so a settings
@@ -221,6 +227,7 @@ impl AudioRecordingManager {
             close_generation: Arc::new(AtomicU64::new(0)),
             cancel_generation: Arc::new(AtomicU64::new(0)),
             stream_router,
+            recording_active: Arc::new(AtomicBool::new(false)),
             cached_device: Arc::new(Mutex::new(None)),
         };
 
@@ -503,6 +510,7 @@ impl AudioRecordingManager {
                     *state = RecordingState::Recording {
                         binding_id: binding_id.to_string(),
                     };
+                    self.recording_active.store(true, Ordering::SeqCst);
                     debug!("Recording started for binding {binding_id}");
                     return Ok(());
                 }
@@ -582,6 +590,7 @@ impl AudioRecordingManager {
 
                 *self.is_recording.lock().unwrap() = false;
                 *self.state.lock().unwrap() = RecordingState::Idle;
+                self.recording_active.store(false, Ordering::SeqCst);
 
                 // In on-demand mode, close the mic (lazily if the setting is enabled)
                 if matches!(*self.mode.lock().unwrap(), MicrophoneMode::OnDemand) {
@@ -612,10 +621,12 @@ impl AudioRecordingManager {
         }
     }
     pub fn is_recording(&self) -> bool {
-        matches!(
-            *self.state.lock().unwrap(),
-            RecordingState::Recording { .. } | RecordingState::Stopping
-        )
+        // Lock-free: mirrors the `state` {Recording, Stopping} membership via
+        // an atomic flipped at the state transitions. Polled from the
+        // webview/main thread, so it MUST NOT take the `state` mutex (a worker
+        // can hold it across a slow CoreAudio open/close → main-thread
+        // deadlock / UI freeze).
+        self.recording_active.load(Ordering::SeqCst)
     }
 
     /// Cancel any ongoing recording without returning audio samples
@@ -626,6 +637,7 @@ impl AudioRecordingManager {
         match *state {
             RecordingState::Recording { .. } => {
                 *state = RecordingState::Idle;
+                self.recording_active.store(false, Ordering::SeqCst);
                 drop(state);
 
                 if let Some(rec) = self.recorder.lock().unwrap().as_ref() {

--- a/src-tauri/src/managers/audio.rs
+++ b/src-tauri/src/managers/audio.rs
@@ -175,6 +175,8 @@ fn create_audio_recorder(
 
 #[derive(Clone)]
 pub struct AudioRecordingManager {
+    /// Never assign through this directly — route every write through
+    /// `set_state()`, which keeps `recording_active` in sync.
     state: Arc<Mutex<RecordingState>>,
     mode: Arc<Mutex<MicrophoneMode>>,
     app_handle: tauri::AppHandle,
@@ -186,11 +188,11 @@ pub struct AudioRecordingManager {
     close_generation: Arc<AtomicU64>,
     cancel_generation: Arc<AtomicU64>,
     stream_router: Arc<StreamRouter>,
-    /// Lock-free mirror of "is the state in {Recording, Stopping}", flipped
-    /// exactly at the state transitions that change that membership. The
-    /// hot-path `is_recording()` reads THIS instead of the std `state` mutex,
-    /// so a UI poll can no longer deadlock the main/webview thread when a
-    /// worker holds `state` across a slow CoreAudio open/close.
+    /// Lock-free mirror of "is the state in {Recording, Stopping}",
+    /// maintained by `set_state()`. The hot-path `is_recording()` reads THIS
+    /// instead of the std `state` mutex, so a UI poll can no longer deadlock
+    /// the main/webview thread when a worker holds `state` across a slow
+    /// CoreAudio open/close.
     recording_active: Arc<AtomicBool>,
     /// Resolution of a *named* microphone (selected or clamshell) to its cpal
     /// device, cached so on-demand recording starts skip the full device
@@ -485,6 +487,21 @@ impl AudioRecordingManager {
 
     /* ---------- recording --------------------------------------------------- */
 
+    /// The one place `state` is written. Derives `recording_active` (the
+    /// lock-free mirror read by `is_recording()`) from the new value itself,
+    /// so the two can never drift: a new `RecordingState` variant only needs
+    /// its active-set membership decided here, once.
+    fn set_state(&self, guard: &mut RecordingState, new_state: RecordingState) {
+        *guard = new_state;
+        self.recording_active.store(
+            matches!(
+                *guard,
+                RecordingState::Recording { .. } | RecordingState::Stopping
+            ),
+            Ordering::SeqCst,
+        );
+    }
+
     pub fn try_start_recording(
         &self,
         binding_id: &str,
@@ -507,10 +524,12 @@ impl AudioRecordingManager {
             if let Some(rec) = self.recorder.lock().unwrap().as_ref() {
                 if rec.start(vad_policy).is_ok() {
                     *self.is_recording.lock().unwrap() = true;
-                    *state = RecordingState::Recording {
-                        binding_id: binding_id.to_string(),
-                    };
-                    self.recording_active.store(true, Ordering::SeqCst);
+                    self.set_state(
+                        &mut state,
+                        RecordingState::Recording {
+                            binding_id: binding_id.to_string(),
+                        },
+                    );
                     debug!("Recording started for binding {binding_id}");
                     return Ok(());
                 }
@@ -550,7 +569,7 @@ impl AudioRecordingManager {
             RecordingState::Recording {
                 binding_id: ref active,
             } if active == binding_id => {
-                *state = RecordingState::Stopping;
+                self.set_state(&mut state, RecordingState::Stopping);
                 drop(state);
 
                 // Optionally keep recording for a bit longer to capture trailing audio.
@@ -589,8 +608,7 @@ impl AudioRecordingManager {
                 };
 
                 *self.is_recording.lock().unwrap() = false;
-                *self.state.lock().unwrap() = RecordingState::Idle;
-                self.recording_active.store(false, Ordering::SeqCst);
+                self.set_state(&mut self.state.lock().unwrap(), RecordingState::Idle);
 
                 // In on-demand mode, close the mic (lazily if the setting is enabled)
                 if matches!(*self.mode.lock().unwrap(), MicrophoneMode::OnDemand) {
@@ -622,10 +640,10 @@ impl AudioRecordingManager {
     }
     pub fn is_recording(&self) -> bool {
         // Lock-free: mirrors the `state` {Recording, Stopping} membership via
-        // an atomic flipped at the state transitions. Polled from the
-        // webview/main thread, so it MUST NOT take the `state` mutex (a worker
-        // can hold it across a slow CoreAudio open/close → main-thread
-        // deadlock / UI freeze).
+        // an atomic maintained by `set_state()`. Polled from the webview/main
+        // thread, so it MUST NOT take the `state` mutex (a worker can hold it
+        // across a slow CoreAudio open/close → main-thread deadlock / UI
+        // freeze).
         self.recording_active.load(Ordering::SeqCst)
     }
 
@@ -636,8 +654,7 @@ impl AudioRecordingManager {
 
         match *state {
             RecordingState::Recording { .. } => {
-                *state = RecordingState::Idle;
-                self.recording_active.store(false, Ordering::SeqCst);
+                self.set_state(&mut state, RecordingState::Idle);
                 drop(state);
 
                 if let Some(rec) = self.recorder.lock().unwrap().as_ref() {


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

(Duplicate search done before opening #1715: no earlier open or closed issue/PR addresses the intermittent UI beachball while audio devices open/close. `#1354` (poisoned mutexes in `Drop` impls) is a different problem: it handles panic-during-`Drop` on quit, not the live main-thread hang during recording. This PR targets the main-thread `Mutex`-across-CoreAudio contention.)

## Human Written Description

I noticed Handy could intermittently beachball while recording, most often when using Bluetooth/USB microphones or changing audio devices. In the worst case the app stopped responding and had to be force-quit.

This change moves the blocking audio work away from UI-facing command paths and makes the recording-state poll lock-free, so normal recording/device operations should not freeze the app.

## Related Issues/Discussions

Fixes #1715

## Community Feedback

Bug fix: a production UI freeze during recording, amplified by Bluetooth/USB microphones. Tracked in #1715; not previously reported upstream as a distinct issue before this bug report. Sibling to #1644.

## Testing

**Root cause (class):** synchronous `#[tauri::command] pub fn ...` runs inline on the webview/main run loop. The audio manager guards its state with `std::sync::Mutex` (blocks the OS thread, no timeout) and holds it across blocking CoreAudio syscalls (cpal stream start/stop in `try_start_recording` / `schedule_lazy_close`, and device enumeration). Any worker holding that mutex across a slow device open/close serializes the main thread, causing deadlock/freeze. The frontend polls `is_recording()`, which locked `state`, the most-polled main-thread contender.

Two manifestations, both still present on `main` @ `d861e24`:
- **(A)** `is_recording()` locked `state` (`src-tauri/src/managers/audio.rs`, `is_recording`).
- **(B)** four cpal-running commands were synchronous `pub fn` on the main run loop: `update_microphone_mode`, `get_available_microphones`, `set_selected_microphone`, `get_available_output_devices` (`src-tauri/src/commands/audio.rs`).

**What changed:**
- **Fix A** (`managers/audio.rs`): added a lock-free `recording_active: Arc<AtomicBool>` mirroring the "`state` in {Recording, Stopping}" membership, flipped at the state transitions. `is_recording()` reads the atomic instead of taking the `state` mutex. (Note: `main` now has a `Stopping` intermediate variant in `RecordingState`, and `is_recording()` already returned `true` for `Recording | Stopping`; the atomic faithfully mirrors both: flipped `true` on `Idle` to `Recording`, `false` on `Stopping` to `Idle` and on cancel `Recording` to `Idle`. The `Recording` to `Stopping` transition needs no flip because `Stopping` stays in the active set.)
- **Fix B** (`commands/audio.rs`): the four cpal-running commands are now `async` and run their blocking cpal work via `tokio::task::spawn_blocking`. Settings reads/writes stay inline (fast). `#[specta::specta]` and all return types are preserved; Tauri's `invoke` is identical for sync/async commands, so there is **no frontend/binding change** (bindings regenerated cleanly).

**Build verification (on `main` @ `d861e24`, branch `fix/main-thread-audio-hang`):**
- `cargo check --locked` to 0 errors
- `cargo clippy --locked` to no new lints (only one pre-existing warning: unused assignment `model_takes_initial_prompt` in `transcription.rs:1168`, unrelated to this change)
- `cargo fmt --check` to clean

**Scope:** 2 files, shared code only: `managers/audio.rs` (Fix A: new atomic field + 3 flip sites + lock-free `is_recording`), `commands/audio.rs` (Fix B: 4 sync `pub fn` to `async` + `spawn_blocking`). No recording semantics changed; no frontend, bindings, or other managers touched.

**Manual verification needed (hardware/concurrency, not unit-testable):**
1. Build + clippy + `tsc` (bindings) green.
2. Record push-to-talk repeatedly (including with a Bluetooth/USB mic); the UI must never beachball while a stream opens/closes.
3. Toggle mic mode (Always-On to On-Demand) mid-session; change input device mid-recording; open Settings then Audio (device enumeration) mid-recording. No freeze in any case.

**Known follow-up (intentionally NOT in this PR):** `try_start_recording` / `schedule_lazy_close` still hold `state` across the cpal open/close, but after A+B only worker threads contend there (no main-thread hot path remains), so no UI freeze. Restructuring them is a recording-semantics risk for no user-visible gain.

## Screenshots/Videos (if applicable)

_Native beachball produces no static screenshot; repro is "record with a Bluetooth/USB mic, change device or toggle mic mode mid-session, and the UI freezes". Happy to capture a no-freeze video on request._

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**
- **Tools used:** Claude (Kilo CLI) for root-cause analysis, patch porting, and build/clippy/fmt verification; the same fixes were independently shipped and verified in production in a downstream fork (TokMo).
- **How extensively:** AI assisted with porting the two fixes onto current `main` (adapting Fix A to `main`'s newer `RecordingState::Stopping` variant) and running the verification. The hang reproduction and the decision to move cpal work off the main thread were driven by real Bluetooth/USB-mic testing in the fork.

