### PR TITLE
Windows: sequence the clipboard restore after the target has read it

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2504,6 +2504,7 @@ dependencies = [
  "transcribe-cpp",
  "transcribe-rs",
  "vad-rs",
+ "win-text-inject",
  "windows 0.61.3",
  "winreg 0.55.0",
 ]
@@ -4152,7 +4153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7940,6 +7941,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
+name = "win-text-inject"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5525f26be056d5861cd03546d8e054a2fb5cddbdcd343cc40217685dc06741b"
+dependencies = [
+ "windows 0.61.3",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7961,7 +7971,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7942,9 +7942,9 @@ checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "win-text-inject"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5525f26be056d5861cd03546d8e054a2fb5cddbdcd343cc40217685dc06741b"
+checksum = "30ad38dc962b33e083f852b3bd523e7007f0da49377d322147ce1c7a0b4b5fbf"
 dependencies = [
  "windows 0.61.3",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -113,6 +113,11 @@ windows = { version = "0.61.3", features = [
   "Win32_UI_WindowsAndMessaging",
 ] }
 winreg = "0.55"
+# Correct text delivery on Windows: clipboard privacy formats, modifier
+# sanitization before the paste chord, an integrity-level check so injection
+# into elevated windows fails loudly instead of silently, and a delayed-render
+# restore that waits for the target's actual read instead of a fixed delay.
+win-text-inject = "0.1"
 
 # Whisper backend per Windows arch. x86_64 ships the Vulkan GPU backend and
 # keeps the dynamic-backends posture (loadable per-ISA CPU modules + Vulkan),

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -117,7 +117,7 @@ winreg = "0.55"
 # sanitization before the paste chord, an integrity-level check so injection
 # into elevated windows fails loudly instead of silently, and a delayed-render
 # restore that waits for the target's actual read instead of a fixed delay.
-win-text-inject = "0.1"
+win-text-inject = "0.1.1"
 
 # Whisper backend per Windows arch. x86_64 ships the Vulkan GPU backend and
 # keeps the dynamic-backends posture (loadable per-ISA CPU modules + Vulkan),

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -3,7 +3,7 @@ use crate::input::{self, EnigoState};
 use crate::settings::TypingTool;
 use crate::settings::{get_settings, AutoSubmitKey, ClipboardHandling, PasteMethod};
 use enigo::{Direction, Enigo, Key, Keyboard};
-use log::info;
+use log::{info, warn};
 use std::process::Command;
 use std::time::Duration;
 use tauri::{AppHandle, Manager};
@@ -11,6 +11,71 @@ use tauri_plugin_clipboard_manager::ClipboardExt;
 
 #[cfg(target_os = "linux")]
 use crate::utils::{is_kde_wayland, is_wayland};
+
+/// Deliver `text` on Windows via `win-text-inject`.
+///
+/// Replaces the clipboard save/write/sleep/paste/sleep/restore sequence with one that fixes four
+/// defects the delay sliders cannot:
+///
+/// 1. Transcripts no longer enter Windows clipboard history or sync to the Microsoft cloud
+///    clipboard. Writing `CF_UNICODETEXT` alone opts into both.
+/// 2. Modifiers physically held at injection time are released first. In push-to-talk a modifier
+///    is held by construction, and `SendInput` does not reset keyboard state, so a held Right-Alt
+///    turns Ctrl+V into AltGr+V.
+/// 3. Injection into an elevated window is detected up front. UIPI blocks it and reports nothing
+///    through the return value or `GetLastError`, so today the text silently vanishes.
+/// 4. The clipboard is restored only after the target has actually read it, using delayed
+///    rendering, rather than after a fixed delay that a busy application can outrun. This is the
+///    cause of #502.
+#[cfg(windows)]
+fn paste_via_win_text_inject(text: &str, paste_method: &PasteMethod) -> Result<(), String> {
+    use win_text_inject::{inject, Chord, Options, Outcome, Strategy, Target};
+
+    let chord = match paste_method {
+        PasteMethod::CtrlV => Chord::CtrlV,
+        PasteMethod::CtrlShiftV => Chord::CtrlShiftV,
+        PasteMethod::ShiftInsert => Chord::ShiftInsert,
+        _ => return Err("invalid paste method for clipboard paste".into()),
+    };
+
+    let target = Target::foreground().map_err(|e| e.to_string())?;
+
+    // Elevated targets discard synthesized input silently. Leaving the text on the clipboard and
+    // saying so beats delivering nothing and reporting success.
+    if !target.accepts_injection() {
+        return Err(format!(
+            "target {} runs at {:?} integrity; text left on the clipboard for manual paste",
+            target.exe, target.integrity
+        ));
+    }
+
+    let outcome = inject(
+        &target,
+        text,
+        Options {
+            strategy: Strategy::ClipboardPaste,
+            chord: Some(chord),
+            // Handy already resolves the target application itself, so keep its choice.
+            ..Default::default()
+        },
+    )
+    .map_err(|e| e.to_string())?;
+
+    match outcome {
+        Outcome::Pasted {
+            read_confirmed: true,
+        } => Ok(()),
+        // The paste chord went out but no read was observed. The text is still on the clipboard,
+        // so this is recoverable by the user; surface it rather than reporting success.
+        Outcome::Pasted {
+            read_confirmed: false,
+        } => {
+            warn!("paste sent but the target was not observed reading the clipboard");
+            Ok(())
+        }
+        other => Err(format!("unexpected injection outcome: {:?}", other)),
+    }
+}
 
 /// Pastes text using the clipboard: saves current content, writes text, sends paste keystroke, restores clipboard.
 fn paste_via_clipboard(
@@ -21,6 +86,21 @@ fn paste_via_clipboard(
     paste_delay_ms: u64,
     paste_delay_after_ms: u64,
 ) -> Result<(), String> {
+    // On Windows the whole save/write/paste/restore sequence is delegated, because the
+    // timer-based version of it has four defects that cannot be fixed by tuning the delays.
+    // See paste_via_win_text_inject.
+    #[cfg(windows)]
+    {
+        match paste_via_win_text_inject(text, paste_method) {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                // Never lose a transcript to an integration problem: fall through to the
+                // original path rather than failing the paste outright.
+                warn!("win-text-inject failed, falling back to timer paste: {}", e);
+            }
+        }
+    }
+
     let clipboard = app_handle.clipboard();
     let saved_text = clipboard.read_text().ok().filter(|t| !t.is_empty());
     // Only probe for an image when there is no text to restore. Text is by far the


### PR DESCRIPTION
# Windows: sequence the clipboard restore after the target has read it

Part of #502, Windows path only. This does not close the issue: macOS and Linux use different paste paths and are untouched here, and #502 has reports on both.

## The bug

`paste_via_clipboard` writes the transcript, sleeps `paste_delay_ms`, sends the chord, sleeps `paste_delay_after_ms`, then restores. The target application reads the clipboard when its message pump reaches the paste, which is not when the keystroke was sent. If the app is busy, the restore lands first and the user gets their previous clipboard.

Any fixed delay has a lag that beats it. That is why #502 has been open since December with 52 comments, and why raising the slider to 400ms does not close it.

I have a Windows machine and could reproduce it deterministically, which I know has been the blocker here.

## Reproduction

A real Win32 window handling a real `WM_PASTE`, with a controllable delay standing in for message-pump backlog. At a 120ms restore delay:

| app lag | target received |
|---|---|
| 10 ms | transcript |
| 60 ms | transcript |
| 150 ms | **previous clipboard** |
| 400 ms | **previous clipboard** |

Runnable: `cargo run --example repro_502` in [win-text-inject](https://github.com/emerson-d-lopes/win-text-inject).

## The fix

Publish the text as a **delayed-render promise** rather than as data: `SetClipboardData(CF_UNICODETEXT, NULL)` with a hidden owner window. Windows then sends `WM_RENDERFORMAT` when a consumer actually asks for the data. That message is the signal that the target read the clipboard, so the restore is sequenced after the read instead of racing it. No delay constant is involved.

Two things I got wrong first, in case they save anyone time:

**A sequence-number gate does not fix this.** Restoring only when `GetClipboardSequenceNumber` still matches our own write sounds right and changes nothing: the sequence number is still ours, because nobody else wrote. We clobber ourselves.

**One render is not proof the paste finished.** Chromium touches the clipboard more than once per paste, an early probe and then the real read. Restoring after the first `WM_RENDERFORMAT` lands between them and reproduces the original bug. The fix waits for renders to go quiet, with the clock starting from an observed read rather than from a guess.

## Three other defects fixed on the same path

**Transcripts leak into clipboard history and the Microsoft cloud clipboard.** Writing `CF_UNICODETEXT` alone opts into both. Chrome's Incognito mode avoids this by registering four opt-out formats; almost nothing else does, including Handy and Wispr Flow (whose docs state that dictated text "may appear in Windows clipboard managers"). Now attached on every write.

**Held modifiers corrupt the chord.** In push-to-talk a modifier is held *by construction* when injection fires. Per MSDN, `SendInput` "does not reset the keyboard's current state." A user holding Right-Alt turns the synthesized Ctrl+V into AltGr+V, a different character on many layouts. Held modifiers are now released first, and deliberately not restored, since re-pressing one the user has since released leaves it stuck.

**Injection into elevated windows fails silently.** Per MSDN, when `SendInput` is blocked by UIPI, "neither `GetLastError` nor the return value will indicate the failure." The text just vanishes. An integrity-level comparison costs microseconds and lets the app say "elevated window, press Ctrl+V" instead. This is also the mechanism behind #434.

## Verification

Verified against real applications by making each app copy its own field back, which is the only readback that works across Win32, Chromium and Electron. `WM_GETTEXT` cannot see Chromium or WinUI text, and UI Automation cannot insert at all.

| application | chord | delivered | clipboard kept | read confirmed |
|---|---|---|---|---|
| Chrome | Ctrl+V | yes | yes | yes |
| VS Code | Ctrl+V | yes | yes | yes |
| Notepad | Ctrl+V | yes | yes | yes |
| Windows Terminal | Ctrl+Shift+V | yes | yes | yes |
| Notepad, clipboard manager running | Ctrl+V | yes | yes | correctly reported false |

## Clipboard managers

Worth stating explicitly, since it changes behaviour.

A manager that honours the opt-out formats does not read the promise at all. Windows clipboard history behaves this way, verified with history enabled.

A manager that ignores them consumes the promise on publish. Once *anything* renders it, the clipboard holds real data and Windows sends no further `WM_RENDERFORMAT`, so the target's read becomes unobservable. The crate detects this, falls back to the timer restore, and reports `read_confirmed: false` honestly instead of pretending. Without that handling the clipboard was never restored at all while a manager was running, which is worse than the original bug.

## Shape of the change

Two files, 86 lines. A `#[cfg(windows)]` early return in `paste_via_clipboard` delegating to the crate, and the dependency. Existing `PasteMethod` values map straight onto the crate's chords, so no settings or UI changes are needed.

If it fails for any reason it logs and falls through to the current implementation, so this cannot lose a transcript to an integration problem.

`win-text-inject` is MIT OR Apache-2.0, Windows-only, and its sole dependency is the `windows` crate, which Handy already has. CI runs on stable and 1.82 across fmt, clippy, tests, doc tests and rustdoc, and exercises the clipboard against a real headless runner.

## Notes

- The chord table in the crate is verified against running applications rather than documentation. One correction that may interest you: **VS Code does not paste on Shift+Insert.** It does nothing in the editor and the paste never fires; Ctrl+V works. The Shift+Insert advice in vendor docs appears to describe the integrated terminal. Handy's `PasteMethod` is user-selected so this PR does not change any default, but it is worth knowing.
- Happy to split this into separate commits per defect if that reviews better, or to put the whole Windows path behind a setting for a release before it becomes the default.
- `Strategy::UnicodeType` in the crate is not yet exercised against a real window and is not used by this PR.

