### PR TITLE
fix(i18n): complete zh-TW translations for newer UI strings

### DIFF
--- a/src/i18n/locales/zh-TW/translation.json
+++ b/src/i18n/locales/zh-TW/translation.json
@@ -19,10 +19,10 @@
   },
   "onboarding": {
     "subtitle": "首先，請選擇一種模型",
-    "existingModelsTitle": "Compatible Models",
-    "downloadModelsTitle": "Available to Download",
-    "showAllModels": "Show all {{total}} models",
-    "showFewerModels": "Show fewer models",
+    "existingModelsTitle": "相容的模型",
+    "downloadModelsTitle": "可供下載",
+    "showAllModels": "顯示全部 {{total}} 個模型",
+    "showFewerModels": "顯示較少模型",
     "recommended": "推薦",
     "customModelDescription": "官方不支援",
     "modelCard": {
@@ -96,7 +96,7 @@
       }
     },
     "errors": {
-      "selectModel": "Failed to select model"
+      "selectModel": "選擇模型失敗"
     },
     "permissions": {
       "title": "需要權限",
@@ -145,7 +145,7 @@
     "capabilities": {
       "languageSelection": "支援多種輸入語言",
       "singleLanguage": "僅支援此語言",
-      "languageCount": "{{total}} languages",
+      "languageCount": "{{total}} 種語言",
       "languageOnly": "僅 {{language}}",
       "translation": "可翻譯為英語",
       "translate": "翻譯為英語",
@@ -188,7 +188,7 @@
       },
       "language": {
         "title": "語言",
-        "description": "選擇語音識別的語言。選擇自動將自動判定語言，選擇特定語言可以提高該語言的準確度",
+        "description": "選擇語音辨識的語言。選擇自動將自動判定語言，選擇特定語言可以提高該語言的準確度",
         "searchPlaceholder": "搜尋語言...",
         "noResults": "未找到語言",
         "auto": "自動"
@@ -282,12 +282,12 @@
       },
       "overlay": {
         "style": {
-          "title": "Overlay",
-          "description": "Choose the recording overlay: None hides it, Minimal shows a compact pill, Live shows transcription in real time as you speak (streaming-capable models only — look for the Streaming badge in the model picker). On Linux 'None' is recommended.",
+          "title": "懸浮窗",
+          "description": "選擇錄音懸浮窗的樣式：「無」會隱藏懸浮窗，「精簡」顯示小巧的膠囊狀指示，「即時」在您說話時即時顯示轉錄內容（僅限支援串流的模型——請在模型選擇器中尋找「串流」標籤）。在 Linux 上建議選擇「無」",
           "options": {
             "none": "無",
-            "minimal": "Minimal",
-            "live": "Live"
+            "minimal": "精簡",
+            "live": "即時"
           }
         },
         "position": {
@@ -365,8 +365,8 @@
         "duplicate": "「{{word}}」已存在"
       },
       "voiceActivityDetection": {
-        "title": "Voice Activity Detection",
-        "description": "Filter silence from recordings. Streaming-capable models use a longer VAD tail; disabling VAD records raw audio."
+        "title": "語音活動偵測",
+        "description": "過濾錄音中的靜音。支援串流的模型會使用較長的 VAD 尾段；停用 VAD 則會錄製原始音訊"
       }
     },
     "postProcessing": {
@@ -560,7 +560,7 @@
         "title": "致謝",
         "ggml": {
           "title": "ggml",
-          "description": "針對 OpenAI Whisper 自動語音識別模型的高效能推理引擎",
+          "description": "針對 OpenAI Whisper 自動語音辨識模型的高效能推理引擎",
           "details": "Handy 使用 ggml 進行快速的本機語音轉文字處理。感謝 Georgi Gerganov 和貢獻者們的傑出工作"
         }
       },


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Human Written Description

I'm a user from Taiwan. After installing v0.9.4, I noticed parts of the UI are still in English — the strings added after the original zh-TW locale (#796) landed were never translated. This PR completes the missing zh-TW translations and unifies the speech-recognition terminology to the Taiwan-standard 「辨識」.

*(I wrote this description in Chinese; it was translated to English with AI assistance.)*

## Related Issues/Discussions

- #796 added the zh-TW locale (Feb 2026); UI strings added since then remained in English.
- While working on this I also found and filed #1794 (system-locale auto-detection sends `zh-Hant-TW` users to Simplified Chinese) — separate code change, not included in this PR.

## Community Feedback

N/A — this completes an existing locale per CONTRIBUTING_TRANSLATIONS.md ("Improving Existing Translations").

## Testing

- JSON is well-formed (parsed programmatically).
- Key parity with `en/translation.json` verified: 385/385 keys, no missing or extra keys.
- All `{{variables}}` verified preserved exactly.
- Terminology kept consistent with the existing zh-TW file (串流 for streaming, 懸浮窗 for overlay, 轉錄 for transcription, 停用 for disable).
- Strings intentionally left identical to English: model names (Whisper Small, Moonshine…), key names (Enter, Cmd+Enter), URL/API-key placeholders, "ggml".

## Screenshots/Videos (if applicable)

N/A — string-only change.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: identified the untranslated strings by diffing against `en/translation.json`, drafted the zh-TW translations (reviewed by the PR author, a native Traditional Chinese speaker from Taiwan), ran the JSON/key-parity/variable validation, and translated the author's PR description from Chinese to English.
