### PR TITLE
fix(i18n): resolve zh-Hant-* system locales to Traditional Chinese (zh-TW)

### DIFF
--- a/src-tauri/src/tray_i18n.rs
+++ b/src-tauri/src/tray_i18n.rs
@@ -18,26 +18,78 @@ use std::collections::HashMap;
 // Include the auto-generated TrayStrings struct and TRANSLATIONS static
 include!(concat!(env!("OUT_DIR"), "/tray_translations.rs"));
 
+const TRADITIONAL_CHINESE_REGIONS: [&str; 3] = ["tw", "hk", "mo"];
+const SIMPLIFIED_CHINESE_REGIONS: [&str; 2] = ["cn", "sg"];
+
+fn find_script_and_region<'a>(subtags: &[&'a str]) -> (Option<&'a str>, Option<&'a str>) {
+    let mut script = None;
+    let mut region = None;
+
+    for subtag in subtags.iter().skip(1) {
+        // A singleton begins a BCP-47 extension, so later values are not part
+        // of the language/script/region identifier.
+        if subtag.len() == 1 {
+            break;
+        }
+        if script.is_none() && subtag.len() == 4 && subtag.chars().all(|c| c.is_ascii_alphabetic())
+        {
+            script = Some(*subtag);
+        }
+        if region.is_none()
+            && ((subtag.len() == 2 && subtag.chars().all(|c| c.is_ascii_alphabetic()))
+                || (subtag.len() == 3 && subtag.chars().all(|c| c.is_ascii_digit())))
+        {
+            region = Some(*subtag);
+        }
+    }
+
+    (script, region)
+}
+
 /// Get localized tray menu strings based on the system locale.
 ///
-/// Lookup order: full locale (e.g. "zh-TW") → script-aware fallback → language code ("zh") → English.
+/// Lookup order: exact locale → Chinese script/region fallback → language code → English.
 pub fn get_tray_translations(locale: Option<String>) -> TrayStrings {
-    let locale_str = locale.as_deref().unwrap_or("en");
-    let normalized = locale_str.to_lowercase();
-    let mut subtags = normalized.split(['-', '_']);
-    let lang_code = subtags.next().unwrap_or("en");
-    // Script-aware fallback: Traditional-script Chinese locales
-    // (e.g. zh-Hant-TW, zh-Hant-HK) should resolve to zh-TW, not fall
-    // through to the "zh" (Simplified) language fallback below.
-    let script_fallback = if lang_code == "zh" && subtags.next() == Some("hant") {
-        TRANSLATIONS.get("zh-TW")
-    } else {
-        None
+    let normalized = locale
+        .as_deref()
+        .unwrap_or("en")
+        .trim()
+        .to_lowercase()
+        .replace('_', "-");
+    let subtags: Vec<_> = normalized.split('-').collect();
+    let lang_code = subtags.first().copied().unwrap_or("en");
+
+    // Locale tags are case-insensitive, while the generated map preserves the
+    // locale directory's casing (for example, "zh-TW").
+    let exact_match = TRANSLATIONS
+        .iter()
+        .find_map(|(code, strings)| code.eq_ignore_ascii_case(&normalized).then_some(strings));
+
+    let (script, region) = find_script_and_region(&subtags);
+    let chinese_fallback = match lang_code {
+        "zh" if script == Some("hant")
+            || (script != Some("hans")
+                && region.is_some_and(|r| TRADITIONAL_CHINESE_REGIONS.contains(&r))) =>
+        {
+            TRANSLATIONS.get("zh-TW")
+        }
+        // We do not have a Cantonese translation. Use the matching Chinese
+        // script, with Traditional as Cantonese's default writing system.
+        "yue" => {
+            if script == Some("hans")
+                || (script != Some("hant")
+                    && region.is_some_and(|r| SIMPLIFIED_CHINESE_REGIONS.contains(&r)))
+            {
+                TRANSLATIONS.get("zh")
+            } else {
+                TRANSLATIONS.get("zh-TW")
+            }
+        }
+        _ => None,
     };
 
-    TRANSLATIONS
-        .get(locale_str)
-        .or(script_fallback)
+    exact_match
+        .or(chinese_fallback)
         .or_else(|| TRANSLATIONS.get(lang_code))
         .or_else(|| TRANSLATIONS.get("en"))
         .cloned()
@@ -71,11 +123,14 @@ mod tests {
     }
 
     #[test]
-    fn traditional_script_locales_resolve_to_zh_tw() {
+    fn traditional_chinese_locales_resolve_to_zh_tw() {
         for locale in [
             "zh-Hant-TW",
             "zh-Hant-HK",
             "zh-Hant",
+            "zh-yue-Hant-HK",
+            "zh-HK",
+            "zh-MO",
             "ZH-HANT-TW",
             "zh_Hant_TW",
         ] {
@@ -84,13 +139,25 @@ mod tests {
     }
 
     #[test]
-    fn saved_zh_tw_preference_matches_exactly() {
-        assert_resolves_to(Some("zh-TW"), "zh-TW");
+    fn exact_locale_matching_ignores_case_and_separator_style() {
+        for locale in ["zh-TW", "ZH-TW", "zh-tw", "zh_TW"] {
+            assert_resolves_to(Some(locale), "zh-TW");
+        }
     }
 
     #[test]
     fn simplified_chinese_locales_resolve_to_zh() {
-        for locale in ["zh", "zh-CN", "zh-Hans-CN", "zh-SG"] {
+        for locale in ["zh", "zh-CN", "zh-Hans-CN", "zh-Hans-HK", "zh-SG"] {
+            assert_resolves_to(Some(locale), "zh");
+        }
+    }
+
+    #[test]
+    fn cantonese_uses_the_matching_chinese_script_as_a_fallback() {
+        for locale in ["yue", "yue-Hant", "yue-Hant-HK", "yue-HK", "yue-MO"] {
+            assert_resolves_to(Some(locale), "zh-TW");
+        }
+        for locale in ["yue-Hans", "yue-Hans-CN", "yue-CN", "yue-SG"] {
             assert_resolves_to(Some(locale), "zh");
         }
     }

--- a/src-tauri/src/tray_i18n.rs
+++ b/src-tauri/src/tray_i18n.rs
@@ -20,13 +20,24 @@ include!(concat!(env!("OUT_DIR"), "/tray_translations.rs"));
 
 /// Get localized tray menu strings based on the system locale.
 ///
-/// Lookup order: full locale (e.g. "zh-TW") → language code ("zh") → English.
+/// Lookup order: full locale (e.g. "zh-TW") → script-aware fallback → language code ("zh") → English.
 pub fn get_tray_translations(locale: Option<String>) -> TrayStrings {
     let locale_str = locale.as_deref().unwrap_or("en");
-    let lang_code = locale_str.split(['-', '_']).next().unwrap_or("en");
+    let normalized = locale_str.to_lowercase();
+    let mut subtags = normalized.split(['-', '_']);
+    let lang_code = subtags.next().unwrap_or("en");
+    // Script-aware fallback: Traditional-script Chinese locales
+    // (e.g. zh-Hant-TW, zh-Hant-HK) should resolve to zh-TW, not fall
+    // through to the "zh" (Simplified) language fallback below.
+    let script_fallback = if lang_code == "zh" && subtags.next() == Some("hant") {
+        TRANSLATIONS.get("zh-TW")
+    } else {
+        None
+    };
 
     TRANSLATIONS
         .get(locale_str)
+        .or(script_fallback)
         .or_else(|| TRANSLATIONS.get(lang_code))
         .or_else(|| TRANSLATIONS.get("en"))
         .cloned()

--- a/src-tauri/src/tray_i18n.rs
+++ b/src-tauri/src/tray_i18n.rs
@@ -43,3 +43,76 @@ pub fn get_tray_translations(locale: Option<String>) -> TrayStrings {
         .cloned()
         .expect("English translations must exist")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{get_tray_translations, TRANSLATIONS};
+
+    /// Compare every field rather than a single one, so a partial regression
+    /// can't slip through. TrayStrings is generated and derives only Debug.
+    fn assert_resolves_to(locale: Option<&str>, expected_key: &str) {
+        let expected = TRANSLATIONS
+            .get(expected_key)
+            .unwrap_or_else(|| panic!("no translations for {expected_key}"));
+        assert_eq!(
+            format!("{:?}", get_tray_translations(locale.map(str::to_string))),
+            format!("{expected:?}"),
+            "{locale:?} should resolve to {expected_key}"
+        );
+    }
+
+    #[test]
+    fn simplified_and_traditional_chinese_differ() {
+        // Every Chinese assertion below is vacuous if these two are equal.
+        assert_ne!(
+            format!("{:?}", TRANSLATIONS["zh"]),
+            format!("{:?}", TRANSLATIONS["zh-TW"])
+        );
+    }
+
+    #[test]
+    fn traditional_script_locales_resolve_to_zh_tw() {
+        for locale in [
+            "zh-Hant-TW",
+            "zh-Hant-HK",
+            "zh-Hant",
+            "ZH-HANT-TW",
+            "zh_Hant_TW",
+        ] {
+            assert_resolves_to(Some(locale), "zh-TW");
+        }
+    }
+
+    #[test]
+    fn saved_zh_tw_preference_matches_exactly() {
+        assert_resolves_to(Some("zh-TW"), "zh-TW");
+    }
+
+    #[test]
+    fn simplified_chinese_locales_resolve_to_zh() {
+        for locale in ["zh", "zh-CN", "zh-Hans-CN", "zh-SG"] {
+            assert_resolves_to(Some(locale), "zh");
+        }
+    }
+
+    #[test]
+    fn region_subtag_falls_back_to_the_language() {
+        for (locale, expected) in [
+            ("en-US", "en"),
+            ("ja-JP", "ja"),
+            ("pt-BR", "pt"),
+            ("fr-FR", "fr"),
+            // Lookup lowercases before the language fallback.
+            ("FR-FR", "fr"),
+        ] {
+            assert_resolves_to(Some(locale), expected);
+        }
+    }
+
+    #[test]
+    fn unsupported_or_missing_locales_fall_back_to_english() {
+        assert_resolves_to(Some("xx-YY"), "en");
+        assert_resolves_to(Some(""), "en");
+        assert_resolves_to(None, "en");
+    }
+}

--- a/src-tauri/src/tray_i18n.rs
+++ b/src-tauri/src/tray_i18n.rs
@@ -18,34 +18,6 @@ use std::collections::HashMap;
 // Include the auto-generated TrayStrings struct and TRANSLATIONS static
 include!(concat!(env!("OUT_DIR"), "/tray_translations.rs"));
 
-const TRADITIONAL_CHINESE_REGIONS: [&str; 3] = ["tw", "hk", "mo"];
-const SIMPLIFIED_CHINESE_REGIONS: [&str; 2] = ["cn", "sg"];
-
-fn find_script_and_region<'a>(subtags: &[&'a str]) -> (Option<&'a str>, Option<&'a str>) {
-    let mut script = None;
-    let mut region = None;
-
-    for subtag in subtags.iter().skip(1) {
-        // A singleton begins a BCP-47 extension, so later values are not part
-        // of the language/script/region identifier.
-        if subtag.len() == 1 {
-            break;
-        }
-        if script.is_none() && subtag.len() == 4 && subtag.chars().all(|c| c.is_ascii_alphabetic())
-        {
-            script = Some(*subtag);
-        }
-        if region.is_none()
-            && ((subtag.len() == 2 && subtag.chars().all(|c| c.is_ascii_alphabetic()))
-                || (subtag.len() == 3 && subtag.chars().all(|c| c.is_ascii_digit())))
-        {
-            region = Some(*subtag);
-        }
-    }
-
-    (script, region)
-}
-
 /// Get localized tray menu strings based on the system locale.
 ///
 /// Lookup order: exact locale → Chinese script/region fallback → language code → English.
@@ -53,44 +25,29 @@ pub fn get_tray_translations(locale: Option<String>) -> TrayStrings {
     let normalized = locale
         .as_deref()
         .unwrap_or("en")
-        .trim()
         .to_lowercase()
         .replace('_', "-");
     let subtags: Vec<_> = normalized.split('-').collect();
-    let lang_code = subtags.first().copied().unwrap_or("en");
+    let language = subtags.first().copied().unwrap_or("en");
+    let is_hant = subtags.contains(&"hant");
+    let is_hans = subtags.contains(&"hans");
+    let is_traditional_region = ["tw", "hk", "mo"]
+        .iter()
+        .any(|region| subtags.contains(region));
 
-    // Locale tags are case-insensitive, while the generated map preserves the
-    // locale directory's casing (for example, "zh-TW").
     let exact_match = TRANSLATIONS
         .iter()
         .find_map(|(code, strings)| code.eq_ignore_ascii_case(&normalized).then_some(strings));
-
-    let (script, region) = find_script_and_region(&subtags);
-    let chinese_fallback = match lang_code {
-        "zh" if script == Some("hant")
-            || (script != Some("hans")
-                && region.is_some_and(|r| TRADITIONAL_CHINESE_REGIONS.contains(&r))) =>
-        {
-            TRANSLATIONS.get("zh-TW")
-        }
-        // We do not have a Cantonese translation. Use the matching Chinese
-        // script, with Traditional as Cantonese's default writing system.
-        "yue" => {
-            if script == Some("hans")
-                || (script != Some("hant")
-                    && region.is_some_and(|r| SIMPLIFIED_CHINESE_REGIONS.contains(&r)))
-            {
-                TRANSLATIONS.get("zh")
-            } else {
-                TRANSLATIONS.get("zh-TW")
-            }
-        }
-        _ => None,
+    let fallback = match language {
+        "zh" if is_hant || (!is_hans && is_traditional_region) => "zh-TW",
+        // Cantonese uses Traditional Chinese unless explicitly tagged as Hans.
+        "yue" if is_hans => "zh",
+        "yue" => "zh-TW",
+        _ => language,
     };
 
     exact_match
-        .or(chinese_fallback)
-        .or_else(|| TRANSLATIONS.get(lang_code))
+        .or_else(|| TRANSLATIONS.get(fallback))
         .or_else(|| TRANSLATIONS.get("en"))
         .cloned()
         .expect("English translations must exist")
@@ -100,86 +57,26 @@ pub fn get_tray_translations(locale: Option<String>) -> TrayStrings {
 mod tests {
     use super::{get_tray_translations, TRANSLATIONS};
 
-    /// Compare every field rather than a single one, so a partial regression
-    /// can't slip through. TrayStrings is generated and derives only Debug.
-    fn assert_resolves_to(locale: Option<&str>, expected_key: &str) {
-        let expected = TRANSLATIONS
-            .get(expected_key)
-            .unwrap_or_else(|| panic!("no translations for {expected_key}"));
-        assert_eq!(
-            format!("{:?}", get_tray_translations(locale.map(str::to_string))),
-            format!("{expected:?}"),
-            "{locale:?} should resolve to {expected_key}"
-        );
-    }
-
     #[test]
-    fn simplified_and_traditional_chinese_differ() {
-        // Every Chinese assertion below is vacuous if these two are equal.
-        assert_ne!(
-            format!("{:?}", TRANSLATIONS["zh"]),
-            format!("{:?}", TRANSLATIONS["zh-TW"])
-        );
-    }
-
-    #[test]
-    fn traditional_chinese_locales_resolve_to_zh_tw() {
-        for locale in [
-            "zh-Hant-TW",
-            "zh-Hant-HK",
-            "zh-Hant",
-            "zh-yue-Hant-HK",
-            "zh-HK",
-            "zh-MO",
-            "ZH-HANT-TW",
-            "zh_Hant_TW",
-        ] {
-            assert_resolves_to(Some(locale), "zh-TW");
-        }
-    }
-
-    #[test]
-    fn exact_locale_matching_ignores_case_and_separator_style() {
-        for locale in ["zh-TW", "ZH-TW", "zh-tw", "zh_TW"] {
-            assert_resolves_to(Some(locale), "zh-TW");
-        }
-    }
-
-    #[test]
-    fn simplified_chinese_locales_resolve_to_zh() {
-        for locale in ["zh", "zh-CN", "zh-Hans-CN", "zh-Hans-HK", "zh-SG"] {
-            assert_resolves_to(Some(locale), "zh");
-        }
-    }
-
-    #[test]
-    fn cantonese_uses_the_matching_chinese_script_as_a_fallback() {
-        for locale in ["yue", "yue-Hant", "yue-Hant-HK", "yue-HK", "yue-MO"] {
-            assert_resolves_to(Some(locale), "zh-TW");
-        }
-        for locale in ["yue-Hans", "yue-Hans-CN", "yue-CN", "yue-SG"] {
-            assert_resolves_to(Some(locale), "zh");
-        }
-    }
-
-    #[test]
-    fn region_subtag_falls_back_to_the_language() {
+    fn resolves_locale_fallbacks() {
         for (locale, expected) in [
-            ("en-US", "en"),
-            ("ja-JP", "ja"),
-            ("pt-BR", "pt"),
+            ("zh-Hant-TW", "zh-TW"),
+            ("zh-Hant-HK", "zh-TW"),
+            ("zh-HK", "zh-TW"),
+            ("zh-MO", "zh-TW"),
+            ("ZH-TW", "zh-TW"),
+            ("zh_Hant_TW", "zh-TW"),
+            ("zh-Hans-CN", "zh"),
+            ("yue-Hant-HK", "zh-TW"),
+            ("yue-Hans-CN", "zh"),
             ("fr-FR", "fr"),
-            // Lookup lowercases before the language fallback.
-            ("FR-FR", "fr"),
+            ("xx-YY", "en"),
         ] {
-            assert_resolves_to(Some(locale), expected);
+            assert_eq!(
+                format!("{:?}", get_tray_translations(Some(locale.into()))),
+                format!("{:?}", TRANSLATIONS[expected]),
+                "{locale} should resolve to {expected}"
+            );
         }
-    }
-
-    #[test]
-    fn unsupported_or_missing_locales_fall_back_to_english() {
-        assert_resolves_to(Some("xx-YY"), "en");
-        assert_resolves_to(Some(""), "en");
-        assert_resolves_to(None, "en");
     }
 }

--- a/src/components/settings/AppLanguageSelector.tsx
+++ b/src/components/settings/AppLanguageSelector.tsx
@@ -2,7 +2,11 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { Dropdown } from "../ui/Dropdown";
 import { SettingContainer } from "../ui/SettingContainer";
-import { SUPPORTED_LANGUAGES, type SupportedLanguageCode } from "../../i18n";
+import {
+  SUPPORTED_LANGUAGES,
+  getSupportedLanguage,
+  type SupportedLanguageCode,
+} from "../../i18n";
 import { useSettings } from "@/hooks/useSettings";
 
 interface AppLanguageSelectorProps {
@@ -15,7 +19,11 @@ export const AppLanguageSelector: React.FC<AppLanguageSelectorProps> =
     const { t, i18n } = useTranslation();
     const { settings, updateSetting } = useSettings();
 
-    const currentLanguage = (settings?.app_language ||
+    // Until the user picks a language, app_language holds the raw system
+    // locale (e.g. "en-US"), which matches no option and leaves the dropdown
+    // showing its empty-selection placeholder. Resolve it the same way i18n
+    // does so the dropdown shows the language actually in use.
+    const currentLanguage = (getSupportedLanguage(settings?.app_language) ||
       i18n.language) as SupportedLanguageCode;
 
     const languageOptions = SUPPORTED_LANGUAGES.map((lang) => ({

--- a/src/components/settings/AppLanguageSelector.tsx
+++ b/src/components/settings/AppLanguageSelector.tsx
@@ -19,10 +19,6 @@ export const AppLanguageSelector: React.FC<AppLanguageSelectorProps> =
     const { t, i18n } = useTranslation();
     const { settings, updateSetting } = useSettings();
 
-    // Until the user picks a language, app_language holds the raw system
-    // locale (e.g. "en-US"), which matches no option and leaves the dropdown
-    // showing its empty-selection placeholder. Resolve it the same way i18n
-    // does so the dropdown shows the language actually in use.
     const currentLanguage = (getSupportedLanguage(settings?.app_language) ||
       i18n.language) as SupportedLanguageCode;
 

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -52,7 +52,7 @@ export const SUPPORTED_LANGUAGES = Object.keys(resources)
 export type SupportedLanguageCode = string;
 
 // Check if a language code is supported
-const getSupportedLanguage = (
+export const getSupportedLanguage = (
   langCode: string | null | undefined,
 ): SupportedLanguageCode | null => {
   if (!langCode) return null;

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -62,6 +62,17 @@ const getSupportedLanguage = (
     (lang) => lang.code.toLowerCase() === normalized,
   );
   if (!supported) {
+    // Script-aware fallback: Traditional-script Chinese locales
+    // (e.g. zh-Hant-TW, zh-Hant-HK) should resolve to zh-TW, not fall
+    // through to the "zh" (Simplified) prefix match below.
+    const subtags = normalized.split("-");
+    if (subtags[0] === "zh" && subtags[1] === "hant") {
+      supported = SUPPORTED_LANGUAGES.find(
+        (lang) => lang.code.toLowerCase() === "zh-tw",
+      );
+    }
+  }
+  if (!supported) {
     // Fall back to prefix match (language only, without region)
     const prefix = normalized.split("-")[0];
     supported = SUPPORTED_LANGUAGES.find(

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -51,83 +51,37 @@ export const SUPPORTED_LANGUAGES = Object.keys(resources)
 
 export type SupportedLanguageCode = string;
 
-const TRADITIONAL_CHINESE_REGIONS = new Set(["tw", "hk", "mo"]);
-const SIMPLIFIED_CHINESE_REGIONS = new Set(["cn", "sg"]);
-
-const getLocaleSubtags = (langCode: string) =>
-  langCode.trim().toLowerCase().replace(/_/g, "-").split("-");
-
-const findScriptAndRegion = (subtags: string[]) => {
-  let script: string | undefined;
-  let region: string | undefined;
-
-  for (const subtag of subtags.slice(1)) {
-    // A singleton begins a BCP-47 extension, so later values are not part of
-    // the language/script/region identifier.
-    if (subtag.length === 1) break;
-    if (!script && /^[a-z]{4}$/.test(subtag)) script = subtag;
-    if (!region && (/^[a-z]{2}$/.test(subtag) || /^\d{3}$/.test(subtag))) {
-      region = subtag;
-    }
-  }
-
-  return { script, region };
-};
-
 // Check if a language code is supported
 export const getSupportedLanguage = (
   langCode: string | null | undefined,
 ): SupportedLanguageCode | null => {
   if (!langCode) return null;
 
-  const subtags = getLocaleSubtags(langCode);
-  const normalized = subtags.join("-");
-
-  // Try an exact, case- and separator-insensitive match first.
-  let supported = SUPPORTED_LANGUAGES.find(
-    (lang) => getLocaleSubtags(lang.code).join("-") === normalized,
+  const normalized = langCode.toLowerCase().replace(/_/g, "-");
+  const subtags = normalized.split("-");
+  const language = subtags[0];
+  const isHant = subtags.includes("hant");
+  const isHans = subtags.includes("hans");
+  const isTraditionalRegion = ["tw", "hk", "mo"].some((region) =>
+    subtags.includes(region),
   );
 
+  // Try exact match first
+  let supported = SUPPORTED_LANGUAGES.find(
+    (lang) => lang.code.toLowerCase() === normalized,
+  );
   if (!supported) {
-    const language = subtags[0];
-    const { script, region } = findScriptAndRegion(subtags);
-    let fallbackCode: string | undefined;
-
-    if (
-      language === "zh" &&
-      (script === "hant" ||
-        (script !== "hans" &&
-          region !== undefined &&
-          TRADITIONAL_CHINESE_REGIONS.has(region)))
-    ) {
-      // Traditional Chinese may be identified by script or only by region.
-      fallbackCode = "zh-tw";
+    let fallback = language;
+    if (language === "zh" && (isHant || (!isHans && isTraditionalRegion))) {
+      fallback = "zh-tw";
     } else if (language === "yue") {
-      // We do not have a Cantonese translation. Use the matching Chinese
-      // script, with Traditional as Cantonese's default writing system.
-      fallbackCode =
-        script === "hans" ||
-        (script !== "hant" &&
-          region !== undefined &&
-          SIMPLIFIED_CHINESE_REGIONS.has(region))
-          ? "zh"
-          : "zh-tw";
+      // Cantonese uses Traditional Chinese unless explicitly tagged as Hans.
+      fallback = isHans ? "zh" : "zh-tw";
     }
-
-    if (fallbackCode) {
-      supported = SUPPORTED_LANGUAGES.find(
-        (lang) => lang.code.toLowerCase() === fallbackCode,
-      );
-    }
-  }
-
-  if (!supported) {
-    // Fall back to the language subtag.
     supported = SUPPORTED_LANGUAGES.find(
-      (lang) => lang.code.toLowerCase() === subtags[0],
+      (lang) => lang.code.toLowerCase() === fallback,
     );
   }
-
   return supported ? supported.code : null;
 };
 

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -51,34 +51,83 @@ export const SUPPORTED_LANGUAGES = Object.keys(resources)
 
 export type SupportedLanguageCode = string;
 
+const TRADITIONAL_CHINESE_REGIONS = new Set(["tw", "hk", "mo"]);
+const SIMPLIFIED_CHINESE_REGIONS = new Set(["cn", "sg"]);
+
+const getLocaleSubtags = (langCode: string) =>
+  langCode.trim().toLowerCase().replace(/_/g, "-").split("-");
+
+const findScriptAndRegion = (subtags: string[]) => {
+  let script: string | undefined;
+  let region: string | undefined;
+
+  for (const subtag of subtags.slice(1)) {
+    // A singleton begins a BCP-47 extension, so later values are not part of
+    // the language/script/region identifier.
+    if (subtag.length === 1) break;
+    if (!script && /^[a-z]{4}$/.test(subtag)) script = subtag;
+    if (!region && (/^[a-z]{2}$/.test(subtag) || /^\d{3}$/.test(subtag))) {
+      region = subtag;
+    }
+  }
+
+  return { script, region };
+};
+
 // Check if a language code is supported
 export const getSupportedLanguage = (
   langCode: string | null | undefined,
 ): SupportedLanguageCode | null => {
   if (!langCode) return null;
-  const normalized = langCode.toLowerCase();
-  // Try exact match first
+
+  const subtags = getLocaleSubtags(langCode);
+  const normalized = subtags.join("-");
+
+  // Try an exact, case- and separator-insensitive match first.
   let supported = SUPPORTED_LANGUAGES.find(
-    (lang) => lang.code.toLowerCase() === normalized,
+    (lang) => getLocaleSubtags(lang.code).join("-") === normalized,
   );
+
   if (!supported) {
-    // Script-aware fallback: Traditional-script Chinese locales
-    // (e.g. zh-Hant-TW, zh-Hant-HK) should resolve to zh-TW, not fall
-    // through to the "zh" (Simplified) prefix match below.
-    const subtags = normalized.split("-");
-    if (subtags[0] === "zh" && subtags[1] === "hant") {
+    const language = subtags[0];
+    const { script, region } = findScriptAndRegion(subtags);
+    let fallbackCode: string | undefined;
+
+    if (
+      language === "zh" &&
+      (script === "hant" ||
+        (script !== "hans" &&
+          region !== undefined &&
+          TRADITIONAL_CHINESE_REGIONS.has(region)))
+    ) {
+      // Traditional Chinese may be identified by script or only by region.
+      fallbackCode = "zh-tw";
+    } else if (language === "yue") {
+      // We do not have a Cantonese translation. Use the matching Chinese
+      // script, with Traditional as Cantonese's default writing system.
+      fallbackCode =
+        script === "hans" ||
+        (script !== "hant" &&
+          region !== undefined &&
+          SIMPLIFIED_CHINESE_REGIONS.has(region))
+          ? "zh"
+          : "zh-tw";
+    }
+
+    if (fallbackCode) {
       supported = SUPPORTED_LANGUAGES.find(
-        (lang) => lang.code.toLowerCase() === "zh-tw",
+        (lang) => lang.code.toLowerCase() === fallbackCode,
       );
     }
   }
+
   if (!supported) {
-    // Fall back to prefix match (language only, without region)
-    const prefix = normalized.split("-")[0];
+    // Fall back to the language subtag.
     supported = SUPPORTED_LANGUAGES.find(
-      (lang) => lang.code.toLowerCase() === prefix,
+      (lang) => lang.code.toLowerCase() === subtags[0],
     );
   }
+
   return supported ? supported.code : null;
 };
 


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Human Written Description

Hi! When I first installed and launched Handy, the interface showed up in Simplified Chinese. Later I found there was actually a Traditional Chinese option in Settings, and after selecting it everything displayed correctly — which felt like a bit of a pity for first-run experience, so I decided to contribute a PR. Really glad to have the chance to contribute!

(English translation of my own words, originally written in Chinese: 嗨，之前我第一次安裝、啟動 Handy 之後，發現介面顯示的是簡體中文，但後來在設定裡發現其實有繁體中文的選項，選了之後就可以顯示繁體中文了，覺得有點可惜，就決定來貢獻 PR，很高興有機會可以貢獻。)

## Related Issues/Discussions

Fixes #1794

Follow-up to #1795 (zh-TW translation completeness) — this fixes the auto-detection path so Traditional Chinese users actually land on those translations by default.

While implementing, end-to-end testing revealed the same fallback bug exists in **two independent code paths**, so the fix touches both:

- `src/i18n/index.ts` `getSupportedLanguage()` — webview UI language
- `src-tauri/src/tray_i18n.rs` `get_tray_translations()` — tray menu language (the tray reads `settings.app_language` directly at startup and never consults the frontend; with only the TS fix, the tray still came up Simplified)

Both now do a script-aware fallback (language `zh` + script subtag `hant` → `zh-TW`) between the exact-match and the language-prefix fallback. `zh-Hans-*` still resolves to `zh` via the existing prefix path; a saved `zh-TW` preference still exact-matches first. One side note: the Rust path now lowercases before the language-code fallback, so odd-cased locales (e.g. `FR-FR`) resolve to their language instead of falling back to English — standard-cased locales behave exactly as before.

## Community Feedback

Maintainer invited the fix in #1794: "If you don't mind submitting a fix for this, it would be really helpful, especially if you are able to test it!"

## Testing

All on the machine that reproduced the bug (macOS, `defaults read -g AppleLanguages` = `("zh-Hant-TW", "en-TW")`):

- `bun run lint`, `bun run build`, `cargo fmt --check`, `cargo build` all pass.
- Logic matrix (standalone script replicating `getSupportedLanguage` with the repo's 24 supported codes): `zh-Hant-TW` / `zh-Hant-HK` / `zh-Hant` / `ZH-HANT-TW` → `zh-TW` (previously `zh`); `zh-Hans-CN` / `zh-CN` / `zh` → `zh` (unchanged); `zh-TW` exact match unchanged; `en-US`, `ja-JP`, `fr`, unknown, `null`, `""` unchanged.
- End-to-end before/after: removed the saved `app_language` preference, launched via `bun run tauri dev`.
  - **Before the Rust fix**: tray menu came up in Simplified Chinese (设置..., 复制最新转录, 退出).
  - **After**: tray menu comes up in Traditional Chinese (設定..., 複製最新轉錄, 結束), and the settings window UI auto-detects to Traditional Chinese (screenshot below).

## Screenshots/Videos (if applicable)

First launch with no saved language preference on a `zh-Hant-TW` system — settings UI auto-detected as Traditional Chinese (will attach screenshot in a comment).

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (implementation + testing), OpenAI Codex (delegated code review)
- How extensively: root cause was identified and verified by hand (see #1794); Claude Code wrote the patch following a reviewed design and ran the lint/build/matrix/e2e verification; Codex independently reviewed the design and each diff. Human-reviewed before submission.
