### PR TITLE
fix(audio): recalibrate mic level meter so speech actually moves the bar

### DIFF
--- a/src-tauri/src/audio_toolkit/audio/visualizer.rs
+++ b/src-tauri/src/audio_toolkit/audio/visualizer.rs
@@ -1,8 +1,14 @@
 use rustfft::{num_complex::Complex32, Fft, FftPlanner};
 use std::sync::Arc;
 
-const DB_MIN: f32 = -55.0;
-const DB_MAX: f32 = -8.0;
+// `db` below is not true dBFS: it's a per-bin average divided by the FFT
+// window size, which lands ~20 dB low for speech. So this window is calibrated
+// against measured mic audio (dictation ~-32 dBFS, room tone ~-48 dBFS) rather
+// than absolute dBFS. The old -55/-8 left speech ~1 px above the overlay's
+// floor, which reads as a frozen waveform (#1694). Not lowered past -68: at
+// -70 a noisy room starts making the idle waveform twitch.
+const DB_MIN: f32 = -68.0;
+const DB_MAX: f32 = -30.0;
 const GAIN: f32 = 1.3;
 const CURVE_POWER: f32 = 0.7;
 


### PR DESCRIPTION
The `db` value computed in AudioVisualiser::feed() is not true dBFS: it is a per-bin average magnitude divided by the FFT window size, which for speech-shaped input lands roughly 20 dB below the band's actual dBFS. DB_MIN/DB_MAX were calibrated as if it were dBFS, so the window sat about 20 dB too high:

- src-tauri/src/audio_toolkit/audio/visualizer.rs (level buckets)
- src/overlay/RecordingOverlay.tsx (draws 3 + v^0.7 * 15 px bars)

Normal dictation therefore mapped to ~0.1, which the overlay draws as a 4 px bar against a 3 px floor and an 18 px maximum — roughly one pixel of travel, which reads as a frozen waveform.

Recalibrate to -68/-30, measured against captured audio on a built-in mic at 48 kHz (dictation ~-32 dBFS median, room tone ~-48 dBFS) and scored on rendered pixels: speech gets ~5 px of travel while room tone stays pinned at the floor. Not lowered to -70, where a noisy room starts making the idle waveform twitch.

Fixes #1694

## Before Submitting This PR

<!--
HANDY IS UNDERGOING A FEATURE FREEZE. IF YOU ARE SUBMITTING A PR WHICH IS A NEW FEATURE THAT THE COMMUNITY HAS NOT ASKED FOR: PREPARE TO BE REJECTED. IF THE COMMUNITY HAS ASKED FOR IT, OR YOU HAVE EXPLICITLY GATHERED SUPPORT IT MAY STILL BE CONSIDERED.

BUG FIXES ARE THE TOP PRIORITY. THERE ARE 60+ ISSUES TO FIX.
-->

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description
I myself was facing the issue. So I gone through the issue tab, then I found the same issue, then I tried to fix it. I am contributing for the first time.

<!-- Describe your changes clearly and concisely

Please write 2-3 sentences in your own words explaining:
- What problem you noticed or idea you had
- Why you think this change matters

This section should be YOUR thinking, not AI-generated text. Even if AI helped write the code, we want to hear from you directly. Your perspective as a human is what makes contributions meaningful. Your PR may be rejected if you do not
include a human-written description.
-->

## Screenshots/Videos (if applicable)

Before 
<img width="293" height="95" alt="image" src="https://github.com/user-attachments/assets/74f6425f-6557-4357-a991-488fe167ed23" />

After
<img width="334" height="100" alt="image" src="https://github.com/user-attachments/assets/53a0120f-d81d-4eca-9268-55811dc7fd23" />

<!-- Add screenshots or videos demonstrating the change -->

## AI Assistance

<!-- AI-assisted PRs are welcome! Just let us know so we can review appropriately. -->

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Mythos
- How extensively: Fully, but I tested it manually too    