### PR TITLE
Add in app bug report

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -108,8 +108,12 @@ pub fn get_system_details() -> SystemDetails {
     #[cfg(target_os = "linux")]
     let os_version = std::fs::read_to_string("/etc/os-release")
         .ok()
-        .and_then(|content| content.lines().find_map(|line| line.strip_prefix("PRETTY_NAME=")))
-        .map(|name| name.trim_matches('"').to_string())
+        .and_then(|content| {
+            content
+                .lines()
+                .find_map(|line| line.strip_prefix("PRETTY_NAME="))
+                .map(|name| name.trim_matches('"').to_string())
+        })
         .unwrap_or_else(|| "Unknown OS".to_string());
     #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
     let os_version = "Unknown OS".to_string();

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -132,11 +132,16 @@ pub fn get_system_details() -> SystemDetails {
     #[cfg(target_os = "linux")]
     let cpu_model = std::fs::read_to_string("/proc/cpuinfo")
         .ok()
-        .and_then(|content| content.lines().find_map(|line| {
-            (line.starts_with("model name") || line.starts_with("Model"))
-                .then(|| line.split_once(':').map(|(_, name)| name.trim().to_string()))
-                .flatten()
-        }))
+        .and_then(|content| {
+            content.lines().find_map(|line| {
+                (line.starts_with("model name") || line.starts_with("Model"))
+                    .then(|| {
+                        line.split_once(':')
+                            .map(|(_, name)| name.trim().to_string())
+                    })
+                    .flatten()
+            })
+        })
         .unwrap_or_else(|| "Unknown CPU".to_string());
     #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
     let cpu_model = "Unknown CPU".to_string();
@@ -151,7 +156,11 @@ pub fn get_system_details() -> SystemDetails {
     SystemDetails {
         os_version,
         cpu_model,
-        gpu_model: if gpu_model.is_empty() { "Unknown GPU".to_string() } else { gpu_model },
+        gpu_model: if gpu_model.is_empty() {
+            "Unknown GPU".to_string()
+        } else {
+            gpu_model
+        },
     }
 }
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -174,8 +174,11 @@ pub fn read_recent_logs(app: AppHandle) -> Result<String, String> {
     const MAX_LINES: usize = 100;
     let log_dir = crate::portable::app_log_dir(&app)
         .map_err(|error| format!("Failed to get log directory: {}", error))?;
-    let file = File::open(log_dir.join("handy.log"))
-        .map_err(|error| format!("Failed to read Handy logs: {}", error))?;
+    let file = match File::open(log_dir.join("handy.log")) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(String::new()),
+        Err(error) => return Err(format!("Failed to read Handy logs: {}", error)),
+    };
     let mut recent_lines = VecDeque::with_capacity(MAX_LINES);
 
     for line in BufReader::new(file).lines() {

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -8,6 +8,13 @@ use crate::utils::cancel_current_operation;
 use tauri::{AppHandle, Manager};
 use tauri_plugin_opener::OpenerExt;
 
+#[derive(serde::Serialize, Clone, specta::Type)]
+pub struct SystemDetails {
+    pub os_version: String,
+    pub cpu_model: String,
+    pub gpu_model: String,
+}
+
 #[tauri::command]
 #[specta::specta]
 pub fn cancel_operation(app: AppHandle) {
@@ -48,6 +55,112 @@ pub fn get_log_dir_path(app: AppHandle) -> Result<String, String> {
         .map_err(|e| format!("Failed to get log directory: {}", e))?;
 
     Ok(log_dir.to_string_lossy().to_string())
+}
+
+#[cfg(target_os = "windows")]
+fn get_windows_os_version() -> String {
+    use winreg::enums::HKEY_LOCAL_MACHINE;
+    use winreg::RegKey;
+
+    let key = match RegKey::predef(HKEY_LOCAL_MACHINE)
+        .open_subkey("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion")
+    {
+        Ok(key) => key,
+        Err(_) => return "Unknown OS".to_string(),
+    };
+    let product_name: String = key.get_value("ProductName").unwrap_or_default();
+    let display_version: String = key.get_value("DisplayVersion").unwrap_or_default();
+
+    match (product_name.is_empty(), display_version.is_empty()) {
+        (false, false) => format!("{} (Version {})", product_name, display_version),
+        (false, true) => product_name,
+        _ => "Unknown OS".to_string(),
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn get_windows_cpu_model() -> String {
+    use winreg::enums::HKEY_LOCAL_MACHINE;
+    use winreg::RegKey;
+
+    RegKey::predef(HKEY_LOCAL_MACHINE)
+        .open_subkey("HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0")
+        .ok()
+        .and_then(|key| key.get_value::<String, _>("ProcessorNameString").ok())
+        .filter(|name| !name.trim().is_empty())
+        .map(|name| name.trim().to_string())
+        .unwrap_or_else(|| "Unknown CPU".to_string())
+}
+
+#[specta::specta]
+#[tauri::command]
+pub fn get_system_details() -> SystemDetails {
+    #[cfg(target_os = "windows")]
+    let os_version = get_windows_os_version();
+    #[cfg(target_os = "macos")]
+    let os_version = std::process::Command::new("sw_vers")
+        .arg("-productVersion")
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| format!("macOS {}", String::from_utf8_lossy(&output.stdout).trim()))
+        .unwrap_or_else(|| "Unknown OS".to_string());
+    #[cfg(target_os = "linux")]
+    let os_version = std::fs::read_to_string("/etc/os-release")
+        .ok()
+        .and_then(|content| content.lines().find_map(|line| line.strip_prefix("PRETTY_NAME=")))
+        .map(|name| name.trim_matches('"').to_string())
+        .unwrap_or_else(|| "Unknown OS".to_string());
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+    let os_version = "Unknown OS".to_string();
+
+    #[cfg(target_os = "windows")]
+    let cpu_model = get_windows_cpu_model();
+    #[cfg(target_os = "macos")]
+    let cpu_model = std::process::Command::new("sysctl")
+        .args(["-n", "machdep.cpu.brand_string"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| "Unknown CPU".to_string());
+    #[cfg(target_os = "linux")]
+    let cpu_model = std::fs::read_to_string("/proc/cpuinfo")
+        .ok()
+        .and_then(|content| content.lines().find_map(|line| {
+            (line.starts_with("model name") || line.starts_with("Model"))
+                .then(|| line.split_once(':').map(|(_, name)| name.trim().to_string()))
+                .flatten()
+        }))
+        .unwrap_or_else(|| "Unknown CPU".to_string());
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+    let cpu_model = "Unknown CPU".to_string();
+
+    let gpu_model = crate::managers::transcription::get_available_accelerators()
+        .gpu_devices
+        .iter()
+        .map(|device| device.name.clone())
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    SystemDetails {
+        os_version,
+        cpu_model,
+        gpu_model: if gpu_model.is_empty() { "Unknown GPU".to_string() } else { gpu_model },
+    }
+}
+
+#[specta::specta]
+#[tauri::command]
+pub fn read_recent_logs(app: AppHandle) -> Result<String, String> {
+    const MAX_LINES: usize = 100;
+    let log_dir = crate::portable::app_log_dir(&app)
+        .map_err(|error| format!("Failed to get log directory: {}", error))?;
+    let content = std::fs::read_to_string(log_dir.join("handy.log"))
+        .map_err(|error| format!("Failed to read Handy logs: {}", error))?;
+    let lines: Vec<_> = content.lines().collect();
+    Ok(lines[lines.len().saturating_sub(MAX_LINES)..].join("\n"))
 }
 
 #[specta::specta]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -154,13 +154,26 @@ pub fn get_system_details() -> SystemDetails {
 #[specta::specta]
 #[tauri::command]
 pub fn read_recent_logs(app: AppHandle) -> Result<String, String> {
+    use std::collections::VecDeque;
+    use std::fs::File;
+    use std::io::{BufRead, BufReader};
+
     const MAX_LINES: usize = 100;
     let log_dir = crate::portable::app_log_dir(&app)
         .map_err(|error| format!("Failed to get log directory: {}", error))?;
-    let content = std::fs::read_to_string(log_dir.join("handy.log"))
+    let file = File::open(log_dir.join("handy.log"))
         .map_err(|error| format!("Failed to read Handy logs: {}", error))?;
-    let lines: Vec<_> = content.lines().collect();
-    Ok(lines[lines.len().saturating_sub(MAX_LINES)..].join("\n"))
+    let mut recent_lines = VecDeque::with_capacity(MAX_LINES);
+
+    for line in BufReader::new(file).lines() {
+        let line = line.map_err(|error| format!("Failed to read Handy logs: {}", error))?;
+        if recent_lines.len() == MAX_LINES {
+            recent_lines.pop_front();
+        }
+        recent_lines.push_back(line);
+    }
+
+    Ok(recent_lines.into_iter().collect::<Vec<_>>().join("\n"))
 }
 
 #[specta::specta]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -676,6 +676,8 @@ pub fn run(cli_args: CliArgs) {
             commands::check_apple_intelligence_available,
             commands::initialize_enigo,
             commands::initialize_shortcuts,
+            commands::get_system_details,
+            commands::read_recent_logs,
             commands::models::get_available_models,
             commands::models::get_model_info,
             commands::models::download_model,

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -597,6 +597,17 @@ async initializeEnigo() : Promise<Result<null, string>> {
  * On macOS, this should be called after accessibility permissions are granted.
  * This is idempotent - calling it multiple times is safe.
  */
+async getSystemDetails() : Promise<SystemDetails> {
+    return await TAURI_INVOKE("get_system_details");
+},
+async readRecentLogs() : Promise<Result<string, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("read_recent_logs") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e as any };
+}
+},
 async initializeShortcuts() : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("initialize_shortcuts") };
@@ -971,6 +982,7 @@ export type EngineType =
  * the file, so this one variant covers the whole transcribe-cpp family.
  */
 "TranscribeCpp" | "Parakeet" | "Moonshine" | "MoonshineStreaming" | "SenseVoice" | "GigaAM" | "Canary" | "Cohere"
+export type SystemDetails = { os_version: string; cpu_model: string; gpu_model: string }
 export type GpuDeviceOption = { id: number; name: string; total_vram_mb: number }
 export type HistoryEntry = { id: number; file_name: string; timestamp: number; saved: boolean; title: string; transcription_text: string; post_processed_text: string | null; post_process_prompt: string | null; post_process_requested: boolean }
 export type HistoryUpdatePayload = { action: "added"; entry: HistoryEntry } | { action: "updated"; entry: HistoryEntry } | { action: "deleted"; id: number } | { action: "toggled"; id: number }

--- a/src/components/settings/about/AboutSettings.tsx
+++ b/src/components/settings/about/AboutSettings.tsx
@@ -88,20 +88,20 @@ export const AboutSettings: React.FC = () => {
         }
       }
 
-      const bodyTemplate = `## Before You Submit
+      const bodyTemplate = `## ${t("settings.about.reportBug.issueTemplate.beforeSubmit")}
 
-**Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.**
+**${t("settings.about.reportBug.issueTemplate.searchExisting")}**
 
-## Bug Description
+## ${t("settings.about.reportBug.issueTemplate.description")}
 
 ${bugDescription}
 
-## System Information
+## ${t("settings.about.reportBug.issueTemplate.systemInformation")}
 
-**App Version:** ${version || "Unknown Version"}
-**Operating System:** ${sysDetails.os_version}
-**CPU:** ${sysDetails.cpu_model}
-**GPU:** ${sysDetails.gpu_model}
+**${t("settings.about.reportBug.issueTemplate.appVersion")}:** ${version || t("settings.about.reportBug.issueTemplate.unknownVersion")}
+**${t("settings.about.reportBug.issueTemplate.operatingSystem")}:** ${sysDetails.os_version}
+**${t("settings.about.reportBug.issueTemplate.cpu")}:** ${sysDetails.cpu_model}
+**${t("settings.about.reportBug.issueTemplate.gpu")}:** ${sysDetails.gpu_model}
 ${
   includeLogs
     ? `
@@ -110,7 +110,7 @@ ${
     : ""
 }`;
 
-      const title = `[BUG - app] ${bugTitle}`;
+      const title = `[${t("settings.about.reportBug.issueTemplate.titlePrefix")}] ${bugTitle}`;
       const url = `https://github.com/cjpais/handy/issues/new?title=${encodeURIComponent(title)}&body=${encodeURIComponent(bodyTemplate)}`;
       await openUrl(url);
       setIsReportBugOpen(false);
@@ -198,22 +198,22 @@ ${
       >
         <div className="space-y-4 py-2 text-start">
           <div className="text-sm text-mid-gray bg-mid-gray/5 p-3 rounded-md border border-mid-gray/20">
-            {/* eslint-disable-next-line i18next/no-literal-string */}
-            Please search{" "}
+            {t("settings.about.reportBug.searchPrompt")} {" "}
             <a
               href="https://github.com/cjpais/Handy/issues"
               target="_blank"
               rel="noopener noreferrer"
               className="text-logo-primary hover:underline font-semibold"
             >
-              existing issues
+              {t("settings.about.reportBug.existingIssuesLink")}
             </a>{" "}
-            to avoid duplicates. Your bug may already be reported!
+            {t("settings.about.reportBug.searchPromptSuffix")}
           </div>
 
           <div className="flex flex-col space-y-1.5">
-            {/* eslint-disable-next-line i18next/no-literal-string */}
-            <label className="text-xs font-semibold text-mid-gray uppercase tracking-wider">Title</label>
+            <label className="text-xs font-semibold text-mid-gray uppercase tracking-wider">
+              {t("settings.about.reportBug.titleLabel")}
+            </label>
             <Input
               value={bugTitle}
               onChange={(e) => setBugTitle(e.target.value)}
@@ -226,8 +226,9 @@ ${
           </div>
 
           <div className="flex flex-col space-y-1.5">
-            {/* eslint-disable-next-line i18next/no-literal-string */}
-            <label className="text-xs font-semibold text-mid-gray uppercase tracking-wider">Description</label>
+            <label className="text-xs font-semibold text-mid-gray uppercase tracking-wider">
+              {t("settings.about.reportBug.descriptionLabel")}
+            </label>
             <Textarea
               value={bugDescription}
               onChange={(e) => setBugDescription(e.target.value)}
@@ -247,8 +248,9 @@ ${
               disabled={isSubmitting}
               className="w-4 h-4 rounded border-mid-gray/80 bg-mid-gray/10 text-logo-primary focus:ring-logo-primary accent-logo-primary"
             />
-            {/* eslint-disable-next-line i18next/no-literal-string */}
-            <span className="font-semibold text-mid-gray">Include recent logs (last 100 lines)</span>
+            <span className="font-semibold text-mid-gray">
+              {t("settings.about.reportBug.includeLogs")}
+            </span>
           </label>
 
           {includeLogs && (

--- a/src/components/settings/about/AboutSettings.tsx
+++ b/src/components/settings/about/AboutSettings.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { getVersion } from "@tauri-apps/api/app";
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { SettingsGroup } from "../../ui/SettingsGroup";
 import { SettingContainer } from "../../ui/SettingContainer";
 import { Button } from "../../ui/Button";
@@ -10,10 +11,20 @@ import { AppLanguageSelector } from "../AppLanguageSelector";
 import { ShowWhatsNewOnUpdate } from "../ShowWhatsNewOnUpdate";
 import { ThemeSelector } from "../ThemeSelector";
 import { LogDirectory } from "../debug";
+import { commands } from "@/bindings";
+import { Dialog } from "../../ui/Dialog";
+import { Input } from "../../ui/Input";
+import { Textarea } from "../../ui/Textarea";
 
 export const AboutSettings: React.FC = () => {
   const { t } = useTranslation();
   const [version, setVersion] = useState("");
+  const [isReportBugOpen, setIsReportBugOpen] = useState(false);
+  const [bugTitle, setBugTitle] = useState("");
+  const [bugDescription, setBugDescription] = useState("");
+  const [includeLogs, setIncludeLogs] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
     const fetchVersion = async () => {
@@ -34,6 +45,81 @@ export const AboutSettings: React.FC = () => {
       await openUrl("https://handy.computer/donate");
     } catch (error) {
       console.error("Failed to open donate link:", error);
+    }
+  };
+
+  const handleReportBugClick = () => {
+    setBugTitle("");
+    setBugDescription("");
+    setIncludeLogs(false);
+    setSubmitError(null);
+    setIsReportBugOpen(true);
+  };
+
+  const handleFormSubmit = async () => {
+    setSubmitError(null);
+    setIsSubmitting(true);
+    try {
+      let sysDetails = {
+        os_version: "Unknown OS",
+        cpu_model: "Unknown CPU",
+        gpu_model: "Unknown GPU",
+      };
+      try {
+        sysDetails = await commands.getSystemDetails();
+      } catch (error) {
+        console.error("Failed to get system details:", error);
+      }
+
+      let logsText = "";
+      if (includeLogs) {
+        try {
+          const logsResult = await commands.readRecentLogs();
+          if (logsResult.status === "error") {
+            setSubmitError(t("settings.about.reportBug.logsFailed"));
+            return;
+          }
+          logsText = logsResult.data;
+          await writeText(logsText);
+        } catch (error) {
+          console.error("Failed to copy logs:", error);
+          setSubmitError(t("settings.about.reportBug.logsFailed"));
+          return;
+        }
+      }
+
+      const bodyTemplate = `## Before You Submit
+
+**Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.**
+
+## Bug Description
+
+${bugDescription}
+
+## System Information
+
+**App Version:** ${version || "Unknown Version"}
+**Operating System:** ${sysDetails.os_version}
+**CPU:** ${sysDetails.cpu_model}
+**GPU:** ${sysDetails.gpu_model}
+${
+  includeLogs
+    ? `
+
+> ${t("settings.about.reportBug.logsInstruction")}`
+    : ""
+}`;
+
+      const title = `[BUG - app] ${bugTitle}`;
+      const url = `https://github.com/cjpais/handy/issues/new?title=${encodeURIComponent(title)}&body=${encodeURIComponent(bodyTemplate)}`;
+      await openUrl(url);
+      setIsReportBugOpen(false);
+      setBugTitle("");
+      setBugDescription("");
+    } catch (error) {
+      console.error("Failed to open bug report link:", error);
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -77,6 +163,16 @@ export const AboutSettings: React.FC = () => {
           </Button>
         </SettingContainer>
 
+        <SettingContainer
+          title={t("settings.about.reportBug.title")}
+          description={t("settings.about.reportBug.description")}
+          grouped={true}
+        >
+          <Button variant="primary-soft" size="md" onClick={handleReportBugClick}>
+            {t("settings.about.reportBug.button")}
+          </Button>
+        </SettingContainer>
+
         <AppDataDirectory descriptionMode="tooltip" grouped={true} />
         <LogDirectory grouped={true} />
       </SettingsGroup>
@@ -93,6 +189,95 @@ export const AboutSettings: React.FC = () => {
           </div>
         </SettingContainer>
       </SettingsGroup>
+
+      <Dialog
+        open={isReportBugOpen}
+        title={t("settings.about.reportBug.title")}
+        closeLabel={t("common.cancel") || "Cancel"}
+        onOpenChange={setIsReportBugOpen}
+      >
+        <div className="space-y-4 py-2 text-start">
+          <div className="text-sm text-mid-gray bg-mid-gray/5 p-3 rounded-md border border-mid-gray/20">
+            {/* eslint-disable-next-line i18next/no-literal-string */}
+            Please search{" "}
+            <a
+              href="https://github.com/cjpais/Handy/issues"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-logo-primary hover:underline font-semibold"
+            >
+              existing issues
+            </a>{" "}
+            to avoid duplicates. Your bug may already be reported!
+          </div>
+
+          <div className="flex flex-col space-y-1.5">
+            {/* eslint-disable-next-line i18next/no-literal-string */}
+            <label className="text-xs font-semibold text-mid-gray uppercase tracking-wider">Title</label>
+            <Input
+              value={bugTitle}
+              onChange={(e) => setBugTitle(e.target.value)}
+              maxLength={120}
+              placeholder={t("settings.about.reportBug.titlePlaceholder")}
+              className="w-full font-medium"
+              required
+              disabled={isSubmitting}
+            />
+          </div>
+
+          <div className="flex flex-col space-y-1.5">
+            {/* eslint-disable-next-line i18next/no-literal-string */}
+            <label className="text-xs font-semibold text-mid-gray uppercase tracking-wider">Description</label>
+            <Textarea
+              value={bugDescription}
+              onChange={(e) => setBugDescription(e.target.value)}
+              maxLength={1500}
+              placeholder={t("settings.about.reportBug.descriptionPlaceholder")}
+              className="w-full min-h-[140px] font-medium"
+              required
+              disabled={isSubmitting}
+            />
+          </div>
+
+          <label className="flex items-center space-x-2.5 text-sm cursor-pointer select-none py-1">
+            <input
+              type="checkbox"
+              checked={includeLogs}
+              onChange={(e) => setIncludeLogs(e.target.checked)}
+              disabled={isSubmitting}
+              className="w-4 h-4 rounded border-mid-gray/80 bg-mid-gray/10 text-logo-primary focus:ring-logo-primary accent-logo-primary"
+            />
+            {/* eslint-disable-next-line i18next/no-literal-string */}
+            <span className="font-semibold text-mid-gray">Include recent logs (last 100 lines)</span>
+          </label>
+
+          {includeLogs && (
+            <div role="alert" className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
+              <p className="font-semibold">{t("settings.about.reportBug.logsWarningTitle")}</p>
+              <p className="mt-1 text-mid-gray">{t("settings.about.reportBug.logsWarning")}</p>
+            </div>
+          )}
+          {submitError && <p role="alert" className="rounded-md border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-400">{submitError}</p>}
+          <div className="flex justify-end space-x-3 pt-3 border-t border-mid-gray/20">
+            <Button
+              variant="secondary"
+              size="md"
+              onClick={() => setIsReportBugOpen(false)}
+              disabled={isSubmitting}
+            >
+              {t("common.cancel") || "Cancel"}
+            </Button>
+            <Button
+              variant="primary"
+              size="md"
+              onClick={handleFormSubmit}
+              disabled={!bugTitle.trim() || !bugDescription.trim() || isSubmitting}
+            >
+              {isSubmitting ? t("settings.about.reportBug.submitting") : t("settings.about.reportBug.submit")}
+            </Button>
+          </div>
+        </div>
+      </Dialog>
     </div>
   );
 };

--- a/src/components/settings/about/AboutSettings.tsx
+++ b/src/components/settings/about/AboutSettings.tsx
@@ -80,6 +80,10 @@ export const AboutSettings: React.FC = () => {
             return;
           }
           logsText = logsResult.data;
+          if (!logsText.trim()) {
+            setSubmitError(t("settings.about.reportBug.noLogsAvailable"));
+            return;
+          }
           await writeText(logsText);
         } catch (error) {
           console.error("Failed to copy logs:", error);
@@ -90,7 +94,7 @@ export const AboutSettings: React.FC = () => {
 
       const bodyTemplate = `## ${t("settings.about.reportBug.issueTemplate.beforeSubmit")}
 
-**${t("settings.about.reportBug.issueTemplate.searchExisting")}**
+**${t("settings.about.reportBug.issueTemplate.searchExisting")}** ${t("settings.about.reportBug.issueTemplate.maintainerNote")}
 
 ## ${t("settings.about.reportBug.issueTemplate.description")}
 
@@ -99,16 +103,30 @@ ${bugDescription}
 ## ${t("settings.about.reportBug.issueTemplate.systemInformation")}
 
 **${t("settings.about.reportBug.issueTemplate.appVersion")}:** ${version || t("settings.about.reportBug.issueTemplate.unknownVersion")}
+
+<!-- ${t("settings.about.reportBug.issueTemplate.appVersionHint")} -->
+
 **${t("settings.about.reportBug.issueTemplate.operatingSystem")}:** ${sysDetails.os_version}
+
+<!-- ${t("settings.about.reportBug.issueTemplate.operatingSystemHint")} -->
+
 **${t("settings.about.reportBug.issueTemplate.cpu")}:** ${sysDetails.cpu_model}
+
+<!-- ${t("settings.about.reportBug.issueTemplate.cpuHint")} -->
+
 **${t("settings.about.reportBug.issueTemplate.gpu")}:** ${sysDetails.gpu_model}
-${
-  includeLogs
-    ? `
+
+<!-- ${t("settings.about.reportBug.issueTemplate.gpuHint")} -->
+
+## ${t("settings.about.reportBug.issueTemplate.logs")}
+
+<!-- ${t("settings.about.reportBug.issueTemplate.logsHint")} -->${
+        includeLogs
+          ? `
 
 > ${t("settings.about.reportBug.logsInstruction")}`
-    : ""
-}`;
+          : ""
+      }`;
 
       const title = `[${t("settings.about.reportBug.issueTemplate.titlePrefix")}] ${bugTitle}`;
       const url = `https://github.com/cjpais/handy/issues/new?title=${encodeURIComponent(title)}&body=${encodeURIComponent(bodyTemplate)}`;
@@ -168,11 +186,7 @@ ${
           description={t("settings.about.reportBug.description")}
           grouped={true}
         >
-          <Button
-            variant="primary-soft"
-            size="md"
-            onClick={handleReportBugClick}
-          >
+          <Button variant="primary" size="md" onClick={handleReportBugClick}>
             {t("settings.about.reportBug.button")}
           </Button>
         </SettingContainer>

--- a/src/components/settings/about/AboutSettings.tsx
+++ b/src/components/settings/about/AboutSettings.tsx
@@ -168,7 +168,11 @@ ${
           description={t("settings.about.reportBug.description")}
           grouped={true}
         >
-          <Button variant="primary-soft" size="md" onClick={handleReportBugClick}>
+          <Button
+            variant="primary-soft"
+            size="md"
+            onClick={handleReportBugClick}
+          >
             {t("settings.about.reportBug.button")}
           </Button>
         </SettingContainer>
@@ -198,7 +202,7 @@ ${
       >
         <div className="space-y-4 py-2 text-start">
           <div className="text-sm text-mid-gray bg-mid-gray/5 p-3 rounded-md border border-mid-gray/20">
-            {t("settings.about.reportBug.searchPrompt")} {" "}
+            {t("settings.about.reportBug.searchPrompt")}{" "}
             <a
               href="https://github.com/cjpais/Handy/issues"
               target="_blank"
@@ -254,12 +258,26 @@ ${
           </label>
 
           {includeLogs && (
-            <div role="alert" className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
-              <p className="font-semibold">{t("settings.about.reportBug.logsWarningTitle")}</p>
-              <p className="mt-1 text-mid-gray">{t("settings.about.reportBug.logsWarning")}</p>
+            <div
+              role="alert"
+              className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm"
+            >
+              <p className="font-semibold">
+                {t("settings.about.reportBug.logsWarningTitle")}
+              </p>
+              <p className="mt-1 text-mid-gray">
+                {t("settings.about.reportBug.logsWarning")}
+              </p>
             </div>
           )}
-          {submitError && <p role="alert" className="rounded-md border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-400">{submitError}</p>}
+          {submitError && (
+            <p
+              role="alert"
+              className="rounded-md border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-400"
+            >
+              {submitError}
+            </p>
+          )}
           <div className="flex justify-end space-x-3 pt-3 border-t border-mid-gray/20">
             <Button
               variant="secondary"
@@ -273,9 +291,13 @@ ${
               variant="primary"
               size="md"
               onClick={handleFormSubmit}
-              disabled={!bugTitle.trim() || !bugDescription.trim() || isSubmitting}
+              disabled={
+                !bugTitle.trim() || !bugDescription.trim() || isSubmitting
+              }
             >
-              {isSubmitting ? t("settings.about.reportBug.submitting") : t("settings.about.reportBug.submit")}
+              {isSubmitting
+                ? t("settings.about.reportBug.submitting")
+                : t("settings.about.reportBug.submit")}
             </Button>
           </div>
         </div>

--- a/src/components/settings/about/AboutSettings.tsx
+++ b/src/components/settings/about/AboutSettings.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { getVersion } from "@tauri-apps/api/app";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { SettingsGroup } from "../../ui/SettingsGroup";
 import { SettingContainer } from "../../ui/SettingContainer";
 import { Button } from "../../ui/Button";
@@ -23,6 +22,9 @@ export const AboutSettings: React.FC = () => {
   const [bugTitle, setBugTitle] = useState("");
   const [bugDescription, setBugDescription] = useState("");
   const [includeLogs, setIncludeLogs] = useState(false);
+  const [submitMethod, setSubmitMethod] = useState<"github" | "email">(
+    "github",
+  );
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -52,6 +54,7 @@ export const AboutSettings: React.FC = () => {
     setBugTitle("");
     setBugDescription("");
     setIncludeLogs(false);
+    setSubmitMethod("github");
     setSubmitError(null);
     setIsReportBugOpen(true);
   };
@@ -84,7 +87,6 @@ export const AboutSettings: React.FC = () => {
             setSubmitError(t("settings.about.reportBug.noLogsAvailable"));
             return;
           }
-          await writeText(logsText);
         } catch (error) {
           console.error("Failed to copy logs:", error);
           setSubmitError(t("settings.about.reportBug.logsFailed"));
@@ -124,13 +126,18 @@ ${bugDescription}
         includeLogs
           ? `
 
-> ${t("settings.about.reportBug.logsInstruction")}`
+> ${submitMethod === "email" ? t("settings.about.reportBug.logsInstruction") : ""}`
           : ""
       }`;
 
       const title = `[${t("settings.about.reportBug.issueTemplate.titlePrefix")}] ${bugTitle}`;
-      const url = `https://github.com/cjpais/handy/issues/new?title=${encodeURIComponent(title)}&body=${encodeURIComponent(bodyTemplate)}`;
-      await openUrl(url);
+      const destination =
+        submitMethod === "email"
+          ? `mailto:contact@handy.computer?subject=${encodeURIComponent(title)}&body=${encodeURIComponent(
+              includeLogs ? `${bodyTemplate}\n\n${logsText}` : bodyTemplate,
+            )}`
+          : `https://github.com/cjpais/handy/issues/new?title=${encodeURIComponent(title)}&body=${encodeURIComponent(bodyTemplate)}`;
+      await openUrl(destination);
       setIsReportBugOpen(false);
       setBugTitle("");
       setBugDescription("");
@@ -262,7 +269,11 @@ ${bugDescription}
             <input
               type="checkbox"
               checked={includeLogs}
-              onChange={(e) => setIncludeLogs(e.target.checked)}
+              onChange={(e) => {
+                const checked = e.target.checked;
+                setIncludeLogs(checked);
+                if (checked) setSubmitMethod("email");
+              }}
               disabled={isSubmitting}
               className="w-4 h-4 rounded border-mid-gray/80 bg-mid-gray/10 text-logo-primary focus:ring-logo-primary accent-logo-primary"
             />
@@ -270,6 +281,54 @@ ${bugDescription}
               {t("settings.about.reportBug.includeLogs")}
             </span>
           </label>
+
+          <fieldset className="space-y-2">
+            <legend className="text-xs font-semibold uppercase tracking-wider text-mid-gray">
+              {t("settings.about.reportBug.submitMethod")}
+            </legend>
+            <label className="flex cursor-pointer items-start gap-2 rounded-md border border-mid-gray/20 p-3 text-sm">
+              <input
+                type="radio"
+                name="bug-report-destination"
+                checked={submitMethod === "github"}
+                onChange={() => setSubmitMethod("github")}
+                disabled={includeLogs || isSubmitting}
+                className="mt-0.5 accent-logo-primary"
+              />
+              <span>
+                <span className="block font-semibold text-text">
+                  {t("settings.about.reportBug.githubOption")}
+                </span>
+                <span className="text-mid-gray">
+                  {t("settings.about.reportBug.githubDescription")}
+                </span>
+              </span>
+            </label>
+            <label className="flex cursor-pointer items-start gap-2 rounded-md border border-mid-gray/20 p-3 text-sm">
+              <input
+                type="radio"
+                name="bug-report-destination"
+                checked={submitMethod === "email"}
+                onChange={() => setSubmitMethod("email")}
+                disabled={isSubmitting}
+                className="mt-0.5 accent-logo-primary"
+              />
+              <span>
+                <span className="block font-semibold text-text">
+                  {t("settings.about.reportBug.emailOption")}
+                </span>
+                <span className="text-mid-gray">
+                  {t("settings.about.reportBug.emailDescription")}
+                </span>
+              </span>
+            </label>
+          </fieldset>
+
+          {includeLogs && (
+            <p className="rounded-md border border-logo-primary/30 bg-logo-primary/10 p-3 text-sm text-mid-gray">
+              {t("settings.about.reportBug.logsEmailOnly")}
+            </p>
+          )}
 
           {includeLogs && (
             <div

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -6,4 +6,5 @@ export { SettingContainer } from "./SettingContainer";
 export { SettingsGroup } from "./SettingsGroup";
 export { TextDisplay } from "./TextDisplay";
 export { Textarea } from "./Textarea";
+export { Input } from "./Input";
 export { Tooltip } from "./Tooltip";

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -595,7 +595,22 @@
         "submit": "Open GitHub issue",
         "submitting": "Preparing issue...",
         "failed": "We could not prepare your bug report. {{error}}",
-        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs.",
+        "searchPrompt": "Please search",
+        "existingIssuesLink": "existing issues",
+        "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
+        "issueTemplate": {
+          "beforeSubmit": "Before You Submit",
+          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "description": "Bug Description",
+          "systemInformation": "System Information",
+          "appVersion": "App Version",
+          "operatingSystem": "Operating System",
+          "cpu": "CPU",
+          "gpu": "GPU",
+          "unknownVersion": "Unknown Version",
+          "titlePrefix": "Bug"
+        }
       }
     },
     "modelSettings": {

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -601,7 +601,7 @@
         "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
         "issueTemplate": {
           "beforeSubmit": "Before You Submit",
-          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "searchExisting": "Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.",
           "description": "Bug Description",
           "systemInformation": "System Information",
           "appVersion": "App Version",
@@ -609,8 +609,16 @@
           "cpu": "CPU",
           "gpu": "GPU",
           "unknownVersion": "Unknown Version",
-          "titlePrefix": "Bug"
-        }
+          "titlePrefix": "Bug",
+          "maintainerNote": "Your bug may already be reported! Right now it's just me maintaining this project so many issues can be overwhelming! Help me out by checking first.",
+          "appVersionHint": "You can find this in the app settings or about section",
+          "operatingSystemHint": "e.g., macOS 14.1, Windows 11, Ubuntu 22.04",
+          "cpuHint": "e.g., Apple M2, Intel i7-12700K, AMD Ryzen 7 5800X",
+          "gpuHint": "e.g., Apple M2 GPU, NVIDIA RTX 4080, AMD RX 6800 XT, Intel UHD Graphics",
+          "logs": "Logs",
+          "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
+        },
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
       }
     },
     "modelSettings": {

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -577,6 +577,25 @@
       "whatsNewUpdates": {
         "label": "إظهار الجديد",
         "description": "إظهار ملاحظات الإصدار بعد تحديثات Handy"
+      },
+      "reportBug": {
+        "title": "Report a Bug",
+        "description": "Create a GitHub issue with details about a problem",
+        "button": "Report a Bug",
+        "dialogDescription": "Describe the problem and we will prepare a GitHub issue for you.",
+        "titleLabel": "Title",
+        "titlePlaceholder": "For example: Recording stops unexpectedly",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "What happened? Include steps to reproduce and what you expected instead.",
+        "characterCount": "{{count}} / {{limit}} characters",
+        "includeLogs": "Copy recent logs to clipboard",
+        "logsWarningTitle": "Logs may contain sensitive information",
+        "logsWarning": "Recent logs will be copied to your clipboard, not uploaded automatically. Review them before you paste them into the GitHub issue. They can include file paths, device names, or other information you may not want to share.",
+        "logsInstruction": "The last 100 log lines were copied to your clipboard. Review them, then paste them into the Logs section of the issue if you are comfortable sharing them.",
+        "submit": "Open GitHub issue",
+        "submitting": "Preparing issue...",
+        "failed": "We could not prepare your bug report. {{error}}",
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
       }
     },
     "modelSettings": {
@@ -625,7 +644,8 @@
     "open": "فتح",
     "copy": "نسخ",
     "clear": "مسح",
-    "noOptionsFound": "لم يتم العثور على خيارات"
+    "noOptionsFound": "لم يتم العثور على خيارات",
+    "cancel": "Cancel"
   },
   "accessibility": {
     "permissionsDescription": ".يحتاج Handy إلى أذونات إمكانية الوصول لكتابة النص المفرغ",

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -618,7 +618,14 @@
           "logs": "Logs",
           "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
         },
-        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again.",
+        "submitMethod": "Send report via",
+        "githubOption": "GitHub issue",
+        "githubDescription": "Best for bug reports without logs.",
+        "emailOption": "Email",
+        "emailDescription": "Send to contact@handy.computer.",
+        "logsEmailOnly": "Reports with logs can only be sent by email. The logs will be included in the email body.",
+        "openEmail": "Open email"
       }
     },
     "modelSettings": {

--- a/src/i18n/locales/bg/translation.json
+++ b/src/i18n/locales/bg/translation.json
@@ -624,7 +624,7 @@
         "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
         "issueTemplate": {
           "beforeSubmit": "Before You Submit",
-          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "searchExisting": "Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.",
           "description": "Bug Description",
           "systemInformation": "System Information",
           "appVersion": "App Version",
@@ -632,8 +632,16 @@
           "cpu": "CPU",
           "gpu": "GPU",
           "unknownVersion": "Unknown Version",
-          "titlePrefix": "Bug"
-        }
+          "titlePrefix": "Bug",
+          "maintainerNote": "Your bug may already be reported! Right now it's just me maintaining this project so many issues can be overwhelming! Help me out by checking first.",
+          "appVersionHint": "You can find this in the app settings or about section",
+          "operatingSystemHint": "e.g., macOS 14.1, Windows 11, Ubuntu 22.04",
+          "cpuHint": "e.g., Apple M2, Intel i7-12700K, AMD Ryzen 7 5800X",
+          "gpuHint": "e.g., Apple M2 GPU, NVIDIA RTX 4080, AMD RX 6800 XT, Intel UHD Graphics",
+          "logs": "Logs",
+          "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
+        },
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
       }
     }
   },

--- a/src/i18n/locales/bg/translation.json
+++ b/src/i18n/locales/bg/translation.json
@@ -641,7 +641,14 @@
           "logs": "Logs",
           "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
         },
-        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again.",
+        "submitMethod": "Send report via",
+        "githubOption": "GitHub issue",
+        "githubDescription": "Best for bug reports without logs.",
+        "emailOption": "Email",
+        "emailDescription": "Send to contact@handy.computer.",
+        "logsEmailOnly": "Reports with logs can only be sent by email. The logs will be included in the email body.",
+        "openEmail": "Open email"
       }
     }
   },

--- a/src/i18n/locales/bg/translation.json
+++ b/src/i18n/locales/bg/translation.json
@@ -600,6 +600,25 @@
       "whatsNewUpdates": {
         "label": "Показвай новостите",
         "description": "Показвай бележки към изданието след актуализации на Handy"
+      },
+      "reportBug": {
+        "title": "Report a Bug",
+        "description": "Create a GitHub issue with details about a problem",
+        "button": "Report a Bug",
+        "dialogDescription": "Describe the problem and we will prepare a GitHub issue for you.",
+        "titleLabel": "Title",
+        "titlePlaceholder": "For example: Recording stops unexpectedly",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "What happened? Include steps to reproduce and what you expected instead.",
+        "characterCount": "{{count}} / {{limit}} characters",
+        "includeLogs": "Copy recent logs to clipboard",
+        "logsWarningTitle": "Logs may contain sensitive information",
+        "logsWarning": "Recent logs will be copied to your clipboard, not uploaded automatically. Review them before you paste them into the GitHub issue. They can include file paths, device names, or other information you may not want to share.",
+        "logsInstruction": "The last 100 log lines were copied to your clipboard. Review them, then paste them into the Logs section of the issue if you are comfortable sharing them.",
+        "submit": "Open GitHub issue",
+        "submitting": "Preparing issue...",
+        "failed": "We could not prepare your bug report. {{error}}",
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
       }
     }
   },
@@ -625,7 +644,8 @@
     "open": "Отваряне",
     "copy": "Копиране",
     "clear": "Изчистване",
-    "noOptionsFound": "Няма намерени опции"
+    "noOptionsFound": "Няма намерени опции",
+    "cancel": "Cancel"
   },
   "accessibility": {
     "permissionsDescription": "Handy се нуждае от разрешения за достъпност, за да въвежда транскрибирания текст.",

--- a/src/i18n/locales/bg/translation.json
+++ b/src/i18n/locales/bg/translation.json
@@ -618,7 +618,22 @@
         "submit": "Open GitHub issue",
         "submitting": "Preparing issue...",
         "failed": "We could not prepare your bug report. {{error}}",
-        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs.",
+        "searchPrompt": "Please search",
+        "existingIssuesLink": "existing issues",
+        "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
+        "issueTemplate": {
+          "beforeSubmit": "Before You Submit",
+          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "description": "Bug Description",
+          "systemInformation": "System Information",
+          "appVersion": "App Version",
+          "operatingSystem": "Operating System",
+          "cpu": "CPU",
+          "gpu": "GPU",
+          "unknownVersion": "Unknown Version",
+          "titlePrefix": "Bug"
+        }
       }
     }
   },

--- a/src/i18n/locales/cs/translation.json
+++ b/src/i18n/locales/cs/translation.json
@@ -600,6 +600,25 @@
       "whatsNewUpdates": {
         "label": "Zobrazovat novinky",
         "description": "Zobrazovat poznámky k vydání po aktualizacích Handy"
+      },
+      "reportBug": {
+        "title": "Report a Bug",
+        "description": "Create a GitHub issue with details about a problem",
+        "button": "Report a Bug",
+        "dialogDescription": "Describe the problem and we will prepare a GitHub issue for you.",
+        "titleLabel": "Title",
+        "titlePlaceholder": "For example: Recording stops unexpectedly",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "What happened? Include steps to reproduce and what you expected instead.",
+        "characterCount": "{{count}} / {{limit}} characters",
+        "includeLogs": "Copy recent logs to clipboard",
+        "logsWarningTitle": "Logs may contain sensitive information",
+        "logsWarning": "Recent logs will be copied to your clipboard, not uploaded automatically. Review them before you paste them into the GitHub issue. They can include file paths, device names, or other information you may not want to share.",
+        "logsInstruction": "The last 100 log lines were copied to your clipboard. Review them, then paste them into the Logs section of the issue if you are comfortable sharing them.",
+        "submit": "Open GitHub issue",
+        "submitting": "Preparing issue...",
+        "failed": "We could not prepare your bug report. {{error}}",
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
       }
     }
   },
@@ -625,7 +644,8 @@
     "open": "Otevřít",
     "copy": "Kopírovat",
     "clear": "Vymazat",
-    "noOptionsFound": "Nenalezeny žádné možnosti"
+    "noOptionsFound": "Nenalezeny žádné možnosti",
+    "cancel": "Cancel"
   },
   "accessibility": {
     "permissionsDescription": "Handy potřebuje oprávnění usnadnění přístupu, aby mohlo psát přepsaný text.",

--- a/src/i18n/locales/cs/translation.json
+++ b/src/i18n/locales/cs/translation.json
@@ -624,7 +624,7 @@
         "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
         "issueTemplate": {
           "beforeSubmit": "Before You Submit",
-          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "searchExisting": "Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.",
           "description": "Bug Description",
           "systemInformation": "System Information",
           "appVersion": "App Version",
@@ -632,8 +632,16 @@
           "cpu": "CPU",
           "gpu": "GPU",
           "unknownVersion": "Unknown Version",
-          "titlePrefix": "Bug"
-        }
+          "titlePrefix": "Bug",
+          "maintainerNote": "Your bug may already be reported! Right now it's just me maintaining this project so many issues can be overwhelming! Help me out by checking first.",
+          "appVersionHint": "You can find this in the app settings or about section",
+          "operatingSystemHint": "e.g., macOS 14.1, Windows 11, Ubuntu 22.04",
+          "cpuHint": "e.g., Apple M2, Intel i7-12700K, AMD Ryzen 7 5800X",
+          "gpuHint": "e.g., Apple M2 GPU, NVIDIA RTX 4080, AMD RX 6800 XT, Intel UHD Graphics",
+          "logs": "Logs",
+          "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
+        },
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
       }
     }
   },

--- a/src/i18n/locales/cs/translation.json
+++ b/src/i18n/locales/cs/translation.json
@@ -641,7 +641,14 @@
           "logs": "Logs",
           "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
         },
-        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again.",
+        "submitMethod": "Send report via",
+        "githubOption": "GitHub issue",
+        "githubDescription": "Best for bug reports without logs.",
+        "emailOption": "Email",
+        "emailDescription": "Send to contact@handy.computer.",
+        "logsEmailOnly": "Reports with logs can only be sent by email. The logs will be included in the email body.",
+        "openEmail": "Open email"
       }
     }
   },

--- a/src/i18n/locales/cs/translation.json
+++ b/src/i18n/locales/cs/translation.json
@@ -618,7 +618,22 @@
         "submit": "Open GitHub issue",
         "submitting": "Preparing issue...",
         "failed": "We could not prepare your bug report. {{error}}",
-        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs.",
+        "searchPrompt": "Please search",
+        "existingIssuesLink": "existing issues",
+        "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
+        "issueTemplate": {
+          "beforeSubmit": "Before You Submit",
+          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "description": "Bug Description",
+          "systemInformation": "System Information",
+          "appVersion": "App Version",
+          "operatingSystem": "Operating System",
+          "cpu": "CPU",
+          "gpu": "GPU",
+          "unknownVersion": "Unknown Version",
+          "titlePrefix": "Bug"
+        }
       }
     }
   },

--- a/src/i18n/locales/da/translation.json
+++ b/src/i18n/locales/da/translation.json
@@ -624,7 +624,7 @@
         "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
         "issueTemplate": {
           "beforeSubmit": "Before You Submit",
-          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "searchExisting": "Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.",
           "description": "Bug Description",
           "systemInformation": "System Information",
           "appVersion": "App Version",
@@ -632,8 +632,16 @@
           "cpu": "CPU",
           "gpu": "GPU",
           "unknownVersion": "Unknown Version",
-          "titlePrefix": "Bug"
-        }
+          "titlePrefix": "Bug",
+          "maintainerNote": "Your bug may already be reported! Right now it's just me maintaining this project so many issues can be overwhelming! Help me out by checking first.",
+          "appVersionHint": "You can find this in the app settings or about section",
+          "operatingSystemHint": "e.g., macOS 14.1, Windows 11, Ubuntu 22.04",
+          "cpuHint": "e.g., Apple M2, Intel i7-12700K, AMD Ryzen 7 5800X",
+          "gpuHint": "e.g., Apple M2 GPU, NVIDIA RTX 4080, AMD RX 6800 XT, Intel UHD Graphics",
+          "logs": "Logs",
+          "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
+        },
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
       }
     }
   },

--- a/src/i18n/locales/da/translation.json
+++ b/src/i18n/locales/da/translation.json
@@ -641,7 +641,14 @@
           "logs": "Logs",
           "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
         },
-        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again.",
+        "submitMethod": "Send report via",
+        "githubOption": "GitHub issue",
+        "githubDescription": "Best for bug reports without logs.",
+        "emailOption": "Email",
+        "emailDescription": "Send to contact@handy.computer.",
+        "logsEmailOnly": "Reports with logs can only be sent by email. The logs will be included in the email body.",
+        "openEmail": "Open email"
       }
     }
   },

--- a/src/i18n/locales/da/translation.json
+++ b/src/i18n/locales/da/translation.json
@@ -618,7 +618,22 @@
         "submit": "Open GitHub issue",
         "submitting": "Preparing issue...",
         "failed": "We could not prepare your bug report. {{error}}",
-        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs.",
+        "searchPrompt": "Please search",
+        "existingIssuesLink": "existing issues",
+        "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
+        "issueTemplate": {
+          "beforeSubmit": "Before You Submit",
+          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "description": "Bug Description",
+          "systemInformation": "System Information",
+          "appVersion": "App Version",
+          "operatingSystem": "Operating System",
+          "cpu": "CPU",
+          "gpu": "GPU",
+          "unknownVersion": "Unknown Version",
+          "titlePrefix": "Bug"
+        }
       }
     }
   },

--- a/src/i18n/locales/da/translation.json
+++ b/src/i18n/locales/da/translation.json
@@ -600,6 +600,25 @@
           "description": "Højtydende tensor-bibliotek til maskinlæringsinferens på enheden",
           "details": "Handys lokale tale-til-tekst funktionalitet er bygget på transcribe.cpp og ggml. Tak for det fantastiske arbejde af Georgi Gerganov og bidragyderne."
         }
+      },
+      "reportBug": {
+        "title": "Report a Bug",
+        "description": "Create a GitHub issue with details about a problem",
+        "button": "Report a Bug",
+        "dialogDescription": "Describe the problem and we will prepare a GitHub issue for you.",
+        "titleLabel": "Title",
+        "titlePlaceholder": "For example: Recording stops unexpectedly",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "What happened? Include steps to reproduce and what you expected instead.",
+        "characterCount": "{{count}} / {{limit}} characters",
+        "includeLogs": "Copy recent logs to clipboard",
+        "logsWarningTitle": "Logs may contain sensitive information",
+        "logsWarning": "Recent logs will be copied to your clipboard, not uploaded automatically. Review them before you paste them into the GitHub issue. They can include file paths, device names, or other information you may not want to share.",
+        "logsInstruction": "The last 100 log lines were copied to your clipboard. Review them, then paste them into the Logs section of the issue if you are comfortable sharing them.",
+        "submit": "Open GitHub issue",
+        "submitting": "Preparing issue...",
+        "failed": "We could not prepare your bug report. {{error}}",
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
       }
     }
   },
@@ -628,7 +647,8 @@
     "open": "Åbn",
     "copy": "Kopiér",
     "clear": "Ryd",
-    "noOptionsFound": "Ingen muligheder fundet"
+    "noOptionsFound": "Ingen muligheder fundet",
+    "cancel": "Cancel"
   },
   "accessibility": {
     "permissionsDescription": "Handy har brug for tilgængelighedstilladelser for at skrive den transskriberede tekst.",

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -600,6 +600,25 @@
       "whatsNewUpdates": {
         "label": "Neuerungen anzeigen",
         "description": "Versionshinweise nach Handy-Updates anzeigen"
+      },
+      "reportBug": {
+        "title": "Report a Bug",
+        "description": "Create a GitHub issue with details about a problem",
+        "button": "Report a Bug",
+        "dialogDescription": "Describe the problem and we will prepare a GitHub issue for you.",
+        "titleLabel": "Title",
+        "titlePlaceholder": "For example: Recording stops unexpectedly",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "What happened? Include steps to reproduce and what you expected instead.",
+        "characterCount": "{{count}} / {{limit}} characters",
+        "includeLogs": "Copy recent logs to clipboard",
+        "logsWarningTitle": "Logs may contain sensitive information",
+        "logsWarning": "Recent logs will be copied to your clipboard, not uploaded automatically. Review them before you paste them into the GitHub issue. They can include file paths, device names, or other information you may not want to share.",
+        "logsInstruction": "The last 100 log lines were copied to your clipboard. Review them, then paste them into the Logs section of the issue if you are comfortable sharing them.",
+        "submit": "Open GitHub issue",
+        "submitting": "Preparing issue...",
+        "failed": "We could not prepare your bug report. {{error}}",
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
       }
     }
   },
@@ -625,7 +644,8 @@
     "open": "Öffnen",
     "copy": "Kopieren",
     "clear": "Leeren",
-    "noOptionsFound": "Keine Optionen gefunden"
+    "noOptionsFound": "Keine Optionen gefunden",
+    "cancel": "Cancel"
   },
   "accessibility": {
     "permissionsDescription": "Handy benötigt Bedienungshilfen-Berechtigungen, um transkribierten Text einzugeben.",

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -624,7 +624,7 @@
         "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
         "issueTemplate": {
           "beforeSubmit": "Before You Submit",
-          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "searchExisting": "Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.",
           "description": "Bug Description",
           "systemInformation": "System Information",
           "appVersion": "App Version",
@@ -632,8 +632,16 @@
           "cpu": "CPU",
           "gpu": "GPU",
           "unknownVersion": "Unknown Version",
-          "titlePrefix": "Bug"
-        }
+          "titlePrefix": "Bug",
+          "maintainerNote": "Your bug may already be reported! Right now it's just me maintaining this project so many issues can be overwhelming! Help me out by checking first.",
+          "appVersionHint": "You can find this in the app settings or about section",
+          "operatingSystemHint": "e.g., macOS 14.1, Windows 11, Ubuntu 22.04",
+          "cpuHint": "e.g., Apple M2, Intel i7-12700K, AMD Ryzen 7 5800X",
+          "gpuHint": "e.g., Apple M2 GPU, NVIDIA RTX 4080, AMD RX 6800 XT, Intel UHD Graphics",
+          "logs": "Logs",
+          "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
+        },
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
       }
     }
   },

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -641,7 +641,14 @@
           "logs": "Logs",
           "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
         },
-        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again.",
+        "submitMethod": "Send report via",
+        "githubOption": "GitHub issue",
+        "githubDescription": "Best for bug reports without logs.",
+        "emailOption": "Email",
+        "emailDescription": "Send to contact@handy.computer.",
+        "logsEmailOnly": "Reports with logs can only be sent by email. The logs will be included in the email body.",
+        "openEmail": "Open email"
       }
     }
   },

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -618,7 +618,22 @@
         "submit": "Open GitHub issue",
         "submitting": "Preparing issue...",
         "failed": "We could not prepare your bug report. {{error}}",
-        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs.",
+        "searchPrompt": "Please search",
+        "existingIssuesLink": "existing issues",
+        "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
+        "issueTemplate": {
+          "beforeSubmit": "Before You Submit",
+          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "description": "Bug Description",
+          "systemInformation": "System Information",
+          "appVersion": "App Version",
+          "operatingSystem": "Operating System",
+          "cpu": "CPU",
+          "gpu": "GPU",
+          "unknownVersion": "Unknown Version",
+          "titlePrefix": "Bug"
+        }
       }
     }
   },

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -600,6 +600,25 @@
           "description": "High-performance tensor library for on-device machine learning inference",
           "details": "Handy's local speech-to-text is built on transcribe.cpp and ggml. Thanks to the amazing work by Georgi Gerganov and contributors."
         }
+      },
+      "reportBug": {
+        "title": "Report a Bug",
+        "description": "Create a GitHub issue with details about a problem",
+        "button": "Report a Bug",
+        "dialogDescription": "Describe the problem and we will prepare a GitHub issue for you.",
+        "titleLabel": "Title",
+        "titlePlaceholder": "For example: Recording stops unexpectedly",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "What happened? Include steps to reproduce and what you expected instead.",
+        "characterCount": "{{count}} / {{limit}} characters",
+        "includeLogs": "Copy recent logs to clipboard",
+        "logsWarningTitle": "Logs may contain sensitive information",
+        "logsWarning": "Recent logs will be copied to your clipboard, not uploaded automatically. Review them before you paste them into the GitHub issue. They can include file paths, device names, or other information you may not want to share.",
+        "logsInstruction": "The last 100 log lines were copied to your clipboard. Review them, then paste them into the Logs section of the issue if you are comfortable sharing them.",
+        "submit": "Open GitHub issue",
+        "submitting": "Preparing issue...",
+        "failed": "We could not prepare your bug report. {{error}}",
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
       }
     }
   },
@@ -628,7 +647,8 @@
     "open": "Open",
     "copy": "Copy",
     "clear": "Clear",
-    "noOptionsFound": "No options found"
+    "noOptionsFound": "No options found",
+    "cancel": "Cancel"
   },
   "accessibility": {
     "permissionsDescription": "Handy needs accessibility permissions to type transcribed text.",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -624,7 +624,7 @@
         "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
         "issueTemplate": {
           "beforeSubmit": "Before You Submit",
-          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "searchExisting": "Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.",
           "description": "Bug Description",
           "systemInformation": "System Information",
           "appVersion": "App Version",
@@ -632,8 +632,16 @@
           "cpu": "CPU",
           "gpu": "GPU",
           "unknownVersion": "Unknown Version",
-          "titlePrefix": "Bug"
-        }
+          "titlePrefix": "Bug",
+          "maintainerNote": "Your bug may already be reported! Right now it's just me maintaining this project so many issues can be overwhelming! Help me out by checking first.",
+          "appVersionHint": "You can find this in the app settings or about section",
+          "operatingSystemHint": "e.g., macOS 14.1, Windows 11, Ubuntu 22.04",
+          "cpuHint": "e.g., Apple M2, Intel i7-12700K, AMD Ryzen 7 5800X",
+          "gpuHint": "e.g., Apple M2 GPU, NVIDIA RTX 4080, AMD RX 6800 XT, Intel UHD Graphics",
+          "logs": "Logs",
+          "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
+        },
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
       }
     }
   },

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -641,7 +641,14 @@
           "logs": "Logs",
           "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
         },
-        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again.",
+        "submitMethod": "Send report via",
+        "githubOption": "GitHub issue",
+        "githubDescription": "Best for bug reports without logs.",
+        "emailOption": "Email",
+        "emailDescription": "Send to contact@handy.computer.",
+        "logsEmailOnly": "Reports with logs can only be sent by email. The logs will be included in the email body.",
+        "openEmail": "Open email"
       }
     }
   },

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -618,7 +618,22 @@
         "submit": "Open GitHub issue",
         "submitting": "Preparing issue...",
         "failed": "We could not prepare your bug report. {{error}}",
-        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs.",
+        "searchPrompt": "Please search",
+        "existingIssuesLink": "existing issues",
+        "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
+        "issueTemplate": {
+          "beforeSubmit": "Before You Submit",
+          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "description": "Bug Description",
+          "systemInformation": "System Information",
+          "appVersion": "App Version",
+          "operatingSystem": "Operating System",
+          "cpu": "CPU",
+          "gpu": "GPU",
+          "unknownVersion": "Unknown Version",
+          "titlePrefix": "Bug"
+        }
       }
     }
   },

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -624,7 +624,7 @@
         "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
         "issueTemplate": {
           "beforeSubmit": "Before You Submit",
-          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "searchExisting": "Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.",
           "description": "Bug Description",
           "systemInformation": "System Information",
           "appVersion": "App Version",
@@ -632,8 +632,16 @@
           "cpu": "CPU",
           "gpu": "GPU",
           "unknownVersion": "Unknown Version",
-          "titlePrefix": "Bug"
-        }
+          "titlePrefix": "Bug",
+          "maintainerNote": "Your bug may already be reported! Right now it's just me maintaining this project so many issues can be overwhelming! Help me out by checking first.",
+          "appVersionHint": "You can find this in the app settings or about section",
+          "operatingSystemHint": "e.g., macOS 14.1, Windows 11, Ubuntu 22.04",
+          "cpuHint": "e.g., Apple M2, Intel i7-12700K, AMD Ryzen 7 5800X",
+          "gpuHint": "e.g., Apple M2 GPU, NVIDIA RTX 4080, AMD RX 6800 XT, Intel UHD Graphics",
+          "logs": "Logs",
+          "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
+        },
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
       }
     }
   },

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -641,7 +641,14 @@
           "logs": "Logs",
           "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
         },
-        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again.",
+        "submitMethod": "Send report via",
+        "githubOption": "GitHub issue",
+        "githubDescription": "Best for bug reports without logs.",
+        "emailOption": "Email",
+        "emailDescription": "Send to contact@handy.computer.",
+        "logsEmailOnly": "Reports with logs can only be sent by email. The logs will be included in the email body.",
+        "openEmail": "Open email"
       }
     }
   },

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -600,6 +600,25 @@
       "whatsNewUpdates": {
         "label": "Mostrar novedades",
         "description": "Mostrar notas de la versión después de las actualizaciones de Handy"
+      },
+      "reportBug": {
+        "title": "Report a Bug",
+        "description": "Create a GitHub issue with details about a problem",
+        "button": "Report a Bug",
+        "dialogDescription": "Describe the problem and we will prepare a GitHub issue for you.",
+        "titleLabel": "Title",
+        "titlePlaceholder": "For example: Recording stops unexpectedly",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "What happened? Include steps to reproduce and what you expected instead.",
+        "characterCount": "{{count}} / {{limit}} characters",
+        "includeLogs": "Copy recent logs to clipboard",
+        "logsWarningTitle": "Logs may contain sensitive information",
+        "logsWarning": "Recent logs will be copied to your clipboard, not uploaded automatically. Review them before you paste them into the GitHub issue. They can include file paths, device names, or other information you may not want to share.",
+        "logsInstruction": "The last 100 log lines were copied to your clipboard. Review them, then paste them into the Logs section of the issue if you are comfortable sharing them.",
+        "submit": "Open GitHub issue",
+        "submitting": "Preparing issue...",
+        "failed": "We could not prepare your bug report. {{error}}",
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
       }
     }
   },
@@ -625,7 +644,8 @@
     "open": "Abrir",
     "copy": "Copiar",
     "clear": "Limpiar",
-    "noOptionsFound": "No se encontraron opciones"
+    "noOptionsFound": "No se encontraron opciones",
+    "cancel": "Cancel"
   },
   "accessibility": {
     "permissionsDescription": "Handy necesita permisos de accesibilidad para escribir texto transcrito.",

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -618,7 +618,22 @@
         "submit": "Open GitHub issue",
         "submitting": "Preparing issue...",
         "failed": "We could not prepare your bug report. {{error}}",
-        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs.",
+        "searchPrompt": "Please search",
+        "existingIssuesLink": "existing issues",
+        "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
+        "issueTemplate": {
+          "beforeSubmit": "Before You Submit",
+          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "description": "Bug Description",
+          "systemInformation": "System Information",
+          "appVersion": "App Version",
+          "operatingSystem": "Operating System",
+          "cpu": "CPU",
+          "gpu": "GPU",
+          "unknownVersion": "Unknown Version",
+          "titlePrefix": "Bug"
+        }
       }
     }
   },

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -624,7 +624,7 @@
         "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
         "issueTemplate": {
           "beforeSubmit": "Before You Submit",
-          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "searchExisting": "Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.",
           "description": "Bug Description",
           "systemInformation": "System Information",
           "appVersion": "App Version",
@@ -632,8 +632,16 @@
           "cpu": "CPU",
           "gpu": "GPU",
           "unknownVersion": "Unknown Version",
-          "titlePrefix": "Bug"
-        }
+          "titlePrefix": "Bug",
+          "maintainerNote": "Your bug may already be reported! Right now it's just me maintaining this project so many issues can be overwhelming! Help me out by checking first.",
+          "appVersionHint": "You can find this in the app settings or about section",
+          "operatingSystemHint": "e.g., macOS 14.1, Windows 11, Ubuntu 22.04",
+          "cpuHint": "e.g., Apple M2, Intel i7-12700K, AMD Ryzen 7 5800X",
+          "gpuHint": "e.g., Apple M2 GPU, NVIDIA RTX 4080, AMD RX 6800 XT, Intel UHD Graphics",
+          "logs": "Logs",
+          "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
+        },
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
       }
     }
   },

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -600,6 +600,25 @@
       "whatsNewUpdates": {
         "label": "Afficher les nouveautés",
         "description": "Afficher les notes de version après les mises à jour de Handy"
+      },
+      "reportBug": {
+        "title": "Report a Bug",
+        "description": "Create a GitHub issue with details about a problem",
+        "button": "Report a Bug",
+        "dialogDescription": "Describe the problem and we will prepare a GitHub issue for you.",
+        "titleLabel": "Title",
+        "titlePlaceholder": "For example: Recording stops unexpectedly",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "What happened? Include steps to reproduce and what you expected instead.",
+        "characterCount": "{{count}} / {{limit}} characters",
+        "includeLogs": "Copy recent logs to clipboard",
+        "logsWarningTitle": "Logs may contain sensitive information",
+        "logsWarning": "Recent logs will be copied to your clipboard, not uploaded automatically. Review them before you paste them into the GitHub issue. They can include file paths, device names, or other information you may not want to share.",
+        "logsInstruction": "The last 100 log lines were copied to your clipboard. Review them, then paste them into the Logs section of the issue if you are comfortable sharing them.",
+        "submit": "Open GitHub issue",
+        "submitting": "Preparing issue...",
+        "failed": "We could not prepare your bug report. {{error}}",
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
       }
     }
   },
@@ -625,7 +644,8 @@
     "open": "Ouvrir",
     "copy": "Copier",
     "clear": "Effacer",
-    "noOptionsFound": "Aucune option trouvée"
+    "noOptionsFound": "Aucune option trouvée",
+    "cancel": "Cancel"
   },
   "accessibility": {
     "permissionsDescription": "Handy a besoin des autorisations d'accessibilité pour taper le texte transcrit.",

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -641,7 +641,14 @@
           "logs": "Logs",
           "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
         },
-        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again.",
+        "submitMethod": "Send report via",
+        "githubOption": "GitHub issue",
+        "githubDescription": "Best for bug reports without logs.",
+        "emailOption": "Email",
+        "emailDescription": "Send to contact@handy.computer.",
+        "logsEmailOnly": "Reports with logs can only be sent by email. The logs will be included in the email body.",
+        "openEmail": "Open email"
       }
     }
   },

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -618,7 +618,22 @@
         "submit": "Open GitHub issue",
         "submitting": "Preparing issue...",
         "failed": "We could not prepare your bug report. {{error}}",
-        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs.",
+        "searchPrompt": "Please search",
+        "existingIssuesLink": "existing issues",
+        "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
+        "issueTemplate": {
+          "beforeSubmit": "Before You Submit",
+          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "description": "Bug Description",
+          "systemInformation": "System Information",
+          "appVersion": "App Version",
+          "operatingSystem": "Operating System",
+          "cpu": "CPU",
+          "gpu": "GPU",
+          "unknownVersion": "Unknown Version",
+          "titlePrefix": "Bug"
+        }
       }
     }
   },

--- a/src/i18n/locales/he/translation.json
+++ b/src/i18n/locales/he/translation.json
@@ -624,7 +624,7 @@
         "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
         "issueTemplate": {
           "beforeSubmit": "Before You Submit",
-          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "searchExisting": "Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.",
           "description": "Bug Description",
           "systemInformation": "System Information",
           "appVersion": "App Version",
@@ -632,8 +632,16 @@
           "cpu": "CPU",
           "gpu": "GPU",
           "unknownVersion": "Unknown Version",
-          "titlePrefix": "Bug"
-        }
+          "titlePrefix": "Bug",
+          "maintainerNote": "Your bug may already be reported! Right now it's just me maintaining this project so many issues can be overwhelming! Help me out by checking first.",
+          "appVersionHint": "You can find this in the app settings or about section",
+          "operatingSystemHint": "e.g., macOS 14.1, Windows 11, Ubuntu 22.04",
+          "cpuHint": "e.g., Apple M2, Intel i7-12700K, AMD Ryzen 7 5800X",
+          "gpuHint": "e.g., Apple M2 GPU, NVIDIA RTX 4080, AMD RX 6800 XT, Intel UHD Graphics",
+          "logs": "Logs",
+          "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
+        },
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
       }
     }
   },

--- a/src/i18n/locales/he/translation.json
+++ b/src/i18n/locales/he/translation.json
@@ -600,6 +600,25 @@
       "whatsNewUpdates": {
         "label": "הצג מה חדש",
         "description": "הצג הערות גרסה לאחר עדכוני Handy"
+      },
+      "reportBug": {
+        "title": "Report a Bug",
+        "description": "Create a GitHub issue with details about a problem",
+        "button": "Report a Bug",
+        "dialogDescription": "Describe the problem and we will prepare a GitHub issue for you.",
+        "titleLabel": "Title",
+        "titlePlaceholder": "For example: Recording stops unexpectedly",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "What happened? Include steps to reproduce and what you expected instead.",
+        "characterCount": "{{count}} / {{limit}} characters",
+        "includeLogs": "Copy recent logs to clipboard",
+        "logsWarningTitle": "Logs may contain sensitive information",
+        "logsWarning": "Recent logs will be copied to your clipboard, not uploaded automatically. Review them before you paste them into the GitHub issue. They can include file paths, device names, or other information you may not want to share.",
+        "logsInstruction": "The last 100 log lines were copied to your clipboard. Review them, then paste them into the Logs section of the issue if you are comfortable sharing them.",
+        "submit": "Open GitHub issue",
+        "submitting": "Preparing issue...",
+        "failed": "We could not prepare your bug report. {{error}}",
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
       }
     }
   },
@@ -625,7 +644,8 @@
     "open": "פתח",
     "copy": "העתק",
     "clear": "נקה",
-    "noOptionsFound": "לא נמצאו אפשרויות"
+    "noOptionsFound": "לא נמצאו אפשרויות",
+    "cancel": "Cancel"
   },
   "accessibility": {
     "permissionsDescription": "Handy צריך הרשאות נגישות כדי להקליד את הטקסט המתומלל.",

--- a/src/i18n/locales/he/translation.json
+++ b/src/i18n/locales/he/translation.json
@@ -641,7 +641,14 @@
           "logs": "Logs",
           "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
         },
-        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again.",
+        "submitMethod": "Send report via",
+        "githubOption": "GitHub issue",
+        "githubDescription": "Best for bug reports without logs.",
+        "emailOption": "Email",
+        "emailDescription": "Send to contact@handy.computer.",
+        "logsEmailOnly": "Reports with logs can only be sent by email. The logs will be included in the email body.",
+        "openEmail": "Open email"
       }
     }
   },

--- a/src/i18n/locales/he/translation.json
+++ b/src/i18n/locales/he/translation.json
@@ -618,7 +618,22 @@
         "submit": "Open GitHub issue",
         "submitting": "Preparing issue...",
         "failed": "We could not prepare your bug report. {{error}}",
-        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs.",
+        "searchPrompt": "Please search",
+        "existingIssuesLink": "existing issues",
+        "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
+        "issueTemplate": {
+          "beforeSubmit": "Before You Submit",
+          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "description": "Bug Description",
+          "systemInformation": "System Information",
+          "appVersion": "App Version",
+          "operatingSystem": "Operating System",
+          "cpu": "CPU",
+          "gpu": "GPU",
+          "unknownVersion": "Unknown Version",
+          "titlePrefix": "Bug"
+        }
       }
     }
   },

--- a/src/i18n/locales/hi/translation.json
+++ b/src/i18n/locales/hi/translation.json
@@ -624,7 +624,7 @@
         "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
         "issueTemplate": {
           "beforeSubmit": "Before You Submit",
-          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "searchExisting": "Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.",
           "description": "Bug Description",
           "systemInformation": "System Information",
           "appVersion": "App Version",
@@ -632,8 +632,16 @@
           "cpu": "CPU",
           "gpu": "GPU",
           "unknownVersion": "Unknown Version",
-          "titlePrefix": "Bug"
-        }
+          "titlePrefix": "Bug",
+          "maintainerNote": "Your bug may already be reported! Right now it's just me maintaining this project so many issues can be overwhelming! Help me out by checking first.",
+          "appVersionHint": "You can find this in the app settings or about section",
+          "operatingSystemHint": "e.g., macOS 14.1, Windows 11, Ubuntu 22.04",
+          "cpuHint": "e.g., Apple M2, Intel i7-12700K, AMD Ryzen 7 5800X",
+          "gpuHint": "e.g., Apple M2 GPU, NVIDIA RTX 4080, AMD RX 6800 XT, Intel UHD Graphics",
+          "logs": "Logs",
+          "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
+        },
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
       }
     }
   },

--- a/src/i18n/locales/hi/translation.json
+++ b/src/i18n/locales/hi/translation.json
@@ -641,7 +641,14 @@
           "logs": "Logs",
           "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
         },
-        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again.",
+        "submitMethod": "Send report via",
+        "githubOption": "GitHub issue",
+        "githubDescription": "Best for bug reports without logs.",
+        "emailOption": "Email",
+        "emailDescription": "Send to contact@handy.computer.",
+        "logsEmailOnly": "Reports with logs can only be sent by email. The logs will be included in the email body.",
+        "openEmail": "Open email"
       }
     }
   },

--- a/src/i18n/locales/hi/translation.json
+++ b/src/i18n/locales/hi/translation.json
@@ -618,7 +618,22 @@
         "submit": "Open GitHub issue",
         "submitting": "Preparing issue...",
         "failed": "We could not prepare your bug report. {{error}}",
-        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs.",
+        "searchPrompt": "Please search",
+        "existingIssuesLink": "existing issues",
+        "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
+        "issueTemplate": {
+          "beforeSubmit": "Before You Submit",
+          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "description": "Bug Description",
+          "systemInformation": "System Information",
+          "appVersion": "App Version",
+          "operatingSystem": "Operating System",
+          "cpu": "CPU",
+          "gpu": "GPU",
+          "unknownVersion": "Unknown Version",
+          "titlePrefix": "Bug"
+        }
       }
     }
   },

--- a/src/i18n/locales/hi/translation.json
+++ b/src/i18n/locales/hi/translation.json
@@ -600,6 +600,25 @@
           "description": "डिवाइस पर ही मशीन लर्निंग इन्फ़रेंस के लिए हाई-परफ़ॉर्मेंस टेंसर लाइब्रेरी",
           "details": "Handy का लोकल स्पीच-टू-टेक्स्ट transcribe.cpp और ggml पर आधारित है. Georgi Gerganov और योगदान देने वालों के शानदार काम के लिए धन्यवाद."
         }
+      },
+      "reportBug": {
+        "title": "Report a Bug",
+        "description": "Create a GitHub issue with details about a problem",
+        "button": "Report a Bug",
+        "dialogDescription": "Describe the problem and we will prepare a GitHub issue for you.",
+        "titleLabel": "Title",
+        "titlePlaceholder": "For example: Recording stops unexpectedly",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "What happened? Include steps to reproduce and what you expected instead.",
+        "characterCount": "{{count}} / {{limit}} characters",
+        "includeLogs": "Copy recent logs to clipboard",
+        "logsWarningTitle": "Logs may contain sensitive information",
+        "logsWarning": "Recent logs will be copied to your clipboard, not uploaded automatically. Review them before you paste them into the GitHub issue. They can include file paths, device names, or other information you may not want to share.",
+        "logsInstruction": "The last 100 log lines were copied to your clipboard. Review them, then paste them into the Logs section of the issue if you are comfortable sharing them.",
+        "submit": "Open GitHub issue",
+        "submitting": "Preparing issue...",
+        "failed": "We could not prepare your bug report. {{error}}",
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
       }
     }
   },
@@ -628,7 +647,8 @@
     "open": "खोलें",
     "copy": "कॉपी करें",
     "clear": "मिटाएं",
-    "noOptionsFound": "कोई विकल्प नहीं मिला"
+    "noOptionsFound": "कोई विकल्प नहीं मिला",
+    "cancel": "Cancel"
   },
   "accessibility": {
     "permissionsDescription": "ट्रांसक्राइब किया गया टेक्स्ट टाइप करने के लिए, Handy को ऐक्सेसिबिलिटी अनुमतियों की ज़रूरत है.",

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -624,7 +624,7 @@
         "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
         "issueTemplate": {
           "beforeSubmit": "Before You Submit",
-          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "searchExisting": "Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.",
           "description": "Bug Description",
           "systemInformation": "System Information",
           "appVersion": "App Version",
@@ -632,8 +632,16 @@
           "cpu": "CPU",
           "gpu": "GPU",
           "unknownVersion": "Unknown Version",
-          "titlePrefix": "Bug"
-        }
+          "titlePrefix": "Bug",
+          "maintainerNote": "Your bug may already be reported! Right now it's just me maintaining this project so many issues can be overwhelming! Help me out by checking first.",
+          "appVersionHint": "You can find this in the app settings or about section",
+          "operatingSystemHint": "e.g., macOS 14.1, Windows 11, Ubuntu 22.04",
+          "cpuHint": "e.g., Apple M2, Intel i7-12700K, AMD Ryzen 7 5800X",
+          "gpuHint": "e.g., Apple M2 GPU, NVIDIA RTX 4080, AMD RX 6800 XT, Intel UHD Graphics",
+          "logs": "Logs",
+          "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
+        },
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
       }
     }
   },

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -600,6 +600,25 @@
       "whatsNewUpdates": {
         "label": "Mostra novità",
         "description": "Mostra le note di rilascio dopo gli aggiornamenti di Handy"
+      },
+      "reportBug": {
+        "title": "Report a Bug",
+        "description": "Create a GitHub issue with details about a problem",
+        "button": "Report a Bug",
+        "dialogDescription": "Describe the problem and we will prepare a GitHub issue for you.",
+        "titleLabel": "Title",
+        "titlePlaceholder": "For example: Recording stops unexpectedly",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "What happened? Include steps to reproduce and what you expected instead.",
+        "characterCount": "{{count}} / {{limit}} characters",
+        "includeLogs": "Copy recent logs to clipboard",
+        "logsWarningTitle": "Logs may contain sensitive information",
+        "logsWarning": "Recent logs will be copied to your clipboard, not uploaded automatically. Review them before you paste them into the GitHub issue. They can include file paths, device names, or other information you may not want to share.",
+        "logsInstruction": "The last 100 log lines were copied to your clipboard. Review them, then paste them into the Logs section of the issue if you are comfortable sharing them.",
+        "submit": "Open GitHub issue",
+        "submitting": "Preparing issue...",
+        "failed": "We could not prepare your bug report. {{error}}",
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
       }
     }
   },
@@ -625,7 +644,8 @@
     "open": "Apri",
     "copy": "Copia",
     "clear": "Svuota",
-    "noOptionsFound": "Nessuna opzione trovata"
+    "noOptionsFound": "Nessuna opzione trovata",
+    "cancel": "Cancel"
   },
   "accessibility": {
     "permissionsDescription": "Handy ha bisogno dei permessi di accessibilità per digitare il testo trascritto.",

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -641,7 +641,14 @@
           "logs": "Logs",
           "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
         },
-        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again.",
+        "submitMethod": "Send report via",
+        "githubOption": "GitHub issue",
+        "githubDescription": "Best for bug reports without logs.",
+        "emailOption": "Email",
+        "emailDescription": "Send to contact@handy.computer.",
+        "logsEmailOnly": "Reports with logs can only be sent by email. The logs will be included in the email body.",
+        "openEmail": "Open email"
       }
     }
   },

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -618,7 +618,22 @@
         "submit": "Open GitHub issue",
         "submitting": "Preparing issue...",
         "failed": "We could not prepare your bug report. {{error}}",
-        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs.",
+        "searchPrompt": "Please search",
+        "existingIssuesLink": "existing issues",
+        "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
+        "issueTemplate": {
+          "beforeSubmit": "Before You Submit",
+          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "description": "Bug Description",
+          "systemInformation": "System Information",
+          "appVersion": "App Version",
+          "operatingSystem": "Operating System",
+          "cpu": "CPU",
+          "gpu": "GPU",
+          "unknownVersion": "Unknown Version",
+          "titlePrefix": "Bug"
+        }
       }
     }
   },

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -624,7 +624,7 @@
         "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
         "issueTemplate": {
           "beforeSubmit": "Before You Submit",
-          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "searchExisting": "Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.",
           "description": "Bug Description",
           "systemInformation": "System Information",
           "appVersion": "App Version",
@@ -632,8 +632,16 @@
           "cpu": "CPU",
           "gpu": "GPU",
           "unknownVersion": "Unknown Version",
-          "titlePrefix": "Bug"
-        }
+          "titlePrefix": "Bug",
+          "maintainerNote": "Your bug may already be reported! Right now it's just me maintaining this project so many issues can be overwhelming! Help me out by checking first.",
+          "appVersionHint": "You can find this in the app settings or about section",
+          "operatingSystemHint": "e.g., macOS 14.1, Windows 11, Ubuntu 22.04",
+          "cpuHint": "e.g., Apple M2, Intel i7-12700K, AMD Ryzen 7 5800X",
+          "gpuHint": "e.g., Apple M2 GPU, NVIDIA RTX 4080, AMD RX 6800 XT, Intel UHD Graphics",
+          "logs": "Logs",
+          "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
+        },
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
       }
     }
   },

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -600,6 +600,25 @@
       "whatsNewUpdates": {
         "label": "新機能を表示",
         "description": "Handy のアップデート後にリリースノートを表示"
+      },
+      "reportBug": {
+        "title": "Report a Bug",
+        "description": "Create a GitHub issue with details about a problem",
+        "button": "Report a Bug",
+        "dialogDescription": "Describe the problem and we will prepare a GitHub issue for you.",
+        "titleLabel": "Title",
+        "titlePlaceholder": "For example: Recording stops unexpectedly",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "What happened? Include steps to reproduce and what you expected instead.",
+        "characterCount": "{{count}} / {{limit}} characters",
+        "includeLogs": "Copy recent logs to clipboard",
+        "logsWarningTitle": "Logs may contain sensitive information",
+        "logsWarning": "Recent logs will be copied to your clipboard, not uploaded automatically. Review them before you paste them into the GitHub issue. They can include file paths, device names, or other information you may not want to share.",
+        "logsInstruction": "The last 100 log lines were copied to your clipboard. Review them, then paste them into the Logs section of the issue if you are comfortable sharing them.",
+        "submit": "Open GitHub issue",
+        "submitting": "Preparing issue...",
+        "failed": "We could not prepare your bug report. {{error}}",
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
       }
     }
   },
@@ -625,7 +644,8 @@
     "open": "開く",
     "copy": "コピー",
     "clear": "クリア",
-    "noOptionsFound": "オプションが見つかりません"
+    "noOptionsFound": "オプションが見つかりません",
+    "cancel": "Cancel"
   },
   "accessibility": {
     "permissionsDescription": "Handy が文字起こしテキストを入力するには、アクセシビリティ権限が必要です。",

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -641,7 +641,14 @@
           "logs": "Logs",
           "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
         },
-        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again.",
+        "submitMethod": "Send report via",
+        "githubOption": "GitHub issue",
+        "githubDescription": "Best for bug reports without logs.",
+        "emailOption": "Email",
+        "emailDescription": "Send to contact@handy.computer.",
+        "logsEmailOnly": "Reports with logs can only be sent by email. The logs will be included in the email body.",
+        "openEmail": "Open email"
       }
     }
   },

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -618,7 +618,22 @@
         "submit": "Open GitHub issue",
         "submitting": "Preparing issue...",
         "failed": "We could not prepare your bug report. {{error}}",
-        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs.",
+        "searchPrompt": "Please search",
+        "existingIssuesLink": "existing issues",
+        "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
+        "issueTemplate": {
+          "beforeSubmit": "Before You Submit",
+          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "description": "Bug Description",
+          "systemInformation": "System Information",
+          "appVersion": "App Version",
+          "operatingSystem": "Operating System",
+          "cpu": "CPU",
+          "gpu": "GPU",
+          "unknownVersion": "Unknown Version",
+          "titlePrefix": "Bug"
+        }
       }
     }
   },

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -600,6 +600,25 @@
       "whatsNewUpdates": {
         "label": "새 소식 표시",
         "description": "Handy 업데이트 후 릴리스 노트를 표시합니다"
+      },
+      "reportBug": {
+        "title": "Report a Bug",
+        "description": "Create a GitHub issue with details about a problem",
+        "button": "Report a Bug",
+        "dialogDescription": "Describe the problem and we will prepare a GitHub issue for you.",
+        "titleLabel": "Title",
+        "titlePlaceholder": "For example: Recording stops unexpectedly",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "What happened? Include steps to reproduce and what you expected instead.",
+        "characterCount": "{{count}} / {{limit}} characters",
+        "includeLogs": "Copy recent logs to clipboard",
+        "logsWarningTitle": "Logs may contain sensitive information",
+        "logsWarning": "Recent logs will be copied to your clipboard, not uploaded automatically. Review them before you paste them into the GitHub issue. They can include file paths, device names, or other information you may not want to share.",
+        "logsInstruction": "The last 100 log lines were copied to your clipboard. Review them, then paste them into the Logs section of the issue if you are comfortable sharing them.",
+        "submit": "Open GitHub issue",
+        "submitting": "Preparing issue...",
+        "failed": "We could not prepare your bug report. {{error}}",
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
       }
     }
   },
@@ -625,7 +644,8 @@
     "open": "열기",
     "copy": "복사",
     "clear": "지우기",
-    "noOptionsFound": "옵션을 찾을 수 없습니다"
+    "noOptionsFound": "옵션을 찾을 수 없습니다",
+    "cancel": "Cancel"
   },
   "accessibility": {
     "permissionsDescription": "Handy는 녹음된 텍스트를 입력하기 위해 접근성 권한이 필요합니다.",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -624,7 +624,7 @@
         "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
         "issueTemplate": {
           "beforeSubmit": "Before You Submit",
-          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "searchExisting": "Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.",
           "description": "Bug Description",
           "systemInformation": "System Information",
           "appVersion": "App Version",
@@ -632,8 +632,16 @@
           "cpu": "CPU",
           "gpu": "GPU",
           "unknownVersion": "Unknown Version",
-          "titlePrefix": "Bug"
-        }
+          "titlePrefix": "Bug",
+          "maintainerNote": "Your bug may already be reported! Right now it's just me maintaining this project so many issues can be overwhelming! Help me out by checking first.",
+          "appVersionHint": "You can find this in the app settings or about section",
+          "operatingSystemHint": "e.g., macOS 14.1, Windows 11, Ubuntu 22.04",
+          "cpuHint": "e.g., Apple M2, Intel i7-12700K, AMD Ryzen 7 5800X",
+          "gpuHint": "e.g., Apple M2 GPU, NVIDIA RTX 4080, AMD RX 6800 XT, Intel UHD Graphics",
+          "logs": "Logs",
+          "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
+        },
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
       }
     }
   },

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -641,7 +641,14 @@
           "logs": "Logs",
           "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
         },
-        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again.",
+        "submitMethod": "Send report via",
+        "githubOption": "GitHub issue",
+        "githubDescription": "Best for bug reports without logs.",
+        "emailOption": "Email",
+        "emailDescription": "Send to contact@handy.computer.",
+        "logsEmailOnly": "Reports with logs can only be sent by email. The logs will be included in the email body.",
+        "openEmail": "Open email"
       }
     }
   },

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -618,7 +618,22 @@
         "submit": "Open GitHub issue",
         "submitting": "Preparing issue...",
         "failed": "We could not prepare your bug report. {{error}}",
-        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs.",
+        "searchPrompt": "Please search",
+        "existingIssuesLink": "existing issues",
+        "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
+        "issueTemplate": {
+          "beforeSubmit": "Before You Submit",
+          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "description": "Bug Description",
+          "systemInformation": "System Information",
+          "appVersion": "App Version",
+          "operatingSystem": "Operating System",
+          "cpu": "CPU",
+          "gpu": "GPU",
+          "unknownVersion": "Unknown Version",
+          "titlePrefix": "Bug"
+        }
       }
     }
   },

--- a/src/i18n/locales/ne/translation.json
+++ b/src/i18n/locales/ne/translation.json
@@ -624,7 +624,7 @@
         "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
         "issueTemplate": {
           "beforeSubmit": "Before You Submit",
-          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "searchExisting": "Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.",
           "description": "Bug Description",
           "systemInformation": "System Information",
           "appVersion": "App Version",
@@ -632,8 +632,16 @@
           "cpu": "CPU",
           "gpu": "GPU",
           "unknownVersion": "Unknown Version",
-          "titlePrefix": "Bug"
-        }
+          "titlePrefix": "Bug",
+          "maintainerNote": "Your bug may already be reported! Right now it's just me maintaining this project so many issues can be overwhelming! Help me out by checking first.",
+          "appVersionHint": "You can find this in the app settings or about section",
+          "operatingSystemHint": "e.g., macOS 14.1, Windows 11, Ubuntu 22.04",
+          "cpuHint": "e.g., Apple M2, Intel i7-12700K, AMD Ryzen 7 5800X",
+          "gpuHint": "e.g., Apple M2 GPU, NVIDIA RTX 4080, AMD RX 6800 XT, Intel UHD Graphics",
+          "logs": "Logs",
+          "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
+        },
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
       }
     }
   },

--- a/src/i18n/locales/ne/translation.json
+++ b/src/i18n/locales/ne/translation.json
@@ -641,7 +641,14 @@
           "logs": "Logs",
           "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
         },
-        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again.",
+        "submitMethod": "Send report via",
+        "githubOption": "GitHub issue",
+        "githubDescription": "Best for bug reports without logs.",
+        "emailOption": "Email",
+        "emailDescription": "Send to contact@handy.computer.",
+        "logsEmailOnly": "Reports with logs can only be sent by email. The logs will be included in the email body.",
+        "openEmail": "Open email"
       }
     }
   },

--- a/src/i18n/locales/ne/translation.json
+++ b/src/i18n/locales/ne/translation.json
@@ -600,6 +600,25 @@
           "description": "अन-डिभाइस मेसिन लर्निङ अनुमानका लागि उच्च-प्रदर्शन टेन्सर लाइब्रेरी",
           "details": "Handy को स्थानीय स्पिच-टु-टेक्स्ट transcribe.cpp र ggml मा आधारित छ। Georgi Gerganov र योगदानकर्ताहरूको उत्कृष्ट कामका लागि धन्यवाद।"
         }
+      },
+      "reportBug": {
+        "title": "Report a Bug",
+        "description": "Create a GitHub issue with details about a problem",
+        "button": "Report a Bug",
+        "dialogDescription": "Describe the problem and we will prepare a GitHub issue for you.",
+        "titleLabel": "Title",
+        "titlePlaceholder": "For example: Recording stops unexpectedly",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "What happened? Include steps to reproduce and what you expected instead.",
+        "characterCount": "{{count}} / {{limit}} characters",
+        "includeLogs": "Copy recent logs to clipboard",
+        "logsWarningTitle": "Logs may contain sensitive information",
+        "logsWarning": "Recent logs will be copied to your clipboard, not uploaded automatically. Review them before you paste them into the GitHub issue. They can include file paths, device names, or other information you may not want to share.",
+        "logsInstruction": "The last 100 log lines were copied to your clipboard. Review them, then paste them into the Logs section of the issue if you are comfortable sharing them.",
+        "submit": "Open GitHub issue",
+        "submitting": "Preparing issue...",
+        "failed": "We could not prepare your bug report. {{error}}",
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
       }
     }
   },
@@ -628,7 +647,8 @@
     "open": "खोल्नुहोस्",
     "copy": "कपी गर्नुहोस्",
     "clear": "खाली गर्नुहोस्",
-    "noOptionsFound": "कुनै विकल्प भेटिएन"
+    "noOptionsFound": "कुनै विकल्प भेटिएन",
+    "cancel": "Cancel"
   },
   "accessibility": {
     "permissionsDescription": "ट्रान्सक्राइब गरिएको टेक्स्ट टाइप गर्न Handy लाई एक्सेसिबिलिटी अनुमति चाहिन्छ।",

--- a/src/i18n/locales/ne/translation.json
+++ b/src/i18n/locales/ne/translation.json
@@ -618,7 +618,22 @@
         "submit": "Open GitHub issue",
         "submitting": "Preparing issue...",
         "failed": "We could not prepare your bug report. {{error}}",
-        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs.",
+        "searchPrompt": "Please search",
+        "existingIssuesLink": "existing issues",
+        "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
+        "issueTemplate": {
+          "beforeSubmit": "Before You Submit",
+          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "description": "Bug Description",
+          "systemInformation": "System Information",
+          "appVersion": "App Version",
+          "operatingSystem": "Operating System",
+          "cpu": "CPU",
+          "gpu": "GPU",
+          "unknownVersion": "Unknown Version",
+          "titlePrefix": "Bug"
+        }
       }
     }
   },

--- a/src/i18n/locales/nl/translation.json
+++ b/src/i18n/locales/nl/translation.json
@@ -600,6 +600,25 @@
           "description": "Krachtige tensorbibliotheek voor lokale AI-verwerking",
           "details": "Handy's lokale spraak-naar-tekst is gebouwd op transcribe.cpp en ggml. Met dank aan het geweldige werk van Georgi Gerganov en alle bijdragers."
         }
+      },
+      "reportBug": {
+        "title": "Report a Bug",
+        "description": "Create a GitHub issue with details about a problem",
+        "button": "Report a Bug",
+        "dialogDescription": "Describe the problem and we will prepare a GitHub issue for you.",
+        "titleLabel": "Title",
+        "titlePlaceholder": "For example: Recording stops unexpectedly",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "What happened? Include steps to reproduce and what you expected instead.",
+        "characterCount": "{{count}} / {{limit}} characters",
+        "includeLogs": "Copy recent logs to clipboard",
+        "logsWarningTitle": "Logs may contain sensitive information",
+        "logsWarning": "Recent logs will be copied to your clipboard, not uploaded automatically. Review them before you paste them into the GitHub issue. They can include file paths, device names, or other information you may not want to share.",
+        "logsInstruction": "The last 100 log lines were copied to your clipboard. Review them, then paste them into the Logs section of the issue if you are comfortable sharing them.",
+        "submit": "Open GitHub issue",
+        "submitting": "Preparing issue...",
+        "failed": "We could not prepare your bug report. {{error}}",
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
       }
     }
   },
@@ -628,7 +647,8 @@
     "open": "Openen",
     "copy": "Kopiëren",
     "clear": "Wissen",
-    "noOptionsFound": "Geen opties gevonden"
+    "noOptionsFound": "Geen opties gevonden",
+    "cancel": "Cancel"
   },
   "accessibility": {
     "permissionsDescription": "Handy heeft toegankelijkheidsmachtigingen nodig om getranscribeerde tekst te kunnen typen.",

--- a/src/i18n/locales/nl/translation.json
+++ b/src/i18n/locales/nl/translation.json
@@ -624,7 +624,7 @@
         "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
         "issueTemplate": {
           "beforeSubmit": "Before You Submit",
-          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "searchExisting": "Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.",
           "description": "Bug Description",
           "systemInformation": "System Information",
           "appVersion": "App Version",
@@ -632,8 +632,16 @@
           "cpu": "CPU",
           "gpu": "GPU",
           "unknownVersion": "Unknown Version",
-          "titlePrefix": "Bug"
-        }
+          "titlePrefix": "Bug",
+          "maintainerNote": "Your bug may already be reported! Right now it's just me maintaining this project so many issues can be overwhelming! Help me out by checking first.",
+          "appVersionHint": "You can find this in the app settings or about section",
+          "operatingSystemHint": "e.g., macOS 14.1, Windows 11, Ubuntu 22.04",
+          "cpuHint": "e.g., Apple M2, Intel i7-12700K, AMD Ryzen 7 5800X",
+          "gpuHint": "e.g., Apple M2 GPU, NVIDIA RTX 4080, AMD RX 6800 XT, Intel UHD Graphics",
+          "logs": "Logs",
+          "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
+        },
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
       }
     }
   },

--- a/src/i18n/locales/nl/translation.json
+++ b/src/i18n/locales/nl/translation.json
@@ -641,7 +641,14 @@
           "logs": "Logs",
           "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
         },
-        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again.",
+        "submitMethod": "Send report via",
+        "githubOption": "GitHub issue",
+        "githubDescription": "Best for bug reports without logs.",
+        "emailOption": "Email",
+        "emailDescription": "Send to contact@handy.computer.",
+        "logsEmailOnly": "Reports with logs can only be sent by email. The logs will be included in the email body.",
+        "openEmail": "Open email"
       }
     }
   },

--- a/src/i18n/locales/nl/translation.json
+++ b/src/i18n/locales/nl/translation.json
@@ -618,7 +618,22 @@
         "submit": "Open GitHub issue",
         "submitting": "Preparing issue...",
         "failed": "We could not prepare your bug report. {{error}}",
-        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs.",
+        "searchPrompt": "Please search",
+        "existingIssuesLink": "existing issues",
+        "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
+        "issueTemplate": {
+          "beforeSubmit": "Before You Submit",
+          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "description": "Bug Description",
+          "systemInformation": "System Information",
+          "appVersion": "App Version",
+          "operatingSystem": "Operating System",
+          "cpu": "CPU",
+          "gpu": "GPU",
+          "unknownVersion": "Unknown Version",
+          "titlePrefix": "Bug"
+        }
       }
     }
   },

--- a/src/i18n/locales/pl/translation.json
+++ b/src/i18n/locales/pl/translation.json
@@ -624,7 +624,7 @@
         "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
         "issueTemplate": {
           "beforeSubmit": "Before You Submit",
-          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "searchExisting": "Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.",
           "description": "Bug Description",
           "systemInformation": "System Information",
           "appVersion": "App Version",
@@ -632,8 +632,16 @@
           "cpu": "CPU",
           "gpu": "GPU",
           "unknownVersion": "Unknown Version",
-          "titlePrefix": "Bug"
-        }
+          "titlePrefix": "Bug",
+          "maintainerNote": "Your bug may already be reported! Right now it's just me maintaining this project so many issues can be overwhelming! Help me out by checking first.",
+          "appVersionHint": "You can find this in the app settings or about section",
+          "operatingSystemHint": "e.g., macOS 14.1, Windows 11, Ubuntu 22.04",
+          "cpuHint": "e.g., Apple M2, Intel i7-12700K, AMD Ryzen 7 5800X",
+          "gpuHint": "e.g., Apple M2 GPU, NVIDIA RTX 4080, AMD RX 6800 XT, Intel UHD Graphics",
+          "logs": "Logs",
+          "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
+        },
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
       }
     }
   },

--- a/src/i18n/locales/pl/translation.json
+++ b/src/i18n/locales/pl/translation.json
@@ -641,7 +641,14 @@
           "logs": "Logs",
           "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
         },
-        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again.",
+        "submitMethod": "Send report via",
+        "githubOption": "GitHub issue",
+        "githubDescription": "Best for bug reports without logs.",
+        "emailOption": "Email",
+        "emailDescription": "Send to contact@handy.computer.",
+        "logsEmailOnly": "Reports with logs can only be sent by email. The logs will be included in the email body.",
+        "openEmail": "Open email"
       }
     }
   },

--- a/src/i18n/locales/pl/translation.json
+++ b/src/i18n/locales/pl/translation.json
@@ -618,7 +618,22 @@
         "submit": "Open GitHub issue",
         "submitting": "Preparing issue...",
         "failed": "We could not prepare your bug report. {{error}}",
-        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs.",
+        "searchPrompt": "Please search",
+        "existingIssuesLink": "existing issues",
+        "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
+        "issueTemplate": {
+          "beforeSubmit": "Before You Submit",
+          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "description": "Bug Description",
+          "systemInformation": "System Information",
+          "appVersion": "App Version",
+          "operatingSystem": "Operating System",
+          "cpu": "CPU",
+          "gpu": "GPU",
+          "unknownVersion": "Unknown Version",
+          "titlePrefix": "Bug"
+        }
       }
     }
   },

--- a/src/i18n/locales/pl/translation.json
+++ b/src/i18n/locales/pl/translation.json
@@ -600,6 +600,25 @@
       "whatsNewUpdates": {
         "label": "Pokaż nowości",
         "description": "Pokazuj informacje o wydaniu po aktualizacjach Handy"
+      },
+      "reportBug": {
+        "title": "Report a Bug",
+        "description": "Create a GitHub issue with details about a problem",
+        "button": "Report a Bug",
+        "dialogDescription": "Describe the problem and we will prepare a GitHub issue for you.",
+        "titleLabel": "Title",
+        "titlePlaceholder": "For example: Recording stops unexpectedly",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "What happened? Include steps to reproduce and what you expected instead.",
+        "characterCount": "{{count}} / {{limit}} characters",
+        "includeLogs": "Copy recent logs to clipboard",
+        "logsWarningTitle": "Logs may contain sensitive information",
+        "logsWarning": "Recent logs will be copied to your clipboard, not uploaded automatically. Review them before you paste them into the GitHub issue. They can include file paths, device names, or other information you may not want to share.",
+        "logsInstruction": "The last 100 log lines were copied to your clipboard. Review them, then paste them into the Logs section of the issue if you are comfortable sharing them.",
+        "submit": "Open GitHub issue",
+        "submitting": "Preparing issue...",
+        "failed": "We could not prepare your bug report. {{error}}",
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
       }
     }
   },
@@ -625,7 +644,8 @@
     "open": "Otwórz",
     "copy": "Kopiuj",
     "clear": "Wyczyść",
-    "noOptionsFound": "Nie znaleziono opcji"
+    "noOptionsFound": "Nie znaleziono opcji",
+    "cancel": "Cancel"
   },
   "accessibility": {
     "permissionsDescription": "Handy potrzebuje uprawnień dostępności, aby wpisywać transkrybowany tekst.",

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -600,6 +600,25 @@
       "whatsNewUpdates": {
         "label": "Mostrar novidades",
         "description": "Mostrar notas de versão após atualizações do Handy"
+      },
+      "reportBug": {
+        "title": "Report a Bug",
+        "description": "Create a GitHub issue with details about a problem",
+        "button": "Report a Bug",
+        "dialogDescription": "Describe the problem and we will prepare a GitHub issue for you.",
+        "titleLabel": "Title",
+        "titlePlaceholder": "For example: Recording stops unexpectedly",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "What happened? Include steps to reproduce and what you expected instead.",
+        "characterCount": "{{count}} / {{limit}} characters",
+        "includeLogs": "Copy recent logs to clipboard",
+        "logsWarningTitle": "Logs may contain sensitive information",
+        "logsWarning": "Recent logs will be copied to your clipboard, not uploaded automatically. Review them before you paste them into the GitHub issue. They can include file paths, device names, or other information you may not want to share.",
+        "logsInstruction": "The last 100 log lines were copied to your clipboard. Review them, then paste them into the Logs section of the issue if you are comfortable sharing them.",
+        "submit": "Open GitHub issue",
+        "submitting": "Preparing issue...",
+        "failed": "We could not prepare your bug report. {{error}}",
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
       }
     }
   },
@@ -625,7 +644,8 @@
     "open": "Abrir",
     "copy": "Copiar",
     "clear": "Limpar",
-    "noOptionsFound": "Nenhuma opção encontrada"
+    "noOptionsFound": "Nenhuma opção encontrada",
+    "cancel": "Cancel"
   },
   "accessibility": {
     "permissionsDescription": "O Handy precisa de permissões de acessibilidade para digitar o texto transcrito.",

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -624,7 +624,7 @@
         "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
         "issueTemplate": {
           "beforeSubmit": "Before You Submit",
-          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "searchExisting": "Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.",
           "description": "Bug Description",
           "systemInformation": "System Information",
           "appVersion": "App Version",
@@ -632,8 +632,16 @@
           "cpu": "CPU",
           "gpu": "GPU",
           "unknownVersion": "Unknown Version",
-          "titlePrefix": "Bug"
-        }
+          "titlePrefix": "Bug",
+          "maintainerNote": "Your bug may already be reported! Right now it's just me maintaining this project so many issues can be overwhelming! Help me out by checking first.",
+          "appVersionHint": "You can find this in the app settings or about section",
+          "operatingSystemHint": "e.g., macOS 14.1, Windows 11, Ubuntu 22.04",
+          "cpuHint": "e.g., Apple M2, Intel i7-12700K, AMD Ryzen 7 5800X",
+          "gpuHint": "e.g., Apple M2 GPU, NVIDIA RTX 4080, AMD RX 6800 XT, Intel UHD Graphics",
+          "logs": "Logs",
+          "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
+        },
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
       }
     }
   },

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -641,7 +641,14 @@
           "logs": "Logs",
           "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
         },
-        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again.",
+        "submitMethod": "Send report via",
+        "githubOption": "GitHub issue",
+        "githubDescription": "Best for bug reports without logs.",
+        "emailOption": "Email",
+        "emailDescription": "Send to contact@handy.computer.",
+        "logsEmailOnly": "Reports with logs can only be sent by email. The logs will be included in the email body.",
+        "openEmail": "Open email"
       }
     }
   },

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -618,7 +618,22 @@
         "submit": "Open GitHub issue",
         "submitting": "Preparing issue...",
         "failed": "We could not prepare your bug report. {{error}}",
-        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs.",
+        "searchPrompt": "Please search",
+        "existingIssuesLink": "existing issues",
+        "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
+        "issueTemplate": {
+          "beforeSubmit": "Before You Submit",
+          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "description": "Bug Description",
+          "systemInformation": "System Information",
+          "appVersion": "App Version",
+          "operatingSystem": "Operating System",
+          "cpu": "CPU",
+          "gpu": "GPU",
+          "unknownVersion": "Unknown Version",
+          "titlePrefix": "Bug"
+        }
       }
     }
   },

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -600,6 +600,25 @@
       "whatsNewUpdates": {
         "label": "Показывать новинки",
         "description": "Показывать примечания к выпуску после обновлений Handy"
+      },
+      "reportBug": {
+        "title": "Report a Bug",
+        "description": "Create a GitHub issue with details about a problem",
+        "button": "Report a Bug",
+        "dialogDescription": "Describe the problem and we will prepare a GitHub issue for you.",
+        "titleLabel": "Title",
+        "titlePlaceholder": "For example: Recording stops unexpectedly",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "What happened? Include steps to reproduce and what you expected instead.",
+        "characterCount": "{{count}} / {{limit}} characters",
+        "includeLogs": "Copy recent logs to clipboard",
+        "logsWarningTitle": "Logs may contain sensitive information",
+        "logsWarning": "Recent logs will be copied to your clipboard, not uploaded automatically. Review them before you paste them into the GitHub issue. They can include file paths, device names, or other information you may not want to share.",
+        "logsInstruction": "The last 100 log lines were copied to your clipboard. Review them, then paste them into the Logs section of the issue if you are comfortable sharing them.",
+        "submit": "Open GitHub issue",
+        "submitting": "Preparing issue...",
+        "failed": "We could not prepare your bug report. {{error}}",
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
       }
     }
   },
@@ -625,7 +644,8 @@
     "open": "Открыть",
     "copy": "Копировать",
     "clear": "Очистить",
-    "noOptionsFound": "Вариантов не найдено"
+    "noOptionsFound": "Вариантов не найдено",
+    "cancel": "Cancel"
   },
   "accessibility": {
     "permissionsDescription": "Handy необходимы разрешения на доступ для ввода расшифрованного текста.",

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -624,7 +624,7 @@
         "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
         "issueTemplate": {
           "beforeSubmit": "Before You Submit",
-          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "searchExisting": "Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.",
           "description": "Bug Description",
           "systemInformation": "System Information",
           "appVersion": "App Version",
@@ -632,8 +632,16 @@
           "cpu": "CPU",
           "gpu": "GPU",
           "unknownVersion": "Unknown Version",
-          "titlePrefix": "Bug"
-        }
+          "titlePrefix": "Bug",
+          "maintainerNote": "Your bug may already be reported! Right now it's just me maintaining this project so many issues can be overwhelming! Help me out by checking first.",
+          "appVersionHint": "You can find this in the app settings or about section",
+          "operatingSystemHint": "e.g., macOS 14.1, Windows 11, Ubuntu 22.04",
+          "cpuHint": "e.g., Apple M2, Intel i7-12700K, AMD Ryzen 7 5800X",
+          "gpuHint": "e.g., Apple M2 GPU, NVIDIA RTX 4080, AMD RX 6800 XT, Intel UHD Graphics",
+          "logs": "Logs",
+          "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
+        },
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
       }
     }
   },

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -641,7 +641,14 @@
           "logs": "Logs",
           "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
         },
-        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again.",
+        "submitMethod": "Send report via",
+        "githubOption": "GitHub issue",
+        "githubDescription": "Best for bug reports without logs.",
+        "emailOption": "Email",
+        "emailDescription": "Send to contact@handy.computer.",
+        "logsEmailOnly": "Reports with logs can only be sent by email. The logs will be included in the email body.",
+        "openEmail": "Open email"
       }
     }
   },

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -618,7 +618,22 @@
         "submit": "Open GitHub issue",
         "submitting": "Preparing issue...",
         "failed": "We could not prepare your bug report. {{error}}",
-        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs.",
+        "searchPrompt": "Please search",
+        "existingIssuesLink": "existing issues",
+        "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
+        "issueTemplate": {
+          "beforeSubmit": "Before You Submit",
+          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "description": "Bug Description",
+          "systemInformation": "System Information",
+          "appVersion": "App Version",
+          "operatingSystem": "Operating System",
+          "cpu": "CPU",
+          "gpu": "GPU",
+          "unknownVersion": "Unknown Version",
+          "titlePrefix": "Bug"
+        }
       }
     }
   },

--- a/src/i18n/locales/sv/translation.json
+++ b/src/i18n/locales/sv/translation.json
@@ -624,7 +624,7 @@
         "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
         "issueTemplate": {
           "beforeSubmit": "Before You Submit",
-          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "searchExisting": "Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.",
           "description": "Bug Description",
           "systemInformation": "System Information",
           "appVersion": "App Version",
@@ -632,8 +632,16 @@
           "cpu": "CPU",
           "gpu": "GPU",
           "unknownVersion": "Unknown Version",
-          "titlePrefix": "Bug"
-        }
+          "titlePrefix": "Bug",
+          "maintainerNote": "Your bug may already be reported! Right now it's just me maintaining this project so many issues can be overwhelming! Help me out by checking first.",
+          "appVersionHint": "You can find this in the app settings or about section",
+          "operatingSystemHint": "e.g., macOS 14.1, Windows 11, Ubuntu 22.04",
+          "cpuHint": "e.g., Apple M2, Intel i7-12700K, AMD Ryzen 7 5800X",
+          "gpuHint": "e.g., Apple M2 GPU, NVIDIA RTX 4080, AMD RX 6800 XT, Intel UHD Graphics",
+          "logs": "Logs",
+          "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
+        },
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
       }
     }
   },

--- a/src/i18n/locales/sv/translation.json
+++ b/src/i18n/locales/sv/translation.json
@@ -600,6 +600,25 @@
       "whatsNewUpdates": {
         "label": "Visa nyheter",
         "description": "Visa versionsinformation efter Handy-uppdateringar"
+      },
+      "reportBug": {
+        "title": "Report a Bug",
+        "description": "Create a GitHub issue with details about a problem",
+        "button": "Report a Bug",
+        "dialogDescription": "Describe the problem and we will prepare a GitHub issue for you.",
+        "titleLabel": "Title",
+        "titlePlaceholder": "For example: Recording stops unexpectedly",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "What happened? Include steps to reproduce and what you expected instead.",
+        "characterCount": "{{count}} / {{limit}} characters",
+        "includeLogs": "Copy recent logs to clipboard",
+        "logsWarningTitle": "Logs may contain sensitive information",
+        "logsWarning": "Recent logs will be copied to your clipboard, not uploaded automatically. Review them before you paste them into the GitHub issue. They can include file paths, device names, or other information you may not want to share.",
+        "logsInstruction": "The last 100 log lines were copied to your clipboard. Review them, then paste them into the Logs section of the issue if you are comfortable sharing them.",
+        "submit": "Open GitHub issue",
+        "submitting": "Preparing issue...",
+        "failed": "We could not prepare your bug report. {{error}}",
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
       }
     }
   },
@@ -625,7 +644,8 @@
     "open": "Öppna",
     "copy": "Kopiera",
     "clear": "Rensa",
-    "noOptionsFound": "Inga alternativ hittades"
+    "noOptionsFound": "Inga alternativ hittades",
+    "cancel": "Cancel"
   },
   "accessibility": {
     "permissionsDescription": "Handy behöver behörighet för hjälpmedel för att kunna skriva transkriberad text.",

--- a/src/i18n/locales/sv/translation.json
+++ b/src/i18n/locales/sv/translation.json
@@ -641,7 +641,14 @@
           "logs": "Logs",
           "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
         },
-        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again.",
+        "submitMethod": "Send report via",
+        "githubOption": "GitHub issue",
+        "githubDescription": "Best for bug reports without logs.",
+        "emailOption": "Email",
+        "emailDescription": "Send to contact@handy.computer.",
+        "logsEmailOnly": "Reports with logs can only be sent by email. The logs will be included in the email body.",
+        "openEmail": "Open email"
       }
     }
   },

--- a/src/i18n/locales/sv/translation.json
+++ b/src/i18n/locales/sv/translation.json
@@ -618,7 +618,22 @@
         "submit": "Open GitHub issue",
         "submitting": "Preparing issue...",
         "failed": "We could not prepare your bug report. {{error}}",
-        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs.",
+        "searchPrompt": "Please search",
+        "existingIssuesLink": "existing issues",
+        "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
+        "issueTemplate": {
+          "beforeSubmit": "Before You Submit",
+          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "description": "Bug Description",
+          "systemInformation": "System Information",
+          "appVersion": "App Version",
+          "operatingSystem": "Operating System",
+          "cpu": "CPU",
+          "gpu": "GPU",
+          "unknownVersion": "Unknown Version",
+          "titlePrefix": "Bug"
+        }
       }
     }
   },

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -600,6 +600,25 @@
       "whatsNewUpdates": {
         "label": "Yenilikleri Göster",
         "description": "Handy güncellemelerinden sonra sürüm notlarını göster"
+      },
+      "reportBug": {
+        "title": "Report a Bug",
+        "description": "Create a GitHub issue with details about a problem",
+        "button": "Report a Bug",
+        "dialogDescription": "Describe the problem and we will prepare a GitHub issue for you.",
+        "titleLabel": "Title",
+        "titlePlaceholder": "For example: Recording stops unexpectedly",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "What happened? Include steps to reproduce and what you expected instead.",
+        "characterCount": "{{count}} / {{limit}} characters",
+        "includeLogs": "Copy recent logs to clipboard",
+        "logsWarningTitle": "Logs may contain sensitive information",
+        "logsWarning": "Recent logs will be copied to your clipboard, not uploaded automatically. Review them before you paste them into the GitHub issue. They can include file paths, device names, or other information you may not want to share.",
+        "logsInstruction": "The last 100 log lines were copied to your clipboard. Review them, then paste them into the Logs section of the issue if you are comfortable sharing them.",
+        "submit": "Open GitHub issue",
+        "submitting": "Preparing issue...",
+        "failed": "We could not prepare your bug report. {{error}}",
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
       }
     }
   },
@@ -625,7 +644,8 @@
     "open": "Aç",
     "copy": "Kopyala",
     "clear": "Temizle",
-    "noOptionsFound": "Seçenek bulunamadı"
+    "noOptionsFound": "Seçenek bulunamadı",
+    "cancel": "Cancel"
   },
   "accessibility": {
     "permissionsDescription": "Handy, transkribe edilen metni yazabilmek için erişilebilirlik izinlerine ihtiyaç duyar.",

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -624,7 +624,7 @@
         "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
         "issueTemplate": {
           "beforeSubmit": "Before You Submit",
-          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "searchExisting": "Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.",
           "description": "Bug Description",
           "systemInformation": "System Information",
           "appVersion": "App Version",
@@ -632,8 +632,16 @@
           "cpu": "CPU",
           "gpu": "GPU",
           "unknownVersion": "Unknown Version",
-          "titlePrefix": "Bug"
-        }
+          "titlePrefix": "Bug",
+          "maintainerNote": "Your bug may already be reported! Right now it's just me maintaining this project so many issues can be overwhelming! Help me out by checking first.",
+          "appVersionHint": "You can find this in the app settings or about section",
+          "operatingSystemHint": "e.g., macOS 14.1, Windows 11, Ubuntu 22.04",
+          "cpuHint": "e.g., Apple M2, Intel i7-12700K, AMD Ryzen 7 5800X",
+          "gpuHint": "e.g., Apple M2 GPU, NVIDIA RTX 4080, AMD RX 6800 XT, Intel UHD Graphics",
+          "logs": "Logs",
+          "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
+        },
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
       }
     }
   },

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -641,7 +641,14 @@
           "logs": "Logs",
           "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
         },
-        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again.",
+        "submitMethod": "Send report via",
+        "githubOption": "GitHub issue",
+        "githubDescription": "Best for bug reports without logs.",
+        "emailOption": "Email",
+        "emailDescription": "Send to contact@handy.computer.",
+        "logsEmailOnly": "Reports with logs can only be sent by email. The logs will be included in the email body.",
+        "openEmail": "Open email"
       }
     }
   },

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -618,7 +618,22 @@
         "submit": "Open GitHub issue",
         "submitting": "Preparing issue...",
         "failed": "We could not prepare your bug report. {{error}}",
-        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs.",
+        "searchPrompt": "Please search",
+        "existingIssuesLink": "existing issues",
+        "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
+        "issueTemplate": {
+          "beforeSubmit": "Before You Submit",
+          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "description": "Bug Description",
+          "systemInformation": "System Information",
+          "appVersion": "App Version",
+          "operatingSystem": "Operating System",
+          "cpu": "CPU",
+          "gpu": "GPU",
+          "unknownVersion": "Unknown Version",
+          "titlePrefix": "Bug"
+        }
       }
     }
   },

--- a/src/i18n/locales/uk/translation.json
+++ b/src/i18n/locales/uk/translation.json
@@ -600,6 +600,25 @@
       "whatsNewUpdates": {
         "label": "Показувати новини",
         "description": "Показувати примітки до випуску після оновлень Handy"
+      },
+      "reportBug": {
+        "title": "Report a Bug",
+        "description": "Create a GitHub issue with details about a problem",
+        "button": "Report a Bug",
+        "dialogDescription": "Describe the problem and we will prepare a GitHub issue for you.",
+        "titleLabel": "Title",
+        "titlePlaceholder": "For example: Recording stops unexpectedly",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "What happened? Include steps to reproduce and what you expected instead.",
+        "characterCount": "{{count}} / {{limit}} characters",
+        "includeLogs": "Copy recent logs to clipboard",
+        "logsWarningTitle": "Logs may contain sensitive information",
+        "logsWarning": "Recent logs will be copied to your clipboard, not uploaded automatically. Review them before you paste them into the GitHub issue. They can include file paths, device names, or other information you may not want to share.",
+        "logsInstruction": "The last 100 log lines were copied to your clipboard. Review them, then paste them into the Logs section of the issue if you are comfortable sharing them.",
+        "submit": "Open GitHub issue",
+        "submitting": "Preparing issue...",
+        "failed": "We could not prepare your bug report. {{error}}",
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
       }
     }
   },
@@ -625,7 +644,8 @@
     "open": "Відкрити",
     "copy": "Копіювати",
     "clear": "Очистити",
-    "noOptionsFound": "Опцій не знайдено"
+    "noOptionsFound": "Опцій не знайдено",
+    "cancel": "Cancel"
   },
   "accessibility": {
     "permissionsDescription": "Handy потребує дозволи доступності для введення транскрибованого тексту.",

--- a/src/i18n/locales/uk/translation.json
+++ b/src/i18n/locales/uk/translation.json
@@ -624,7 +624,7 @@
         "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
         "issueTemplate": {
           "beforeSubmit": "Before You Submit",
-          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "searchExisting": "Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.",
           "description": "Bug Description",
           "systemInformation": "System Information",
           "appVersion": "App Version",
@@ -632,8 +632,16 @@
           "cpu": "CPU",
           "gpu": "GPU",
           "unknownVersion": "Unknown Version",
-          "titlePrefix": "Bug"
-        }
+          "titlePrefix": "Bug",
+          "maintainerNote": "Your bug may already be reported! Right now it's just me maintaining this project so many issues can be overwhelming! Help me out by checking first.",
+          "appVersionHint": "You can find this in the app settings or about section",
+          "operatingSystemHint": "e.g., macOS 14.1, Windows 11, Ubuntu 22.04",
+          "cpuHint": "e.g., Apple M2, Intel i7-12700K, AMD Ryzen 7 5800X",
+          "gpuHint": "e.g., Apple M2 GPU, NVIDIA RTX 4080, AMD RX 6800 XT, Intel UHD Graphics",
+          "logs": "Logs",
+          "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
+        },
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
       }
     }
   },

--- a/src/i18n/locales/uk/translation.json
+++ b/src/i18n/locales/uk/translation.json
@@ -641,7 +641,14 @@
           "logs": "Logs",
           "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
         },
-        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again.",
+        "submitMethod": "Send report via",
+        "githubOption": "GitHub issue",
+        "githubDescription": "Best for bug reports without logs.",
+        "emailOption": "Email",
+        "emailDescription": "Send to contact@handy.computer.",
+        "logsEmailOnly": "Reports with logs can only be sent by email. The logs will be included in the email body.",
+        "openEmail": "Open email"
       }
     }
   },

--- a/src/i18n/locales/uk/translation.json
+++ b/src/i18n/locales/uk/translation.json
@@ -618,7 +618,22 @@
         "submit": "Open GitHub issue",
         "submitting": "Preparing issue...",
         "failed": "We could not prepare your bug report. {{error}}",
-        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs.",
+        "searchPrompt": "Please search",
+        "existingIssuesLink": "existing issues",
+        "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
+        "issueTemplate": {
+          "beforeSubmit": "Before You Submit",
+          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "description": "Bug Description",
+          "systemInformation": "System Information",
+          "appVersion": "App Version",
+          "operatingSystem": "Operating System",
+          "cpu": "CPU",
+          "gpu": "GPU",
+          "unknownVersion": "Unknown Version",
+          "titlePrefix": "Bug"
+        }
       }
     }
   },

--- a/src/i18n/locales/vi/translation.json
+++ b/src/i18n/locales/vi/translation.json
@@ -624,7 +624,7 @@
         "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
         "issueTemplate": {
           "beforeSubmit": "Before You Submit",
-          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "searchExisting": "Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.",
           "description": "Bug Description",
           "systemInformation": "System Information",
           "appVersion": "App Version",
@@ -632,8 +632,16 @@
           "cpu": "CPU",
           "gpu": "GPU",
           "unknownVersion": "Unknown Version",
-          "titlePrefix": "Bug"
-        }
+          "titlePrefix": "Bug",
+          "maintainerNote": "Your bug may already be reported! Right now it's just me maintaining this project so many issues can be overwhelming! Help me out by checking first.",
+          "appVersionHint": "You can find this in the app settings or about section",
+          "operatingSystemHint": "e.g., macOS 14.1, Windows 11, Ubuntu 22.04",
+          "cpuHint": "e.g., Apple M2, Intel i7-12700K, AMD Ryzen 7 5800X",
+          "gpuHint": "e.g., Apple M2 GPU, NVIDIA RTX 4080, AMD RX 6800 XT, Intel UHD Graphics",
+          "logs": "Logs",
+          "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
+        },
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
       }
     }
   },

--- a/src/i18n/locales/vi/translation.json
+++ b/src/i18n/locales/vi/translation.json
@@ -641,7 +641,14 @@
           "logs": "Logs",
           "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
         },
-        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again.",
+        "submitMethod": "Send report via",
+        "githubOption": "GitHub issue",
+        "githubDescription": "Best for bug reports without logs.",
+        "emailOption": "Email",
+        "emailDescription": "Send to contact@handy.computer.",
+        "logsEmailOnly": "Reports with logs can only be sent by email. The logs will be included in the email body.",
+        "openEmail": "Open email"
       }
     }
   },

--- a/src/i18n/locales/vi/translation.json
+++ b/src/i18n/locales/vi/translation.json
@@ -600,6 +600,25 @@
       "whatsNewUpdates": {
         "label": "Hiển thị điểm mới",
         "description": "Hiển thị ghi chú phát hành sau khi Handy cập nhật"
+      },
+      "reportBug": {
+        "title": "Report a Bug",
+        "description": "Create a GitHub issue with details about a problem",
+        "button": "Report a Bug",
+        "dialogDescription": "Describe the problem and we will prepare a GitHub issue for you.",
+        "titleLabel": "Title",
+        "titlePlaceholder": "For example: Recording stops unexpectedly",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "What happened? Include steps to reproduce and what you expected instead.",
+        "characterCount": "{{count}} / {{limit}} characters",
+        "includeLogs": "Copy recent logs to clipboard",
+        "logsWarningTitle": "Logs may contain sensitive information",
+        "logsWarning": "Recent logs will be copied to your clipboard, not uploaded automatically. Review them before you paste them into the GitHub issue. They can include file paths, device names, or other information you may not want to share.",
+        "logsInstruction": "The last 100 log lines were copied to your clipboard. Review them, then paste them into the Logs section of the issue if you are comfortable sharing them.",
+        "submit": "Open GitHub issue",
+        "submitting": "Preparing issue...",
+        "failed": "We could not prepare your bug report. {{error}}",
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
       }
     }
   },
@@ -625,7 +644,8 @@
     "open": "Mở",
     "copy": "Sao chép",
     "clear": "Xóa",
-    "noOptionsFound": "Không tìm thấy tùy chọn"
+    "noOptionsFound": "Không tìm thấy tùy chọn",
+    "cancel": "Cancel"
   },
   "accessibility": {
     "permissionsDescription": "Handy cần quyền truy cập để gõ văn bản đã chuyển đổi.",

--- a/src/i18n/locales/vi/translation.json
+++ b/src/i18n/locales/vi/translation.json
@@ -618,7 +618,22 @@
         "submit": "Open GitHub issue",
         "submitting": "Preparing issue...",
         "failed": "We could not prepare your bug report. {{error}}",
-        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs.",
+        "searchPrompt": "Please search",
+        "existingIssuesLink": "existing issues",
+        "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
+        "issueTemplate": {
+          "beforeSubmit": "Before You Submit",
+          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "description": "Bug Description",
+          "systemInformation": "System Information",
+          "appVersion": "App Version",
+          "operatingSystem": "Operating System",
+          "cpu": "CPU",
+          "gpu": "GPU",
+          "unknownVersion": "Unknown Version",
+          "titlePrefix": "Bug"
+        }
       }
     }
   },

--- a/src/i18n/locales/zh-TW/translation.json
+++ b/src/i18n/locales/zh-TW/translation.json
@@ -624,7 +624,7 @@
         "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
         "issueTemplate": {
           "beforeSubmit": "Before You Submit",
-          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "searchExisting": "Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.",
           "description": "Bug Description",
           "systemInformation": "System Information",
           "appVersion": "App Version",
@@ -632,8 +632,16 @@
           "cpu": "CPU",
           "gpu": "GPU",
           "unknownVersion": "Unknown Version",
-          "titlePrefix": "Bug"
-        }
+          "titlePrefix": "Bug",
+          "maintainerNote": "Your bug may already be reported! Right now it's just me maintaining this project so many issues can be overwhelming! Help me out by checking first.",
+          "appVersionHint": "You can find this in the app settings or about section",
+          "operatingSystemHint": "e.g., macOS 14.1, Windows 11, Ubuntu 22.04",
+          "cpuHint": "e.g., Apple M2, Intel i7-12700K, AMD Ryzen 7 5800X",
+          "gpuHint": "e.g., Apple M2 GPU, NVIDIA RTX 4080, AMD RX 6800 XT, Intel UHD Graphics",
+          "logs": "Logs",
+          "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
+        },
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
       }
     }
   },

--- a/src/i18n/locales/zh-TW/translation.json
+++ b/src/i18n/locales/zh-TW/translation.json
@@ -641,7 +641,14 @@
           "logs": "Logs",
           "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
         },
-        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again.",
+        "submitMethod": "Send report via",
+        "githubOption": "GitHub issue",
+        "githubDescription": "Best for bug reports without logs.",
+        "emailOption": "Email",
+        "emailDescription": "Send to contact@handy.computer.",
+        "logsEmailOnly": "Reports with logs can only be sent by email. The logs will be included in the email body.",
+        "openEmail": "Open email"
       }
     }
   },

--- a/src/i18n/locales/zh-TW/translation.json
+++ b/src/i18n/locales/zh-TW/translation.json
@@ -600,6 +600,25 @@
       "whatsNewUpdates": {
         "label": "顯示新功能",
         "description": "Handy 更新後顯示版本資訊"
+      },
+      "reportBug": {
+        "title": "Report a Bug",
+        "description": "Create a GitHub issue with details about a problem",
+        "button": "Report a Bug",
+        "dialogDescription": "Describe the problem and we will prepare a GitHub issue for you.",
+        "titleLabel": "Title",
+        "titlePlaceholder": "For example: Recording stops unexpectedly",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "What happened? Include steps to reproduce and what you expected instead.",
+        "characterCount": "{{count}} / {{limit}} characters",
+        "includeLogs": "Copy recent logs to clipboard",
+        "logsWarningTitle": "Logs may contain sensitive information",
+        "logsWarning": "Recent logs will be copied to your clipboard, not uploaded automatically. Review them before you paste them into the GitHub issue. They can include file paths, device names, or other information you may not want to share.",
+        "logsInstruction": "The last 100 log lines were copied to your clipboard. Review them, then paste them into the Logs section of the issue if you are comfortable sharing them.",
+        "submit": "Open GitHub issue",
+        "submitting": "Preparing issue...",
+        "failed": "We could not prepare your bug report. {{error}}",
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
       }
     }
   },
@@ -625,7 +644,8 @@
     "open": "開啟",
     "copy": "複製",
     "clear": "清除",
-    "noOptionsFound": "未找到選項"
+    "noOptionsFound": "未找到選項",
+    "cancel": "Cancel"
   },
   "accessibility": {
     "permissionsDescription": "Handy 需要輔助使用權限才能輸入轉錄的文字",

--- a/src/i18n/locales/zh-TW/translation.json
+++ b/src/i18n/locales/zh-TW/translation.json
@@ -618,7 +618,22 @@
         "submit": "Open GitHub issue",
         "submitting": "Preparing issue...",
         "failed": "We could not prepare your bug report. {{error}}",
-        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs.",
+        "searchPrompt": "Please search",
+        "existingIssuesLink": "existing issues",
+        "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
+        "issueTemplate": {
+          "beforeSubmit": "Before You Submit",
+          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "description": "Bug Description",
+          "systemInformation": "System Information",
+          "appVersion": "App Version",
+          "operatingSystem": "Operating System",
+          "cpu": "CPU",
+          "gpu": "GPU",
+          "unknownVersion": "Unknown Version",
+          "titlePrefix": "Bug"
+        }
       }
     }
   },

--- a/src/i18n/locales/zh/translation.json
+++ b/src/i18n/locales/zh/translation.json
@@ -600,6 +600,25 @@
       "whatsNewUpdates": {
         "label": "显示新功能",
         "description": "Handy 更新后显示发行说明"
+      },
+      "reportBug": {
+        "title": "Report a Bug",
+        "description": "Create a GitHub issue with details about a problem",
+        "button": "Report a Bug",
+        "dialogDescription": "Describe the problem and we will prepare a GitHub issue for you.",
+        "titleLabel": "Title",
+        "titlePlaceholder": "For example: Recording stops unexpectedly",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "What happened? Include steps to reproduce and what you expected instead.",
+        "characterCount": "{{count}} / {{limit}} characters",
+        "includeLogs": "Copy recent logs to clipboard",
+        "logsWarningTitle": "Logs may contain sensitive information",
+        "logsWarning": "Recent logs will be copied to your clipboard, not uploaded automatically. Review them before you paste them into the GitHub issue. They can include file paths, device names, or other information you may not want to share.",
+        "logsInstruction": "The last 100 log lines were copied to your clipboard. Review them, then paste them into the Logs section of the issue if you are comfortable sharing them.",
+        "submit": "Open GitHub issue",
+        "submitting": "Preparing issue...",
+        "failed": "We could not prepare your bug report. {{error}}",
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
       }
     }
   },
@@ -625,7 +644,8 @@
     "open": "打开",
     "copy": "复制",
     "clear": "清除",
-    "noOptionsFound": "未找到选项"
+    "noOptionsFound": "未找到选项",
+    "cancel": "Cancel"
   },
   "accessibility": {
     "permissionsDescription": "Handy 需要辅助功能权限才能输入转录的文字。",

--- a/src/i18n/locales/zh/translation.json
+++ b/src/i18n/locales/zh/translation.json
@@ -624,7 +624,7 @@
         "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
         "issueTemplate": {
           "beforeSubmit": "Before You Submit",
-          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "searchExisting": "Please search [existing issues](https://github.com/cjpais/Handy/issues) to avoid duplicates.",
           "description": "Bug Description",
           "systemInformation": "System Information",
           "appVersion": "App Version",
@@ -632,8 +632,16 @@
           "cpu": "CPU",
           "gpu": "GPU",
           "unknownVersion": "Unknown Version",
-          "titlePrefix": "Bug"
-        }
+          "titlePrefix": "Bug",
+          "maintainerNote": "Your bug may already be reported! Right now it's just me maintaining this project so many issues can be overwhelming! Help me out by checking first.",
+          "appVersionHint": "You can find this in the app settings or about section",
+          "operatingSystemHint": "e.g., macOS 14.1, Windows 11, Ubuntu 22.04",
+          "cpuHint": "e.g., Apple M2, Intel i7-12700K, AMD Ryzen 7 5800X",
+          "gpuHint": "e.g., Apple M2 GPU, NVIDIA RTX 4080, AMD RX 6800 XT, Intel UHD Graphics",
+          "logs": "Logs",
+          "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
+        },
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
       }
     }
   },

--- a/src/i18n/locales/zh/translation.json
+++ b/src/i18n/locales/zh/translation.json
@@ -641,7 +641,14 @@
           "logs": "Logs",
           "logsHint": "Please attach relevant logs to help us diagnose the issue. You can find the log directory by going to Settings > About in the app."
         },
-        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again."
+        "noLogsAvailable": "No logs are available yet. Try reproducing the issue, then report it again.",
+        "submitMethod": "Send report via",
+        "githubOption": "GitHub issue",
+        "githubDescription": "Best for bug reports without logs.",
+        "emailOption": "Email",
+        "emailDescription": "Send to contact@handy.computer.",
+        "logsEmailOnly": "Reports with logs can only be sent by email. The logs will be included in the email body.",
+        "openEmail": "Open email"
       }
     }
   },

--- a/src/i18n/locales/zh/translation.json
+++ b/src/i18n/locales/zh/translation.json
@@ -618,7 +618,22 @@
         "submit": "Open GitHub issue",
         "submitting": "Preparing issue...",
         "failed": "We could not prepare your bug report. {{error}}",
-        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs."
+        "logsFailed": "We could not copy the logs to your clipboard. You can try again or continue without logs.",
+        "searchPrompt": "Please search",
+        "existingIssuesLink": "existing issues",
+        "searchPromptSuffix": "to avoid duplicates. Your bug may already be reported!",
+        "issueTemplate": {
+          "beforeSubmit": "Before You Submit",
+          "searchExisting": "Please search existing issues to avoid duplicates.",
+          "description": "Bug Description",
+          "systemInformation": "System Information",
+          "appVersion": "App Version",
+          "operatingSystem": "Operating System",
+          "cpu": "CPU",
+          "gpu": "GPU",
+          "unknownVersion": "Unknown Version",
+          "titlePrefix": "Bug"
+        }
       }
     }
   },


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

It uses the Handy bug report template from GitHub. It automatically injects the system info into the template, and there is a checkbox to attach logs. Currently, it generates and opens a link to GitHub in the browser with everything filled in, so the user only has to submit it. The flow can later be changed to use a backend and eliminate the need to open Github at all. This will be a good start.

Code quality is failing because languages are missing.

## Related Issues/Discussions

Fixes #
Discussion: #1744

## Community Feedback

Requested via discussion #1744, @cjpais agreed.

## Testing

It builds and works. It only has some issues, the url is too long when attaching the logs so this has to be manualy pasted form the clipboard by the user. also minor ui issus link padding and spacing.

## Screenshots/Videos (if applicable)

<img width="849" height="752" alt="image" src="https://github.com/user-attachments/assets/c656dd47-3924-4953-b665-658ccf8de8ad" />
<img width="848" height="748" alt="image" src="https://github.com/user-attachments/assets/0cf905f3-d178-4cab-919c-eeea66ba7145" />


## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: opencode
- How extensively: generate the base
