### PR TITLE
feat: add debug mode toggle to experimental settings

### DIFF
--- a/src/components/settings/advanced/AdvancedSettings.tsx
+++ b/src/components/settings/advanced/AdvancedSettings.tsx
@@ -21,6 +21,7 @@ import { KeyboardImplementationSelector } from "../debug/KeyboardImplementationS
 import { VoiceActivityDetection } from "../VoiceActivityDetection";
 import { AccelerationSelector } from "../AccelerationSelector";
 import { LazyStreamClose } from "../LazyStreamClose";
+import { DebugModeToggle } from "./DebugModeToggle";
 
 export const AdvancedSettings: React.FC = () => {
   const { t } = useTranslation();
@@ -68,6 +69,7 @@ export const AdvancedSettings: React.FC = () => {
           />
           <AccelerationSelector descriptionMode="tooltip" grouped={true} />
           <LazyStreamClose descriptionMode="tooltip" grouped={true} />
+          <DebugModeToggle descriptionMode="tooltip" grouped={true} />
         </SettingsGroup>
       )}
     </div>

--- a/src/components/settings/advanced/DebugModeToggle.tsx
+++ b/src/components/settings/advanced/DebugModeToggle.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { ToggleSwitch } from "../../ui/ToggleSwitch";
+import { useSettings } from "../../../hooks/useSettings";
+
+interface DebugModeToggleProps {
+  descriptionMode?: "inline" | "tooltip";
+  grouped?: boolean;
+}
+
+export const DebugModeToggle: React.FC<DebugModeToggleProps> = React.memo(
+  ({ descriptionMode = "tooltip", grouped = false }) => {
+    const { t } = useTranslation();
+    const { getSetting, updateSetting, isUpdating } = useSettings();
+
+    const enabled = getSetting("debug_mode") ?? false;
+
+    return (
+      <ToggleSwitch
+        checked={enabled}
+        onChange={(enabled) => updateSetting("debug_mode", enabled)}
+        isUpdating={isUpdating("debug_mode")}
+        label={t("settings.advanced.debugMode.label")}
+        description={t("settings.advanced.debugMode.description")}
+        descriptionMode={descriptionMode}
+        grouped={grouped}
+      />
+    );
+  },
+);

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -255,6 +255,10 @@
         "label": "Keep Mic Open Between Transcriptions",
         "description": "Keeps the microphone stream open for 30 seconds after recording stops, reducing latency for back-to-back transcriptions. May degrade Bluetooth audio quality while active."
       },
+      "debugMode": {
+        "label": "Debug Mode",
+        "description": "Enable debug features like the Debug panel, advanced logging, and experimental settings."
+      },
       "acceleration": {
         "transcribe": {
           "title": "transcribe.cpp Acceleration",

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -255,6 +255,10 @@
         "label": "Mantener micrófono abierto entre transcripciones",
         "description": "Mantiene el flujo del micrófono abierto durante 30 segundos después de detener la grabación, reduciendo la latencia en transcripciones consecutivas. Puede degradar la calidad del audio Bluetooth mientras está activo."
       },
+      "debugMode": {
+        "label": "Modo Depuración",
+        "description": "Activa funciones de depuración como el panel Debug, registro avanzado y opciones experimentales."
+      },
       "acceleration": {
         "transcribe": {
           "title": "Aceleración de transcribe.cpp",


### PR DESCRIPTION
## Human Written Description

Until now, the only way to enable Debug Mode was the Ctrl+Shift+D keyboard shortcut. While convenient for those who know it, new users may not even know the Debug panel exists. I added a toggle in Advanced > Experimental to enable/disable debug mode from the UI, just like the shortcut does. This makes it easier for advanced users to discover and use the debugging features.

## Related Issues/Discussions

Related to discussion #454 where the maintainer (cjpais) mentioned considering a "power-user toggle" for making debug and experimental features more accessible.

## Community Feedback

Small UX improvement. No community feedback was gathered.

## Testing

- Added `DebugModeToggle` component that controls `debug_mode` setting via `updateSetting("debug_mode", enabled)`
- When toggled on, sidebar shows Debug section (same behavior as Ctrl+Shift+D)
- Toggle is placed inside Advanced → Experimental (requires experimental_enabled = true)
- Works consistently with keyboard shortcut — either method toggles the same setting
- Tested toggle on/off, verified sidebar updates correctly
- TypeScript and lint pass without errors

## Screenshots/Videos

**Before:**
<img width="883" height="760" alt="debug-original" src="https://github.com/user-attachments/assets/cf2d4e31-e182-4d0b-93a5-da8fbcee55ad" />

**After:** 
<img width="895" height="760" alt="debug-modificado" src="https://github.com/user-attachments/assets/37f7027a-3ef7-457d-9a5d-25e50ff1ce56" />

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**
- Tools used: opencode (AI coding assistant)
- How extensively: AI implemented the feature, user reviewed and approved
