### PR TITLE
fix(linux): X11 keymap resets silently drop characters in Direct paste (stale enigo keycode bindings)

### DIFF
--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -611,10 +611,23 @@ pub fn paste(text: String, app_handle: AppHandle) -> Result<(), String> {
     let enigo_state = app_handle
         .try_state::<EnigoState>()
         .ok_or("Enigo state not initialized")?;
-    let mut enigo = enigo_state
+    let mut enigo_slot = enigo_state
         .0
         .lock()
         .map_err(|e| format!("Failed to lock Enigo: {}", e))?;
+
+    // On X11 a long-lived Enigo instance can hold keycode bindings the server
+    // has since discarded, which silently drops those characters when typing
+    // (see input::refresh_enigo). Rebuild it so this paste runs against the
+    // current keymap.
+    #[cfg(target_os = "linux")]
+    if paste_method != PasteMethod::None && !is_wayland() {
+        input::refresh_enigo(&mut enigo_slot)?;
+    }
+
+    let enigo = enigo_slot
+        .as_mut()
+        .ok_or("Enigo instance is not available")?;
 
     // Perform the paste operation
     match paste_method {
@@ -623,7 +636,7 @@ pub fn paste(text: String, app_handle: AppHandle) -> Result<(), String> {
         }
         PasteMethod::Direct => {
             paste_direct(
-                &mut enigo,
+                enigo,
                 &text,
                 #[cfg(target_os = "linux")]
                 settings.typing_tool,
@@ -631,7 +644,7 @@ pub fn paste(text: String, app_handle: AppHandle) -> Result<(), String> {
         }
         PasteMethod::CtrlV | PasteMethod::CtrlShiftV | PasteMethod::ShiftInsert => {
             paste_via_clipboard(
-                &mut enigo,
+                enigo,
                 &text,
                 &app_handle,
                 &paste_method,
@@ -651,7 +664,7 @@ pub fn paste(text: String, app_handle: AppHandle) -> Result<(), String> {
 
     if should_send_auto_submit(settings.auto_submit, paste_method) {
         std::thread::sleep(Duration::from_millis(50));
-        send_return_key(&mut enigo, settings.auto_submit_key)?;
+        send_return_key(enigo, settings.auto_submit_key)?;
     }
 
     // After pasting, optionally copy to clipboard based on settings

--- a/src-tauri/src/input.rs
+++ b/src-tauri/src/input.rs
@@ -3,15 +3,39 @@ use std::sync::Mutex;
 use tauri::{AppHandle, Manager};
 
 /// Wrapper for Enigo to store in Tauri's managed state.
-/// Enigo is wrapped in a Mutex since it requires mutable access.
-pub struct EnigoState(pub Mutex<Enigo>);
+/// Enigo is wrapped in a Mutex since it requires mutable access, and in an
+/// Option so the instance can be dropped and recreated (see `refresh_enigo`).
+pub struct EnigoState(pub Mutex<Option<Enigo>>);
 
 impl EnigoState {
     pub fn new() -> Result<Self, String> {
         let enigo = Enigo::new(&Settings::default())
             .map_err(|e| format!("Failed to initialize Enigo: {}", e))?;
-        Ok(Self(Mutex::new(enigo)))
+        Ok(Self(Mutex::new(Some(enigo))))
     }
+}
+
+/// Drop and recreate the Enigo instance held in `slot`.
+///
+/// On X11, enigo types characters that are not on the first level of the
+/// active layout (capital letters among them) by binding their keysyms to
+/// spare keycodes, and it trusts those bindings for the lifetime of the
+/// instance. Any external keymap reload (layout re-apply, suspend/resume,
+/// device hotplug) reverts the bindings behind enigo's back, after which
+/// those characters are silently dropped from typed text. Recreating the
+/// instance immediately before an injection rebinds everything against the
+/// server's current keymap.
+///
+/// The old instance must be dropped *before* the new one is created: enigo's
+/// Drop reverts the old instance's bindings, and an instance created earlier
+/// would have captured those bindings in its keymap snapshot and kept firing
+/// the then-dead keycodes.
+pub fn refresh_enigo(slot: &mut Option<Enigo>) -> Result<(), String> {
+    slot.take();
+    let fresh = Enigo::new(&Settings::default())
+        .map_err(|e| format!("Failed to recreate Enigo: {}", e))?;
+    *slot = Some(fresh);
+    Ok(())
 }
 
 /// Get the current mouse cursor position using the managed Enigo instance.
@@ -19,7 +43,7 @@ impl EnigoState {
 pub fn get_cursor_position(app_handle: &AppHandle) -> Option<(i32, i32)> {
     let enigo_state = app_handle.try_state::<EnigoState>()?;
     let enigo = enigo_state.0.lock().ok()?;
-    enigo.location().ok()
+    enigo.as_ref()?.location().ok()
 }
 
 /// Sends a Ctrl+V or Cmd+V paste command using platform-specific virtual key codes.


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

I was using Handy and noticed that the first letter of various words were being truncated consistently. Upon investigating, I found that this had to do with an X11 quirk. It was a quick fix.

## Related Issues/Discussions

Related but distinct root causes: #1661 (KDE Wayland Shift+key race), #429 (Wayland first-char loss).

PR #809 was closed for replacing enigo's `.text()` with manual Shift+key typing. This PR keeps `.text()` unchanged — it only changes when the `Enigo` instance is created.

**Root cause.** On X11, enigo types characters that aren't on the first level of the active layout (capital letters included) by binding their keysyms to spare keycodes, and caches those bindings for the lifetime of the `Enigo` instance. Handy keeps a single `Enigo` in managed state for the whole process. When the X server reloads its keymap (suspend/resume, layout re-apply, device hotplug), the bindings are reverted behind enigo's back, and every affected character is silently dropped from typed output until Handy restarts — while the transcript in history stays correct.

Debug log from the session where I caught it: keycode 184 was bound to `XK_S` at 17:05; after an idle gap containing a keymap reset, a 20:27 dictation dropped every `S`/`I`/`A` (bound before the reset) while `H` survived (first bound at 19:28, after the reset):

```
[17:05:14] enigo::platform::keymap: mapped keycode 184 to keysym XK_S
[19:28:17] enigo::platform::keymap: mapped keycode 219 to keysym XK_H
[20:27:50] Transcription result: So, right now I'm just using Handy and I'm ...
           typed output:         o, right now 'm just using Handy and 'm ...
```

**Fix.** Hold the managed `Enigo` in `Mutex<Option<Enigo>>` and drop-then-recreate it at the start of each paste on X11 (`refresh_enigo` in `input.rs`), so bindings are always made against the server's current keymap. Wayland and other platforms are untouched.

The drop-before-create order matters: enigo's `Drop` (`Drop for Con`, `linux/x11rb.rs` in enigo 0.6.1) reverts its own bindings, and an instance created before the old one is dropped would capture those bindings in its keymap snapshot and keep firing keycodes that die moments later.

A longer-term fix belongs in enigo itself (invalidate the cache on `MappingNotify`), as suggested on #809. This change is complementary: it stays within enigo's public API and keeps Handy correct either way.

Fixes #
Discussion:

## Community Feedback

<!-- bug fix; no discussion thread yet -->

## Testing

- Reproduced on Ubuntu 24.04, GNOME on X11 (aarch64), paste method "Direct" with no xdotool installed (enigo fallback path): capitals dropped after suspend/resume, matching the stale-binding timeline above.
- Built the patched arm64 deb and have been running it as my daily dictation driver; capitals type correctly, including after the previously failing suspend/resume condition.
- Sanity-checked the per-paste lifecycle cost: 30 consecutive `Enigo::new` → query → drop cycles against a live X server with no failures; connection setup is milliseconds against a multi-second XTEST typing pass.
- `cargo fmt` clean; release build succeeds.

## Screenshots/Videos (if applicable)

n/a — the log excerpt above shows the before/after.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: AI coding assistant (Claude Code)
- How extensively: Helped trace the root cause through Handy's debug logs and the enigo 0.6.1 source, and drafted the patch. I hit the bug in daily use and verified the fix by dictating with the patched build on my machine.
