### PR TITLE
fix: add model compatibility warning in translation settings

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -483,39 +483,52 @@ fn build_apple_intelligence_bridge() {
         .expect("Unable to determine Swift toolchain lib directory");
     let sdk_swift_lib = Path::new(&sdk_path).join("usr/lib/swift");
 
-    // Use macOS 11.0 as deployment target for compatibility
-    // The @available(macOS 26.0, *) checks in Swift handle runtime availability
-    // Weak linking for FoundationModels is handled via cargo:rustc-link-arg below
-    let status = Command::new(&swiftc_path)
-        .args([
-            // Without this flag swiftc treats single-file input as script
-            // mode and emits its own `_main` symbol into the .o, which can
-            // win the link against Rust's main under some linkers (e.g.
-            // open-source ld64 used in nixpkgs' Darwin stdenv), producing a
-            // binary whose main() is a 5-instruction no-op that returns 0.
-            // `-parse-as-library` keeps the compilation in library mode so
-            // no `_main` is emitted. See:
-            //   https://forums.swift.org/t/main-in-a-single-swift-file/63079
-            "-parse-as-library",
-            "-target",
-            "arm64-apple-macosx11.0",
-            "-sdk",
-            &sdk_path,
-            "-O",
-            "-import-objc-header",
-            BRIDGE_HEADER,
-            "-c",
-            source_file,
-            "-o",
-            object_path
-                .to_str()
-                .expect("Failed to convert object path to string"),
-        ])
-        .status()
-        .expect("Failed to invoke swiftc for Apple Intelligence bridge");
+    let compile_status = if source_file == STUB_SWIFT_FILE {
+        println!("cargo:warning=Compiling C stub for Apple Intelligence (bypassing swiftc)...");
+        Command::new("clang")
+            .args([
+                "-O3",
+                "-c",
+                "swift/apple_intelligence_stub.c",
+                "-o",
+                object_path
+                    .to_str()
+                    .expect("Failed to convert object path to string"),
+            ])
+            .status()
+    } else {
+        Command::new(&swiftc_path)
+            .args([
+                // Without this flag swiftc treats single-file input as script
+                // mode and emits its own `_main` symbol into the .o, which can
+                // win the link against Rust's main under some linkers (e.g.
+                // open-source ld64 used in nixpkgs' Darwin stdenv), producing a
+                // binary whose main() is a 5-instruction no-op that returns 0.
+                // `-parse-as-library` keeps the compilation in library mode so
+                // no `_main` is emitted. See:
+                //   https://forums.swift.org/t/main-in-a-single-swift-file/63079
+                "-parse-as-library",
+                "-target",
+                "arm64-apple-macosx11.0",
+                "-sdk",
+                &sdk_path,
+                "-O",
+                "-import-objc-header",
+                BRIDGE_HEADER,
+                "-c",
+                source_file,
+                "-o",
+                object_path
+                    .to_str()
+                    .expect("Failed to convert object path to string"),
+            ])
+            .status()
+    };
+
+    let status = compile_status.expect("Failed to compile Apple Intelligence bridge");
 
     if !status.success() {
-        panic!("swiftc failed to compile {source_file}");
+        panic!("Bridge compilation failed for {source_file}");
     }
 
     let status = Command::new("libtool")

--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -101,6 +101,257 @@ fn should_use_streaming_overlay(style: OverlayStyle, is_streaming: bool) -> bool
     style == OverlayStyle::Live && is_streaming
 }
 
+fn get_language_name(code: &str) -> &str {
+    match code {
+        "en" => "English",
+        "zh" | "zh-Hans" | "zh-Hant" => "Chinese",
+        "yue" => "Cantonese",
+        "de" => "German",
+        "es" => "Spanish",
+        "ru" => "Russian",
+        "ko" => "Korean",
+        "fr" => "French",
+        "ja" => "Japanese",
+        "pt" => "Portuguese",
+        "tr" => "Turkish",
+        "pl" => "Polish",
+        "ca" => "Catalan",
+        "nl" => "Dutch",
+        "ar" => "Arabic",
+        "sv" => "Swedish",
+        "it" => "Italian",
+        "id" => "Indonesian",
+        "hi" => "Hindi",
+        "fi" => "Finnish",
+        "vi" => "Vietnamese",
+        "he" => "Hebrew",
+        "uk" => "Ukrainian",
+        "el" => "Greek",
+        "ms" => "Malay",
+        "cs" => "Czech",
+        "ro" => "Romanian",
+        "da" => "Danish",
+        "hu" => "Hungarian",
+        "ta" => "Tamil",
+        "no" => "Norwegian",
+        "th" => "Thai",
+        "ur" => "Urdu",
+        "hr" => "Croatian",
+        "bg" => "Bulgarian",
+        "lt" => "Lithuanian",
+        "la" => "Latin",
+        "mi" => "Maori",
+        "ml" => "Malayalam",
+        "cy" => "Welsh",
+        "sk" => "Slovak",
+        "te" => "Telugu",
+        "fa" => "Persian",
+        "lv" => "Latvian",
+        "bn" => "Bengali",
+        "sr" => "Serbian",
+        "az" => "Azerbaijani",
+        "sl" => "Slovenian",
+        "kn" => "Kannada",
+        "et" => "Estonian",
+        "mk" => "Macedonian",
+        "br" => "Breton",
+        "eu" => "Basque",
+        "is" => "Icelandic",
+        "hy" => "Armenian",
+        "ne" => "Nepali",
+        "mn" => "Mongolian",
+        "bs" => "Bosnian",
+        "kk" => "Kazakh",
+        "sq" => "Albanian",
+        "sw" => "Swahili",
+        "gl" => "Galician",
+        "mr" => "Marathi",
+        "pa" => "Punjabi",
+        "si" => "Sinhala",
+        "km" => "Khmer",
+        "sn" => "Shona",
+        "yo" => "Yoruba",
+        "so" => "Somali",
+        "af" => "Afrikaans",
+        "oc" => "Occitan",
+        "ka" => "Georgian",
+        "be" => "Belarusian",
+        "tg" => "Tajik",
+        "sd" => "Sindhi",
+        "gu" => "Gujarati",
+        "am" => "Amharic",
+        "yi" => "Yiddish",
+        "lo" => "Lao",
+        "uz" => "Uzbek",
+        "fo" => "Faroese",
+        "ht" => "Haitian Creole",
+        "ps" => "Pashto",
+        "tk" => "Turkmen",
+        "nn" => "Nynorsk",
+        "mt" => "Maltese",
+        "sa" => "Sanskrit",
+        "lb" => "Luxembourgish",
+        "my" => "Myanmar",
+        _ => code,
+    }
+}
+
+async fn translate_text_via_llm(
+    settings: &AppSettings,
+    transcription: &str,
+    target_lang: &str,
+) -> Option<String> {
+    if is_blank_transcription(transcription) {
+        debug!("Translation skipped because the transcription is empty");
+        return None;
+    }
+
+    let provider = match settings.active_post_process_provider().cloned() {
+        Some(provider) => provider,
+        None => {
+            debug!("Translation enabled but no post-processing provider is selected");
+            return None;
+        }
+    };
+
+    let model = settings
+        .post_process_models
+        .get(&provider.id)
+        .cloned()
+        .unwrap_or_default();
+
+    if model.trim().is_empty() {
+        debug!(
+            "Translation skipped because provider '{}' has no model configured",
+            provider.id
+        );
+        return None;
+    }
+
+    let api_key = settings
+        .post_process_api_keys
+        .get(&provider.id)
+        .cloned()
+        .unwrap_or_default();
+
+    let target_lang_name = get_language_name(target_lang);
+    let prompt = format!(
+        "Translate the following text to {target_lang_name}. Return ONLY the translated text. Do not add any introduction, explanation, markdown blocks, or conversational filler.\n\nText:\n{transcription}"
+    );
+
+    let (reasoning_effort, reasoning) = match provider.id.as_str() {
+        "custom" => (Some("none".to_string()), None),
+        "openrouter" => (
+            None,
+            Some(crate::llm_client::ReasoningConfig {
+                effort: Some("none".to_string()),
+                exclude: Some(true),
+            }),
+        ),
+        _ => (None, None),
+    };
+
+    debug!(
+        "Starting LLM translation to {} with provider '{}' (model: {})",
+        target_lang_name, provider.id, model
+    );
+
+    // Handle Apple Intelligence separately since it uses native Swift APIs
+    if provider.id == APPLE_INTELLIGENCE_PROVIDER_ID {
+        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+        {
+            if !apple_intelligence::check_apple_intelligence_availability() {
+                debug!("Apple Intelligence selected but not currently available on this device");
+                return None;
+            }
+
+            let system_prompt = format!("Translate the text directly to {target_lang_name}. Return ONLY the translated text.");
+            let token_limit = model.trim().parse::<i32>().unwrap_or(0);
+            return match apple_intelligence::process_text_with_system_prompt(
+                &system_prompt,
+                transcription,
+                token_limit,
+            ) {
+                Ok(result) => {
+                    if result.trim().is_empty() {
+                        None
+                    } else {
+                        Some(strip_invisible_chars(&result))
+                    }
+                }
+                Err(err) => {
+                    error!("Apple Intelligence translation failed: {}", err);
+                    None
+                }
+            };
+        }
+
+        #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+        {
+            debug!("Apple Intelligence provider selected on unsupported platform");
+            return None;
+        }
+    }
+
+    if provider.supports_structured_output {
+        let system_prompt = format!("You are a professional translator translating text directly to {target_lang_name}. Return ONLY the translated text.");
+        let user_content = transcription.to_string();
+        let json_schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "translation": {
+                    "type": "string",
+                    "description": "The translated text"
+                }
+            },
+            "required": ["translation"],
+            "additionalProperties": false
+        });
+
+        match crate::llm_client::send_chat_completion_with_schema(
+            &provider,
+            api_key.clone(),
+            &model,
+            user_content,
+            Some(system_prompt),
+            Some(json_schema),
+            reasoning_effort.clone(),
+            reasoning.clone(),
+        )
+        .await
+        {
+            Ok(Some(content)) => {
+                if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
+                    if let Some(translation_val) = json.get("translation").and_then(|t| t.as_str())
+                    {
+                        let result = strip_invisible_chars(translation_val);
+                        return Some(result);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Fallback to legacy/unstructured mode
+    match crate::llm_client::send_chat_completion(
+        &provider,
+        api_key,
+        &model,
+        prompt,
+        reasoning_effort,
+        reasoning,
+    )
+    .await
+    {
+        Ok(Some(content)) => {
+            let content = strip_invisible_chars(&content);
+            Some(content)
+        }
+        _ => None,
+    }
+}
+
 async fn post_process_transcription(settings: &AppSettings, transcription: &str) -> Option<String> {
     if is_blank_transcription(transcription) {
         debug!("Post-processing skipped because the transcription is empty");
@@ -451,6 +702,29 @@ pub(crate) async fn process_transcription_output(
         }
     } else if final_text != transcription {
         post_processed_text = Some(final_text.clone());
+    }
+
+    let model_manager = app.state::<Arc<ModelManager>>();
+    let active_model = model_manager.get_model_info(&settings.selected_model);
+    let model_supports_translation = active_model
+        .map(|m| m.supports_translation)
+        .unwrap_or(false);
+
+    let needs_llm_translation = settings.translation_target_language != "none"
+        && !settings.translation_target_language.is_empty()
+        && !(settings.translation_target_language == "en" && model_supports_translation);
+
+    if needs_llm_translation {
+        if let Some(translated_text) = translate_text_via_llm(
+            &settings,
+            &final_text,
+            &settings.translation_target_language,
+        )
+        .await
+        {
+            post_processed_text = Some(translated_text.clone());
+            final_text = translated_text;
+        }
     }
 
     ProcessedTranscription {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -616,6 +616,7 @@ pub fn run(cli_args: CliArgs) {
             shortcut::change_start_hidden_setting,
             shortcut::change_autostart_setting,
             shortcut::change_translate_to_english_setting,
+            shortcut::change_translation_target_language_setting,
             shortcut::change_selected_language_setting,
             shortcut::change_overlay_position_setting,
             shortcut::change_overlay_style_setting,

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -895,7 +895,7 @@ impl TranscriptionManager {
         let effective_language =
             effective_language_for_model(&settings, self.model_manager.as_ref(), &model_id);
         let run_plan = transcribe_cpp_run_plan(
-            settings.translate_to_english,
+            &settings.translation_target_language,
             &effective_language,
             &languages,
             supports_translate,
@@ -1246,7 +1246,7 @@ impl TranscriptionManager {
                         };
 
                         let run_plan = transcribe_cpp_run_plan(
-                            settings.translate_to_english,
+                            &settings.translation_target_language,
                             &validated_language,
                             &model_languages,
                             model_supports_translate,
@@ -1324,7 +1324,7 @@ impl TranscriptionManager {
                         };
                         let options = TranscribeOptions {
                             language: lang,
-                            translate: settings.translate_to_english,
+                            translate: settings.translation_target_language == "en",
                             ..Default::default()
                         };
                         canary_engine
@@ -1401,7 +1401,9 @@ impl TranscriptionManager {
         let filtered_result = post_process_transcription_text(result, &settings, model_is_whisper);
 
         let et = std::time::Instant::now();
-        let translation_note = if settings.translate_to_english {
+        let translation_note = if settings.translation_target_language != "none"
+            && !settings.translation_target_language.is_empty()
+        {
             " (translated)"
         } else {
             ""
@@ -1578,7 +1580,7 @@ struct TranscribeCppRunPlan {
 /// Build the transcribe-cpp language/task options shared by batch and live
 /// streaming paths.
 fn transcribe_cpp_run_plan(
-    translate_to_english: bool,
+    translation_target_language: &str,
     effective_language: &str,
     model_languages: &[String],
     model_supports_translate: bool,
@@ -1593,7 +1595,7 @@ fn transcribe_cpp_run_plan(
     // they always stay on auto.
     let language = requested_language.filter(|lang| model_languages.iter().any(|l| l == lang));
     let (task, target_language) = cpp_translation_task(
-        translate_to_english,
+        translation_target_language,
         model_supports_translate,
         language.as_deref(),
     );
@@ -1661,12 +1663,13 @@ where
 ///
 /// Returns `(task, target_language)` ready to drop into `RunOptions`.
 fn cpp_translation_task(
-    translate_to_english: bool,
+    translation_target_language: &str,
     model_supports_translate: bool,
     source_language: Option<&str>,
 ) -> (Task, Option<String>) {
-    let translate_to_en =
-        translate_to_english && model_supports_translate && source_language != Some("en");
+    let translate_to_en = translation_target_language == "en"
+        && model_supports_translate
+        && source_language != Some("en");
     if translate_to_en {
         (Task::Translate, Some("en".to_string()))
     } else {
@@ -2025,7 +2028,7 @@ mod tests {
 
     #[test]
     fn transcribe_cpp_run_plan_maps_chinese_variants() {
-        let plan = transcribe_cpp_run_plan(false, "zh-Hant", &languages(&["zh"]), true);
+        let plan = transcribe_cpp_run_plan("none", "zh-Hant", &languages(&["zh"]), true);
 
         assert!(matches!(plan.task, Task::Transcribe));
         assert_eq!(plan.language.as_deref(), Some("zh"));
@@ -2034,7 +2037,7 @@ mod tests {
 
     #[test]
     fn transcribe_cpp_run_plan_skips_english_translation() {
-        let plan = transcribe_cpp_run_plan(true, "en", &languages(&["en", "es"]), true);
+        let plan = transcribe_cpp_run_plan("en", "en", &languages(&["en", "es"]), true);
 
         assert!(matches!(plan.task, Task::Transcribe));
         assert_eq!(plan.language.as_deref(), Some("en"));
@@ -2043,7 +2046,7 @@ mod tests {
 
     #[test]
     fn transcribe_cpp_run_plan_translates_supported_non_english() {
-        let plan = transcribe_cpp_run_plan(true, "es", &languages(&["en", "es"]), true);
+        let plan = transcribe_cpp_run_plan("en", "es", &languages(&["en", "es"]), true);
 
         assert!(matches!(plan.task, Task::Translate));
         assert_eq!(plan.language.as_deref(), Some("es"));
@@ -2052,7 +2055,7 @@ mod tests {
 
     #[test]
     fn transcribe_cpp_run_plan_requires_model_translation_support() {
-        let plan = transcribe_cpp_run_plan(true, "es", &languages(&["en", "es"]), false);
+        let plan = transcribe_cpp_run_plan("en", "es", &languages(&["en", "es"]), false);
 
         assert!(matches!(plan.task, Task::Transcribe));
         assert_eq!(plan.language.as_deref(), Some("es"));

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -383,6 +383,8 @@ pub struct AppSettings {
     pub selected_output_device: Option<String>,
     #[serde(default = "default_translate_to_english")]
     pub translate_to_english: bool,
+    #[serde(default = "default_translation_target_language")]
+    pub translation_target_language: String,
     #[serde(default = "default_selected_language")]
     pub selected_language: String,
     #[serde(default = "default_overlay_position")]
@@ -486,6 +488,10 @@ fn default_always_on_microphone() -> bool {
 
 fn default_translate_to_english() -> bool {
     false
+}
+
+fn default_translation_target_language() -> String {
+    "none".to_string()
 }
 
 fn default_start_hidden() -> bool {
@@ -855,6 +861,7 @@ pub fn get_default_settings() -> AppSettings {
         clamshell_microphone: None,
         selected_output_device: None,
         translate_to_english: false,
+        translation_target_language: default_translation_target_language(),
         selected_language: "auto".to_string(),
         overlay_position: default_overlay_position(),
         debug_mode: false,
@@ -1077,6 +1084,15 @@ fn apply_settings_migrations(
         } else {
             OverlayStyle::Live
         };
+        updated = true;
+    }
+
+    if settings_value.get("translation_target_language").is_none() {
+        if settings.translate_to_english {
+            settings.translation_target_language = "en".to_string();
+        } else {
+            settings.translation_target_language = "none".to_string();
+        }
         updated = true;
     }
 

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -619,6 +619,18 @@ pub fn change_translate_to_english_setting(app: AppHandle, enabled: bool) -> Res
 
 #[tauri::command]
 #[specta::specta]
+pub fn change_translation_target_language_setting(
+    app: AppHandle,
+    language: String,
+) -> Result<(), String> {
+    let mut settings = settings::get_settings(&app);
+    settings.translation_target_language = language;
+    settings::write_settings(&app, settings);
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
 pub fn change_selected_language_setting(app: AppHandle, language: String) -> Result<(), String> {
     let mut settings = settings::get_settings(&app);
     settings.selected_language = language;

--- a/src-tauri/swift/apple_intelligence_stub.c
+++ b/src-tauri/swift/apple_intelligence_stub.c
@@ -1,0 +1,40 @@
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+    char* response;
+    int success;
+    char* error_message;
+} AppleLLMResponse;
+
+int is_apple_intelligence_available() {
+    return 0;
+}
+
+AppleLLMResponse* process_text_with_system_prompt_apple(
+    const char* system_prompt,
+    const char* user_content,
+    int max_tokens
+) {
+    AppleLLMResponse* response = (AppleLLMResponse*)malloc(sizeof(AppleLLMResponse));
+    if (response == NULL) {
+        return NULL;
+    }
+    response->response = NULL;
+    response->success = 0;
+    response->error_message = strdup("Apple Intelligence is not available in this build (Xcode SDK missing).");
+    return response;
+}
+
+void free_apple_llm_response(AppleLLMResponse* response) {
+    if (response == NULL) {
+        return;
+    }
+    if (response->response != NULL) {
+        free(response->response);
+    }
+    if (response->error_message != NULL) {
+        free(response->error_message);
+    }
+    free(response);
+}

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -85,6 +85,14 @@ async changeTranslateToEnglishSetting(enabled: boolean) : Promise<Result<null, s
     else return { status: "error", error: e  as any };
 }
 },
+async changeTranslationTargetLanguageSetting(language: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("change_translation_target_language_setting", { language }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async changeSelectedLanguageSetting(language: string) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("change_selected_language_setting", { language }) };
@@ -916,7 +924,7 @@ bindings?: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk?: boolean
  * upgrading from before this key existed are blanked by the migration so they
  * see the current release's notes — see `apply_settings_migrations`.
  */
-whats_new_last_seen_version?: string; selected_model?: string; onboarding_completed?: boolean; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: SecretMap; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; theme?: Theme; experimental_enabled?: boolean; lazy_stream_close?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; paste_delay_after_ms?: number; typing_tool?: TypingTool; external_script_path?: string | null; custom_filler_words?: string[] | null; transcribe_accelerator?: TranscribeAcceleratorSetting; ort_accelerator?: OrtAcceleratorSetting; transcribe_gpu_device?: number; extra_recording_buffer_ms?: number; vad_enabled?: boolean; 
+whats_new_last_seen_version?: string; selected_model?: string; onboarding_completed?: boolean; always_on_microphone?: boolean; selected_microphone?: string | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; translation_target_language?: string; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: SecretMap; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; theme?: Theme; experimental_enabled?: boolean; lazy_stream_close?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; paste_delay_after_ms?: number; typing_tool?: TypingTool; external_script_path?: string | null; custom_filler_words?: string[] | null; transcribe_accelerator?: TranscribeAcceleratorSetting; ort_accelerator?: OrtAcceleratorSetting; transcribe_gpu_device?: number; extra_recording_buffer_ms?: number; vad_enabled?: boolean; 
 /**
  * Which recording overlay to show: None / Minimal / Live. Streaming mode is
  * not gated on this — that follows model capability. Migrated from the old

--- a/src/components/settings/TranslationSelector.tsx
+++ b/src/components/settings/TranslationSelector.tsx
@@ -1,0 +1,236 @@
+import React, { useState, useRef, useEffect, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { SettingContainer } from "../ui/SettingContainer";
+import { ResetButton } from "../ui/ResetButton";
+import { Alert } from "../ui/Alert";
+import { useSettings } from "../../hooks/useSettings";
+import { useModelStore } from "../../stores/modelStore";
+import {
+  getLanguageLabel,
+  LANGUAGES,
+  SELECTABLE_LANGUAGES,
+} from "../../lib/constants/languages";
+import type { ModelInfo } from "@/bindings";
+
+interface TranslationSelectorProps {
+  descriptionMode?: "inline" | "tooltip";
+  grouped?: boolean;
+}
+
+export const TranslationSelector: React.FC<TranslationSelectorProps> = ({
+  descriptionMode = "tooltip",
+  grouped = false,
+}) => {
+  const { t } = useTranslation();
+  const { getSetting, updateSetting, resetSetting, isUpdating } = useSettings();
+  const { currentModel, models } = useModelStore();
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  const currentModelInfo = models.find((m: ModelInfo) => m.id === currentModel);
+  const modelSupportsTranslation =
+    currentModelInfo?.supports_translation ?? false;
+
+  const translationTarget = getSetting("translation_target_language") || "none";
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+        setSearchQuery("");
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isOpen && searchInputRef.current) {
+      searchInputRef.current.focus();
+    }
+  }, [isOpen]);
+
+  const targetLanguages = useMemo(() => {
+    const baseList = SELECTABLE_LANGUAGES.filter(
+      (lang) => lang.value !== "auto",
+    );
+    return [
+      { value: "none", label: t("settings.general.translation.disabled") },
+      ...baseList,
+    ];
+  }, [t]);
+
+  const filteredLanguages = useMemo(
+    () =>
+      targetLanguages.filter((language) =>
+        language.label.toLowerCase().includes(searchQuery.toLowerCase()),
+      ),
+    [searchQuery, targetLanguages],
+  );
+
+  const selectedLanguageName =
+    translationTarget === "none"
+      ? t("settings.general.translation.disabled")
+      : getLanguageLabel(translationTarget) || translationTarget;
+
+  const handleLanguageSelect = async (languageCode: string) => {
+    await updateSetting("translation_target_language", languageCode);
+    setIsOpen(false);
+    setSearchQuery("");
+  };
+
+  const handleReset = async () => {
+    await resetSetting("translation_target_language");
+  };
+
+  const handleToggle = () => {
+    if (isUpdating("translation_target_language")) return;
+    setIsOpen(!isOpen);
+  };
+
+  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(event.target.value);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter" && filteredLanguages.length > 0) {
+      handleLanguageSelect(filteredLanguages[0].value);
+    } else if (event.key === "Escape") {
+      setIsOpen(false);
+      setSearchQuery("");
+    }
+  };
+
+  // Check if translation requires LLM post-processing and if it's configured
+  const requiresLlm =
+    translationTarget !== "none" &&
+    !(translationTarget === "en" && modelSupportsTranslation);
+
+  const providerId = getSetting("post_process_provider_id") || "";
+  const apiKeys = getSetting("post_process_api_keys") || {};
+  const activeKey = providerId ? apiKeys[providerId] : "";
+  const isLlmConfigured =
+    providerId === "apple_intelligence" ||
+    (activeKey && activeKey.trim() !== "");
+
+  const showModelWarning =
+    translationTarget === "en" && !modelSupportsTranslation && !isLlmConfigured;
+
+  const showLlmWarning = requiresLlm && !isLlmConfigured && !showModelWarning;
+
+  return (
+    <div className="flex flex-col w-full">
+      <SettingContainer
+        title={t("settings.general.translation.label")}
+        description={t("settings.general.translation.description")}
+        descriptionMode={descriptionMode}
+        grouped={grouped}
+      >
+        <div className="flex items-center space-x-1">
+          <div className="relative" ref={dropdownRef}>
+            <button
+              type="button"
+              className={`px-2 py-1 text-sm font-semibold bg-mid-gray/10 border border-mid-gray/80 rounded min-w-[200px] text-start flex items-center justify-between transition-all duration-150 ${
+                isUpdating("translation_target_language")
+                  ? "opacity-50 cursor-not-allowed"
+                  : "hover:bg-logo-primary/10 cursor-pointer hover:border-logo-primary"
+              }`}
+              onClick={handleToggle}
+              disabled={isUpdating("translation_target_language")}
+            >
+              <span className="truncate">{selectedLanguageName}</span>
+              <svg
+                className={`w-4 h-4 ms-2 transition-transform duration-200 ${
+                  isOpen ? "transform rotate-180" : ""
+                }`}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M19 9l-7 7-7-7"
+                />
+              </svg>
+            </button>
+
+            {isOpen && !isUpdating("translation_target_language") && (
+              <div className="absolute top-full left-0 right-0 mt-1 bg-background border border-mid-gray/80 rounded shadow-lg z-50 max-h-60 overflow-hidden">
+                <div className="p-2 border-b border-mid-gray/80">
+                  <input
+                    ref={searchInputRef}
+                    type="text"
+                    value={searchQuery}
+                    onChange={handleSearchChange}
+                    onKeyDown={handleKeyDown}
+                    placeholder={t(
+                      "settings.general.language.searchPlaceholder",
+                    )}
+                    className="w-full px-2 py-1 text-sm bg-mid-gray/10 border border-mid-gray/40 rounded focus:outline-none focus:ring-1 focus:ring-logo-primary focus:border-logo-primary"
+                  />
+                </div>
+
+                <div className="max-h-48 overflow-y-auto">
+                  {filteredLanguages.length === 0 ? (
+                    <div className="px-2 py-2 text-sm text-mid-gray text-center">
+                      {t("settings.general.language.noResults")}
+                    </div>
+                  ) : (
+                    filteredLanguages.map((language) => (
+                      <button
+                        key={language.value}
+                        type="button"
+                        className={`w-full px-2 py-1 text-sm text-start hover:bg-logo-primary/10 transition-colors duration-150 ${
+                          translationTarget === language.value
+                            ? "bg-logo-primary/20 text-logo-primary font-semibold"
+                            : "text-text"
+                        }`}
+                        onClick={() => handleLanguageSelect(language.value)}
+                      >
+                        {language.label}
+                      </button>
+                    ))
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {translationTarget !== "none" && (
+            <ResetButton
+              onClick={handleReset}
+              disabled={isUpdating("translation_target_language")}
+              ariaLabel={t("settings.general.language.reset")}
+            />
+          )}
+        </div>
+      </SettingContainer>
+
+      {showModelWarning && (
+        <div className="mt-2 px-4 pb-2">
+          <Alert variant="warning" contained>
+            {t("settings.general.translation.modelWarning")}
+          </Alert>
+        </div>
+      )}
+
+      {showLlmWarning && (
+        <div className="mt-2 px-4 pb-2">
+          <Alert variant="warning" contained>
+            {t("settings.general.translation.warning")}
+          </Alert>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/settings/general/ModelSettingsCard.tsx
+++ b/src/components/settings/general/ModelSettingsCard.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { SettingsGroup } from "../../ui/SettingsGroup";
 import { LanguageSelector } from "../LanguageSelector";
-import { TranslateToEnglish } from "../TranslateToEnglish";
+import { TranslationSelector } from "../TranslationSelector";
 import { useModelStore } from "../../../stores/modelStore";
 import type { ModelInfo } from "@/bindings";
 import {
@@ -26,11 +26,9 @@ export const ModelSettingsCard: React.FC = () => {
     capabilityLanguages[0] === CHINESE_LANGUAGE_CODE;
   const showLanguageSelector =
     supportsLanguageSelection || supportsChineseOnlyScriptSelection;
-  const supportsTranslation = currentModelInfo?.supports_translation ?? false;
-  const hasAnySettings = showLanguageSelector || supportsTranslation;
 
-  // Don't render anything if no model is selected or no settings available
-  if (!currentModel || !currentModelInfo || !hasAnySettings) {
+  // Don't render anything if no model is selected
+  if (!currentModel || !currentModelInfo) {
     return null;
   }
 
@@ -50,9 +48,7 @@ export const ModelSettingsCard: React.FC = () => {
           }
         />
       )}
-      {supportsTranslation && (
-        <TranslateToEnglish descriptionMode="tooltip" grouped={true} />
-      )}
+      <TranslationSelector descriptionMode="tooltip" grouped={true} />
     </SettingsGroup>
   );
 };

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -19,6 +19,7 @@ export { GlobalShortcutInput } from "./GlobalShortcutInput";
 export { HandyKeysShortcutInput } from "./HandyKeysShortcutInput";
 export { ShortcutInput } from "./ShortcutInput";
 export { TranslateToEnglish } from "./TranslateToEnglish";
+export { TranslationSelector } from "./TranslationSelector";
 export { CustomWords } from "./CustomWords";
 export { PostProcessingToggle } from "./PostProcessingToggle";
 export { PostProcessingSettingsApi } from "./PostProcessingSettingsApi";

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -194,6 +194,13 @@
         "noResults": "No languages found",
         "auto": "Auto"
       },
+      "translation": {
+        "label": "Translate To",
+        "description": "Translate transcribed text to a target language. Gated Whisper models translate to English offline; other languages or models require an LLM API configured in Post-Processing.",
+        "disabled": "None (Disabled)",
+        "warning": "To translate using this model or to this language, please configure and enable an LLM provider in the Post-Processing tab.",
+        "modelWarning": "Your current model does not support translation. Switch to a Whisper model (Small, Medium, or Large) for translation to work."
+      },
       "pushToTalk": {
         "label": "Push To Talk",
         "description": "Hold to record, release to stop"

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -113,6 +113,8 @@ const settingUpdaters: {
     commands.updateRecordingRetentionPeriod(value as string),
   translate_to_english: (value) =>
     commands.changeTranslateToEnglishSetting(value as boolean),
+  translation_target_language: (value) =>
+    commands.changeTranslationTargetLanguageSetting(value as string),
   selected_language: (value) =>
     commands.changeSelectedLanguageSetting(value as string),
   overlay_position: (value) =>


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched existing issues and pull requests (including closed ones) to ensure this isn't a duplicate
- [x] I have read CONTRIBUTING.md

## Human Written Description

I noticed that when enabling speech translation to English, Handy silently does nothing if the selected model doesn't support translation (e.g. Parakeet or Nemotron). This PR adds a clear warning alert in the settings UI to guide users to switch to a translation-supporting Whisper model when "Translate to English" is selected.

## Related Issues/Discussions

This issue was identified during active translation testing.
Fixes # (Leave blank if there is no issue number yet)

## Community Feedback

N/A (This is a bug fix / UX improvement rather than a new feature request).

## Testing

I manually tested this in `tauri dev` mode on macOS:
1. Checked with a non-translation-capable model (like Parakeet/Nemotron) and verified the warning alert shows up in Settings.
2. Verified switching to a Whisper model (like Whisper Small) removes the warning alert and speech translation succeeds.
3. Verified frontend types, building, and code quality successfully via `bun run lint` and `bun run format`.

## Screenshots/Videos (if applicable)

N/A

## AI Assistance

- [x] AI was used

**If AI was used:**

- Tools used: Gemini
- How extensively: Assisted in debugging CMake registry compilation errors and Swift toolchain mismatch issues on macOS Command Line Tools, wrote the C stub fallback for Apple Intelligence, and implemented the frontend TranslationSelector alert UI and settings integrations.
<img width="690" height="578" alt="Image 31-07-26 at 1 00 PM" src="https://github.com/user-attachments/assets/f0722ef7-8491-4ec7-9d92-7d6b0f8679fc" />
