### PR TITLE
fix: enable window maximize and Aero Snap support on Windows

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -874,7 +874,7 @@ pub fn run(cli_args: CliArgs) {
                     .inner_size(680.0, 570.0)
                     .min_inner_size(680.0, 570.0)
                     .resizable(true)
-                    .maximizable(false)
+                    .maximizable(true)
                     .visible(false);
 
             if let Some(data_dir) = portable::data_dir() {


### PR DESCRIPTION
## Human Written Description

When using Handy on Windows, I like to have the window maximized to see all settings without scrolling. I also use Windows Aero Snap to organize my windows. I noticed Handy had maximizing disabled, so I enabled it. It's a small change but it significantly improves the Windows experience.

## Related Issues/Discussions

No related issues or discussions found.

## Community Feedback

Small UX fix — 1 line change. No community feedback was gathered.

## Testing

- Changed `.maximizable(false)` to `.maximizable(true)` in `src-tauri/src/lib.rs`
- Compiled and ran with `bun run tauri dev`
- Verified: maximize button appears, double-click title bar maximizes, Aero Snap works (drag to edges/corners)
- Verified: window still respects minimum size (680×570)

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**
- Tools used: opencode (AI coding assistant)
- How extensively: AI suggested the fix, user reviewed and approved
