### PR TITLE
fix: exit immediately on Windows session end so shutdown is not blocked (for #1710)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -109,6 +109,7 @@ windows = { version = "0.61.3", features = [
   "Win32_System_Variant",
   "Win32_Foundation",
   "Win32_UI_WindowsAndMessaging",
+  "Win32_UI_Shell",
 ] }
 winreg = "0.55"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -522,6 +522,84 @@ fn run_headless_transcription(app: &AppHandle, args: &CliArgs) -> i32 {
     0
 }
 
+/// Subclass ID for [`session_end_subclass_proc`]. `SetWindowSubclass` keys
+/// subclasses per-window by this value, so it only needs to be unique among
+/// subclasses *we* install on the same window (there is only one).
+#[cfg(target_os = "windows")]
+const SESSION_END_SUBCLASS_ID: usize = 1;
+
+/// Subclass procedure that intercepts Windows session-end messages before
+/// tao's own window procedure sees them.
+///
+/// tao has no shutdown-aware handling: `WM_ENDSESSION` falls through to its
+/// default processing, which synchronously runs Tauri's `RunEvent::Exit`
+/// (transcribe-cpp/GPU teardown) and joins the hotkey-hook, cpal, and
+/// idle-watcher threads — all *inside this window-procedure call*. If any of
+/// that stalls (GPU teardown has been observed to hang on some machines, see
+/// #1710), the call never returns and Windows shows "this app is preventing
+/// shutdown" until the process is force-killed.
+///
+/// Per Microsoft's shutdown guidance, an app should never block
+/// `WM_QUERYENDSESSION` and should exit immediately on `WM_ENDSESSION`
+/// without further cleanup — the OS reclaims all process resources
+/// regardless. So we always allow the session to end, then terminate the
+/// moment it actually does, skipping the teardown path entirely.
+#[cfg(target_os = "windows")]
+unsafe extern "system" fn session_end_subclass_proc(
+    hwnd: windows::Win32::Foundation::HWND,
+    msg: u32,
+    wparam: windows::Win32::Foundation::WPARAM,
+    lparam: windows::Win32::Foundation::LPARAM,
+    _uidsubclass: usize,
+    _dwrefdata: usize,
+) -> windows::Win32::Foundation::LRESULT {
+    use windows::Win32::Foundation::LRESULT;
+    use windows::Win32::UI::Shell::DefSubclassProc;
+    use windows::Win32::UI::WindowsAndMessaging::{WM_ENDSESSION, WM_QUERYENDSESSION};
+
+    match msg {
+        // Never block a shutdown/logoff/restart request.
+        WM_QUERYENDSESSION => LRESULT(1),
+        // wParam is TRUE only when the session is actually ending (FALSE if
+        // another app vetoed the shutdown) — nothing to undo in that case
+        // since we never blocked anything above.
+        WM_ENDSESSION if wparam.0 != 0 => {
+            log::info!("Windows session ending; exiting immediately to avoid blocking shutdown");
+            std::process::exit(0);
+        }
+        _ => DefSubclassProc(hwnd, msg, wparam, lparam),
+    }
+}
+
+/// Installs [`session_end_subclass_proc`] on the main window so session-end
+/// messages are handled before tao's own (potentially slow) cleanup runs.
+#[cfg(target_os = "windows")]
+fn install_session_end_handler(window: &tauri::WebviewWindow) {
+    use windows::Win32::UI::Shell::SetWindowSubclass;
+
+    match window.hwnd() {
+        Ok(hwnd) => {
+            let installed = unsafe {
+                SetWindowSubclass(
+                    hwnd,
+                    Some(session_end_subclass_proc),
+                    SESSION_END_SUBCLASS_ID,
+                    0,
+                )
+            };
+            if !installed.as_bool() {
+                log::warn!("Failed to install Windows session-end handler");
+            }
+        }
+        Err(e) => {
+            log::warn!(
+                "Failed to get main window HWND for session-end handler: {}",
+                e
+            );
+        }
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run(cli_args: CliArgs) {
     // Detect portable mode before anything else
@@ -813,7 +891,14 @@ pub fn run(cli_args: CliArgs) {
                 win_builder = win_builder.data_directory(data_dir.join("webview"));
             }
 
-            win_builder.build()?;
+            #[allow(unused_variables)]
+            let main_window = win_builder.build()?;
+
+            // Make sure Windows session end (shutdown/restart/logoff) exits
+            // us immediately instead of running the graceful teardown path,
+            // which can hang and block the shutdown (see #1710).
+            #[cfg(target_os = "windows")]
+            install_session_end_handler(&main_window);
 
             let mut settings = get_settings(app.handle());
 


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Related Issues/Discussions

Fixes #1710

## Community Feedback

Reported in #1710 (Windows 11, v0.9.3): Handy blocks PC shutdown until manually killed. The attached log shows repeated WebView2/Vulkan "resource not in correct state" errors during model unload on that machine — consistent with the root cause below.

## Testing

**Root cause:** Handy has no Windows session-end–aware handling. tao (the windowing backend) has none either — on `WM_ENDSESSION` it falls straight through to its default processing, which synchronously fires Tauri's `RunEvent::Exit`. Handy's handler for that event calls `TranscriptionManager::unload_model()` (transcribe-cpp/GPU teardown), and dropping the `App` afterward joins the handy-keys hotkey-hook thread, cpal audio worker threads, and the idle-watcher thread — all of this runs **inside the window procedure call** that Windows is waiting on. If any step hangs or is slow (GPU/Vulkan teardown misbehaving, as in the reporter's log), the window procedure never returns, and Windows shows "this app is preventing shutdown" until the process is force-killed.

**Fix:** Install a `SetWindowSubclass` handler on the main window (subclasses run LIFO, so ours intercepts before tao's) that:
- Always answers `WM_QUERYENDSESSION` with `TRUE` — Handy should never be the app that blocks a shutdown/restart/logoff.
- On `WM_ENDSESSION` with `wParam != 0` (the session is actually ending, not just queried), calls `std::process::exit(0)` immediately — skipping the graceful teardown path entirely. This is intentional and safe: the OS reclaims all process resources (GPU, threads, handles) regardless of how the process exits, and Microsoft's own shutdown guidance is to exit promptly here without further cleanup work. The careful teardown ordering elsewhere in the code exists for a macOS ggml-metal static-destructor concern and is unaffected — this fix is `#[cfg(target_os = "windows")]` only.
- Falls through to `DefSubclassProc` for everything else (including a canceled shutdown, `WM_ENDSESSION` with `wParam == 0`), so normal behavior is untouched.

**Verified end-to-end on Windows 11** by sending the exact messages Windows sends during shutdown directly to Handy's main window (`SendMessage`, synchronous):
- `WM_QUERYENDSESSION` → returns `1` immediately, app keeps running (allows shutdown to proceed).
- `WM_ENDSESSION` with `wParam=1` (real shutdown) → app logs `Windows session ending; exiting immediately to avoid blocking shutdown` and the process exits in under 20ms — no hang, no manual kill needed.
- `WM_ENDSESSION` with `wParam=0` (shutdown canceled by another app) → app correctly keeps running.
- Regression check: `WM_CLOSE` (normal window "X") still hides to tray as before — this fix only touches the session-end messages, not the existing close-to-tray behavior.
- `cargo fmt --check` and `cargo clippy` pass with no new warnings (two pre-existing, unrelated warnings remain in `transcription.rs`/`audio.rs`). macOS/Linux code paths are untouched (`#[cfg(target_os = "windows")]`).


