### PR TITLE
fix: add moss to KNOWN_ARCHES to unbreak catalog test (follow-up to e8c73ba7)

### DIFF
--- a/src-tauri/src/managers/model_capabilities.rs
+++ b/src-tauri/src/managers/model_capabilities.rs
@@ -46,6 +46,7 @@ pub const KNOWN_ARCHES: &[&str] = &[
     "granite_speech_nar",
     "funasr_nano",
     "medasr",
+    "moss",
 ];
 
 // GGUF metadata keys transcribe-cpp writes for ASR models.


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

(Not applicable — this is a bug fix for broken CI on `main`, not a previously closed/rejected change.)

## Human Written Description

This is a follow-up to commit e8c73ba7 ("update catalog"): that commit added a `moss`-architecture model to the catalog but forgot to register `moss` in `KNOWN_ARCHES`, which broke the `test` CI workflow on the main branch. I verified that `moss` is a real architecture in transcribe.cpp (`src/arch/moss`), so it belongs in the list.

## Related Issues/Discussions

<!-- Link to related issues, discussions, or previous PRs -->
<!-- If reopening something previously closed, explain why this should be reconsidered -->

Fixes #

No issue was filed — the breakage is directly visible in CI on `main`:

- Commit [`e8c73ba7`](https://github.com/cjpais/Handy/commit/e8c73ba7) ("update catalog", pushed directly to `main`, no PR) added the `handy-computer/moss-transcribe-diarize-gguf` model with `"architecture": "moss"` to `src-tauri/src/catalog/catalog.json`, but `"moss"` was never added to `KNOWN_ARCHES` in `src-tauri/src/managers/model_capabilities.rs`.
- Since that commit, `catalog::tests::catalog_architectures_are_known_to_capability_probe` fails with `catalog architecture(s) missing from KNOWN_ARCHES: {"moss"}`.
- The `test` workflow has failed on **every** `main` commit since, starting with the breaking commit itself:
  - [e8c73ba7 — fail](https://github.com/cjpais/Handy/actions/runs/29830511352)
  - [e1152d86 — fail](https://github.com/cjpais/Handy/actions/runs/29901799558)
  - [8a362e9e — fail](https://github.com/cjpais/Handy/actions/runs/29906410771)
  - [390729a8 — fail](https://github.com/cjpais/Handy/actions/runs/30009329310)
- It also breaks unrelated PRs, e.g. [#1773](https://github.com/cjpais/Handy/pull/1773) (changes only `commands/models.rs` and `managers/model.rs`) — its `rust-tests` job [fails identically](https://github.com/cjpais/Handy/actions/runs/29998189178/job/89176778670).

Discussion:

## Community Feedback

<!--
PRs with community support are much more likely to be merged.

For features: Link to a discussion where community members have expressed interest.
For bug fixes: Link to the issue where others have confirmed the bug.
-->

No discussion/issue — this is a mechanical fix for CI that is red on `main` itself (see the run links above; every `main` run since `e8c73ba7` fails on this test, and the last green run was the commit right before it). The `moss` architecture genuinely exists in transcribe.cpp ([`src/arch/moss`](https://github.com/handy-computer/transcribe.cpp/tree/main/src/arch/moss), `.name = "moss"`), which is exactly what `KNOWN_ARCHES` is documented to mirror.

## Testing

<!-- Describe how you tested your changes and if you need help getting additional testing -->

On a branch cut from fresh `origin/main` (inside `nix develop`, Linux):

1. **Before the fix** — reproduced the failure:
   `cargo test catalog` → `catalog::tests::catalog_architectures_are_known_to_capability_probe ... FAILED` with `catalog architecture(s) missing from KNOWN_ARCHES: {"moss"}`
2. **After the fix**:
   - `cargo test catalog` → 4 passed, 0 failed
   - `cargo test --lib` → 128 passed, 0 failed
   - `cargo fmt --check` → clean

The change is a single line: `"moss"` appended to `KNOWN_ARCHES` in `src-tauri/src/managers/model_capabilities.rs`, in the position matching its order of addition to transcribe.cpp (after `medasr`).

## Screenshots/Videos (if applicable)

<!-- Add screenshots or videos demonstrating the change -->

N/A — one-line change to a string constant; behavior is covered by the test output above.

## AI Assistance

<!-- AI-assisted PRs are welcome! Just let us know so we can review appropriately. -->

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Kimi Code CLI
- How extensively: AI investigated the root cause (identified the breaking commit `e8c73ba7`, confirmed no associated PR, verified the `moss` architecture exists in `handy-computer/transcribe.cpp`), applied the one-line fix, and ran the local test suite. The commit message and this PR description were drafted by AI and reviewed/approved by a human.
