### PR TITLE
chore: add Arch PKGBUILD for Handy release packaging

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,41 @@
+pkgname=handy
+pkgver=0.9.3
+pkgrel=1
+pkgdesc="A free, open source, and extensible speech-to-text application that works offline"
+arch=('x86_64')
+url="https://github.com/cjpais/Handy"
+license=('MIT')
+depends=(
+  'gtk3'
+  'webkit2gtk-4.1'
+  'gtk-layer-shell'
+  'libayatana-appindicator'
+  'openblas'
+)
+makedepends=(
+  'binutils'
+  'coreutils'
+)
+source=("handy-${pkgver}.deb::https://github.com/cjpais/Handy/releases/download/v${pkgver}/Handy_${pkgver}_amd64.deb")
+sha256sums=('SKIP')
+noextract=("handy-${pkgver}.deb")
+
+build() {
+  return 0
+}
+
+prepare() {
+  cd "$srcdir"
+  ar x "handy-${pkgver}.deb" data.tar.gz
+  tar -xzf data.tar.gz
+}
+
+package() {
+  cd "$srcdir"
+  install -Dm755 usr/bin/handy "${pkgdir}/usr/bin/handy"
+  cp -a usr/lib/Handy "${pkgdir}/usr/lib/"
+  cp -a usr/lib/*.so* "${pkgdir}/usr/lib/"
+  install -Dm644 usr/share/applications/Handy.desktop "${pkgdir}/usr/share/applications/Handy.desktop"
+  cp -a usr/share/icons/hicolor "${pkgdir}/usr/share/icons/"
+}
+


### PR DESCRIPTION
## Before Submitting This PR

- [ ] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

I added a repository-native Arch Linux packaging path so users can install Handy using a standard `makepkg`/Pacman workflow without manual extraction steps. This makes it easier for Arch users to install and keep the app in a package-managed way.

The change keeps binaries and resources as shipped in the upstream release `.deb` and stages the same layout under `/usr`, which matches the existing runtime expectations of the app.

## Related Issues/Discussions

Fixes #
Discussion:

## Community Feedback

None yet.

## Testing

- Built a local `PKGBUILD`-based package with `makepkg`
- Installed the package and verified the app entry point runs: `handy --help`

## Screenshots/Videos (if applicable)

Not applicable (packaging change only).

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

Tools used:
- ChatGPT/Codex for workflow and patch scaffolding, shell verification, and packaging checks

How extensively:
- Drafted PKGBUILD and validated build/install flow end-to-end
