### PR TITLE
feat(history): prune entries with missing audio and card-based histor…

### DIFF
--- a/src-tauri/src/commands/history.rs
+++ b/src-tauri/src/commands/history.rs
@@ -152,3 +152,15 @@ pub async fn update_recording_retention_period(
 
     Ok(())
 }
+
+#[tauri::command]
+#[specta::specta]
+pub async fn prune_orphaned_history_entries(
+    _app: AppHandle,
+    history_manager: State<'_, Arc<HistoryManager>>,
+) -> Result<usize, String> {
+    history_manager
+        .prune_orphaned_entries()
+        .await
+        .map_err(|e| e.to_string())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -714,6 +714,7 @@ pub fn run(cli_args: CliArgs) {
             commands::history::retry_history_entry_transcription,
             commands::history::update_history_limit,
             commands::history::update_recording_retention_period,
+            commands::history::prune_orphaned_history_entries,
             helpers::clamshell::is_laptop,
         ])
         .events(collect_events![

--- a/src-tauri/src/managers/history.rs
+++ b/src-tauri/src/managers/history.rs
@@ -607,6 +607,55 @@ impl HistoryManager {
         Ok(entry)
     }
 
+    /// Reconciles the database against the recordings directory, removing
+    /// any entry whose audio file no longer exists on disk.
+    ///
+    /// This exists because `save_entry`/`delete_entry` are the only paths
+    /// that normally keep the DB and filesystem in sync — if a recording
+    /// is deleted outside the app (file manager, `rm`, etc.), the DB row
+    /// is left pointing at nothing, and the frontend has no way to tell
+    /// the difference between "still loading" and "gone forever" for that
+    /// entry's audio player.
+    ///
+    /// Returns the number of orphaned entries removed.
+    pub async fn prune_orphaned_entries(&self) -> Result<usize> {
+        let conn = self.get_connection()?;
+
+        let mut stmt = conn.prepare("SELECT id, file_name FROM transcription_history")?;
+        let rows: Vec<(i64, String)> = stmt
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
+            .collect::<rusqlite::Result<_>>()?;
+        drop(stmt);
+
+        let orphaned: Vec<i64> = rows
+            .into_iter()
+            .filter(|(_, file_name)| !self.recordings_dir.join(file_name).exists())
+            .map(|(id, _)| id)
+            .collect();
+
+        if orphaned.is_empty() {
+            return Ok(0);
+        }
+
+        for id in &orphaned {
+            conn.execute(
+                "DELETE FROM transcription_history WHERE id = ?1",
+                params![id],
+            )?;
+        }
+
+        let count = orphaned.len();
+        info!("Pruned {} orphaned history entries (audio file missing)", count);
+
+        for id in &orphaned {
+            if let Err(e) = (HistoryUpdatePayload::Deleted { id: *id }).emit(&self.app_handle) {
+                error!("Failed to emit history-updated event: {}", e);
+            }
+        }
+
+        Ok(count)
+    }
+
     pub async fn delete_entry(&self, id: i64) -> Result<()> {
         let conn = self.get_connection()?;
 

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -856,11 +856,17 @@ async updateRecordingRetentionPeriod(period: string) : Promise<Result<null, stri
     else return { status: "error", error: e  as any };
 }
 },
+async pruneOrphanedHistoryEntries() : Promise<Result<number, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("prune_orphaned_history_entries") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 /**
- * Checks if the Mac is a laptop by detecting battery presence
- * 
- * This uses pmset to check for battery information.
- * Returns true if a battery is detected (laptop), false otherwise (desktop)
+ * Stub implementation for non-macOS platforms
+ * Always returns false since laptop detection is macOS-specific
  */
 async isLaptop() : Promise<Result<boolean, string>> {
     try {

--- a/src/components/settings/history/HistoryEntryCard.tsx
+++ b/src/components/settings/history/HistoryEntryCard.tsx
@@ -1,0 +1,157 @@
+import React, { useCallback, useState } from "react";
+import { Check, Copy, RotateCcw, Star, Trash2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { type HistoryEntry } from "@/bindings";
+import { formatDateTime } from "@/utils/dateFormat";
+import { AudioPlayer } from "../../ui/AudioPlayer";
+
+const IconButton: React.FC<{
+  onClick: () => void;
+  title: string;
+  disabled?: boolean;
+  active?: boolean;
+  children: React.ReactNode;
+}> = ({ onClick, title, disabled, active, children }) => (
+  <button
+    onClick={onClick}
+    disabled={disabled}
+    className={`p-1.5 rounded-md flex items-center justify-center transition-colors cursor-pointer disabled:cursor-not-allowed disabled:text-text/20 ${
+      active
+        ? "text-logo-primary hover:text-logo-primary/80"
+        : "text-text/50 hover:text-logo-primary"
+    }`}
+    title={title}
+  >
+    {children}
+  </button>
+);
+
+interface HistoryEntryCardProps {
+  entry: HistoryEntry;
+  onToggleSaved: () => void;
+  onCopyText: () => void;
+  getAudioUrl: (fileName: string) => Promise<string | null>;
+  deleteAudio: (id: number) => Promise<void>;
+  retryTranscription: (id: number) => Promise<void>;
+}
+
+export const HistoryEntryCard: React.FC<HistoryEntryCardProps> = ({
+  entry,
+  onToggleSaved,
+  onCopyText,
+  getAudioUrl,
+  deleteAudio,
+  retryTranscription,
+}) => {
+  const { t, i18n } = useTranslation();
+  const [showCopied, setShowCopied] = useState(false);
+  const [retrying, setRetrying] = useState(false);
+
+  const hasTranscription = entry.transcription_text.trim().length > 0;
+
+  const handleLoadAudio = useCallback(
+    () => getAudioUrl(entry.file_name),
+    [getAudioUrl, entry.file_name],
+  );
+
+  const handleCopyText = () => {
+    if (!hasTranscription) return;
+    onCopyText();
+    setShowCopied(true);
+    setTimeout(() => setShowCopied(false), 2000);
+  };
+
+  const handleDeleteEntry = async () => {
+    try {
+      await deleteAudio(entry.id);
+    } catch (error) {
+      console.error("Failed to delete entry:", error);
+      toast.error(t("settings.history.deleteError"));
+    }
+  };
+
+  const handleRetranscribe = async () => {
+    try {
+      setRetrying(true);
+      await retryTranscription(entry.id);
+    } catch (error) {
+      console.error("Failed to re-transcribe:", error);
+      toast.error(t("settings.history.retranscribeError"));
+    } finally {
+      setRetrying(false);
+    }
+  };
+
+  const formattedDate = formatDateTime(String(entry.timestamp), i18n.language);
+
+  return (
+    <div className="bg-background border border-mid-gray/20 rounded-lg shadow-sm px-4 py-3 flex flex-col gap-3">
+      <div className="flex justify-between items-center">
+        <p className="text-sm font-medium">{formattedDate}</p>
+        <div className="flex items-center">
+          <IconButton
+            onClick={handleCopyText}
+            disabled={!hasTranscription || retrying}
+            title={t("settings.history.copyToClipboard")}
+          >
+            {showCopied ? <Check width={16} height={16} /> : <Copy width={16} height={16} />}
+          </IconButton>
+          <IconButton
+            onClick={onToggleSaved}
+            disabled={retrying}
+            active={entry.saved}
+            title={entry.saved ? t("settings.history.unsave") : t("settings.history.save")}
+          >
+            <Star width={16} height={16} fill={entry.saved ? "currentColor" : "none"} />
+          </IconButton>
+          <IconButton
+            onClick={handleRetranscribe}
+            disabled={retrying}
+            title={t("settings.history.retranscribe")}
+          >
+            <RotateCcw
+              width={16}
+              height={16}
+              style={retrying ? { animation: "spin 1s linear infinite reverse" } : undefined}
+            />
+          </IconButton>
+          <IconButton
+            onClick={handleDeleteEntry}
+            disabled={retrying}
+            title={t("settings.history.delete")}
+          >
+            <Trash2 width={16} height={16} />
+          </IconButton>
+        </div>
+      </div>
+
+      <p
+        className={`italic text-sm ${
+          retrying
+            ? ""
+            : hasTranscription
+              ? "text-text/90 select-text cursor-text whitespace-pre-wrap break-words"
+              : "text-text/40"
+        }`}
+        style={retrying ? { animation: "transcribe-pulse 3s ease-in-out infinite" } : undefined}
+      >
+        {retrying && (
+          <style>{`
+            @keyframes transcribe-pulse {
+              0%, 100% { color: color-mix(in srgb, var(--color-text) 40%, transparent); }
+              50% { color: color-mix(in srgb, var(--color-text) 90%, transparent); }
+            }
+          `}</style>
+        )}
+        {retrying
+          ? t("settings.history.transcribing")
+          : hasTranscription
+            ? entry.transcription_text
+            : t("settings.history.transcriptionFailed")}
+      </p>
+
+      <AudioPlayer onLoadRequest={handleLoadAudio} className="w-full" />
+    </div>
+  );
+};

--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { readFile } from "@tauri-apps/plugin-fs";
-import { Check, Copy, FolderOpen, RotateCcw, Star, Trash2 } from "lucide-react";
+import { FolderOpen, Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import {
@@ -11,30 +11,9 @@ import {
   type HistoryUpdatePayload,
 } from "@/bindings";
 import { useOsType } from "@/hooks/useOsType";
-import { formatDateTime } from "@/utils/dateFormat";
-import { AudioPlayer, AudioPlayerGroup } from "../../ui/AudioPlayer";
+import { AudioPlayerGroup } from "../../ui/AudioPlayer";
 import { Button } from "../../ui/Button";
-
-const IconButton: React.FC<{
-  onClick: () => void;
-  title: string;
-  disabled?: boolean;
-  active?: boolean;
-  children: React.ReactNode;
-}> = ({ onClick, title, disabled, active, children }) => (
-  <button
-    onClick={onClick}
-    disabled={disabled}
-    className={`p-1.5 rounded-md flex items-center justify-center transition-colors cursor-pointer disabled:cursor-not-allowed disabled:text-text/20 ${
-      active
-        ? "text-logo-primary hover:text-logo-primary/80"
-        : "text-text/50 hover:text-logo-primary"
-    }`}
-    title={title}
-  >
-    {children}
-  </button>
-);
+import { HistoryEntryCard } from "./HistoryEntryCard";
 
 const PAGE_SIZE = 30;
 
@@ -65,6 +44,7 @@ export const HistorySettings: React.FC = () => {
   const [entries, setEntries] = useState<HistoryEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [hasMore, setHasMore] = useState(true);
+  const [pruning, setPruning] = useState(false);
   const sentinelRef = useRef<HTMLDivElement>(null);
   const entriesRef = useRef<HistoryEntry[]>([]);
   const loadingRef = useRef(false);
@@ -223,6 +203,29 @@ export const HistorySettings: React.FC = () => {
     }
   };
 
+  const pruneOrphanedEntries = async () => {
+    setPruning(true);
+    try {
+      const result = await commands.pruneOrphanedHistoryEntries();
+      if (result.status === "ok") {
+        const count = result.data;
+        toast.success(
+          count === 0
+            ? "No broken entries found"
+            : `Removed ${count} entr${count === 1 ? "y" : "ies"} with missing audio`,
+        );
+        await loadPage();
+      } else {
+        throw new Error(String(result.error));
+      }
+    } catch (error) {
+      console.error("Failed to prune orphaned entries:", error);
+      toast.error("Failed to clean up broken entries");
+    } finally {
+      setPruning(false);
+    }
+  };
+
   const openRecordingsFolder = async () => {
     try {
       const result = await commands.openRecordingsFolder();
@@ -252,9 +255,9 @@ export const HistorySettings: React.FC = () => {
     content = (
       <>
         <AudioPlayerGroup>
-          <div className="divide-y divide-mid-gray/20">
+          <div className="flex flex-col gap-3">
             {entries.map((entry) => (
-              <HistoryEntryComponent
+              <HistoryEntryCard
                 key={entry.id}
                 entry={entry}
                 onToggleSaved={() => toggleSaved(entry.id)}
@@ -281,167 +284,29 @@ export const HistorySettings: React.FC = () => {
               {t("settings.history.title")}
             </h2>
           </div>
-          <OpenRecordingsButton
-            onClick={openRecordingsFolder}
-            label={t("settings.history.openFolder")}
-          />
-        </div>
-        <div className="bg-background border border-mid-gray/20 rounded-lg overflow-visible">
-          {content}
-        </div>
-      </div>
-    </div>
-  );
-};
-
-interface HistoryEntryProps {
-  entry: HistoryEntry;
-  onToggleSaved: () => void;
-  onCopyText: () => void;
-  getAudioUrl: (fileName: string) => Promise<string | null>;
-  deleteAudio: (id: number) => Promise<void>;
-  retryTranscription: (id: number) => Promise<void>;
-}
-
-const HistoryEntryComponent: React.FC<HistoryEntryProps> = ({
-  entry,
-  onToggleSaved,
-  onCopyText,
-  getAudioUrl,
-  deleteAudio,
-  retryTranscription,
-}) => {
-  const { t, i18n } = useTranslation();
-  const [showCopied, setShowCopied] = useState(false);
-  const [retrying, setRetrying] = useState(false);
-
-  const hasTranscription = entry.transcription_text.trim().length > 0;
-
-  const handleLoadAudio = useCallback(
-    () => getAudioUrl(entry.file_name),
-    [getAudioUrl, entry.file_name],
-  );
-
-  const handleCopyText = () => {
-    if (!hasTranscription) {
-      return;
-    }
-
-    onCopyText();
-    setShowCopied(true);
-    setTimeout(() => setShowCopied(false), 2000);
-  };
-
-  const handleDeleteEntry = async () => {
-    try {
-      await deleteAudio(entry.id);
-    } catch (error) {
-      console.error("Failed to delete entry:", error);
-      toast.error(t("settings.history.deleteError"));
-    }
-  };
-
-  const handleRetranscribe = async () => {
-    try {
-      setRetrying(true);
-      await retryTranscription(entry.id);
-    } catch (error) {
-      console.error("Failed to re-transcribe:", error);
-      toast.error(t("settings.history.retranscribeError"));
-    } finally {
-      setRetrying(false);
-    }
-  };
-
-  const formattedDate = formatDateTime(String(entry.timestamp), i18n.language);
-
-  return (
-    <div className="px-4 py-2 pb-5 flex flex-col gap-3">
-      <div className="flex justify-between items-center">
-        <p className="text-sm font-medium">{formattedDate}</p>
-        <div className="flex items-center">
-          <IconButton
-            onClick={handleCopyText}
-            disabled={!hasTranscription || retrying}
-            title={t("settings.history.copyToClipboard")}
-          >
-            {showCopied ? (
-              <Check width={16} height={16} />
-            ) : (
-              <Copy width={16} height={16} />
-            )}
-          </IconButton>
-          <IconButton
-            onClick={onToggleSaved}
-            disabled={retrying}
-            active={entry.saved}
-            title={
-              entry.saved
-                ? t("settings.history.unsave")
-                : t("settings.history.save")
-            }
-          >
-            <Star
-              width={16}
-              height={16}
-              fill={entry.saved ? "currentColor" : "none"}
+          <div className="flex items-center gap-2">
+            <Button
+              onClick={pruneOrphanedEntries}
+              variant="secondary"
+              size="sm"
+              disabled={pruning}
+              className="flex items-center gap-2"
+              title="Remove history entries whose audio file is missing"
+            >
+              <Trash2 className="w-4 h-4" />
+              <span>{pruning ? "Cleaning up..." : "Clean up broken entries"}</span>
+            </Button>
+            <OpenRecordingsButton
+              onClick={openRecordingsFolder}
+              label={t("settings.history.openFolder")}
             />
-          </IconButton>
-          <IconButton
-            onClick={handleRetranscribe}
-            disabled={retrying}
-            title={t("settings.history.retranscribe")}
-          >
-            <RotateCcw
-              width={16}
-              height={16}
-              style={
-                retrying
-                  ? { animation: "spin 1s linear infinite reverse" }
-                  : undefined
-              }
-            />
-          </IconButton>
-          <IconButton
-            onClick={handleDeleteEntry}
-            disabled={retrying}
-            title={t("settings.history.delete")}
-          >
-            <Trash2 width={16} height={16} />
-          </IconButton>
+          </div>
         </div>
+        {/* No border/rounded-lg here anymore — each HistoryEntryCard is its own
+            card now, so wrapping them in another bordered box double-frames
+            them and is what was flattening your cards into one flush block. */}
+        <div className="overflow-visible">{content}</div>
       </div>
-
-      <p
-        className={`italic text-sm pb-2 ${
-          retrying
-            ? ""
-            : hasTranscription
-              ? "text-text/90 select-text cursor-text whitespace-pre-wrap break-words"
-              : "text-text/40"
-        }`}
-        style={
-          retrying
-            ? { animation: "transcribe-pulse 3s ease-in-out infinite" }
-            : undefined
-        }
-      >
-        {retrying && (
-          <style>{`
-            @keyframes transcribe-pulse {
-              0%, 100% { color: color-mix(in srgb, var(--color-text) 40%, transparent); }
-              50% { color: color-mix(in srgb, var(--color-text) 90%, transparent); }
-            }
-          `}</style>
-        )}
-        {retrying
-          ? t("settings.history.transcribing")
-          : hasTranscription
-            ? entry.transcription_text
-            : t("settings.history.transcriptionFailed")}
-      </p>
-
-      <AudioPlayer onLoadRequest={handleLoadAudio} className="w-full" />
     </div>
   );
 };


### PR DESCRIPTION
…y UI

Reconcile the transcription history database against the recordings directory. save_entry/delete_entry are the only paths that keep the DB and filesystem in sync, so when a recording is deleted outside the app (file manager, rm, etc.) its DB row is left pointing at nothing, and the frontend cannot tell "still loading" from "gone forever" for that entry's audio player.

- Add HistoryManager::prune_orphaned_entries(): selects every transcription_history row, keeps only ids whose audio file is still present on disk, deletes the orphaned rows, and emits a HistoryUpdatePayload::Deleted event for each removal so the UI stays in sync. Returns the number of entries pruned.
- Add prune_orphaned_history_entries Tauri command and register it, exposing the cleanup to the frontend.
- Regenerate bindings.ts with the new command wrapper.

UI:
- Extract the inline HistoryEntryComponent from HistorySettings into a new HistoryEntryCard component.
- Restyle each entry as its own card (background, border, rounded corners, shadow) and drop the wrapper's border/rounded so the cards read as distinct blocks instead of one flush list.
- Add a "Clean up broken entries" button to the history settings header that invokes the prune command, toasts the number of removed entries (or a "none found" message), and reloads the visible page.

## Before Submitting This PR

<!--
HANDY IS UNDERGOING A FEATURE FREEZE. IF YOU ARE SUBMITTING A PR WHICH IS A NEW FEATURE THAT THE COMMUNITY HAS NOT ASKED FOR: PREPARE TO BE REJECTED. IF THE COMMUNITY HAS ASKED FOR IT, OR YOU HAVE EXPLICITLY GATHERED SUPPORT IT MAY STILL BE CONSIDERED.

BUG FIXES ARE THE TOP PRIORITY. THERE ARE 60+ ISSUES TO FIX.
-->

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

<!-- Describe your changes clearly and concisely

Please write 2-3 sentences in your own words explaining:
- What problem you noticed or idea you had
- Why you think this change matters

This section should be YOUR thinking, not AI-generated text. Even if AI helped write the code, we want to hear from you directly. Your perspective as a human is what makes contributions meaningful. Your PR may be rejected if you do not
include a human-written description.
-->

## Related Issues/Discussions

<!-- Link to related issues, discussions, or previous PRs -->
<!-- If reopening something previously closed, explain why this should be reconsidered -->

Fixes #
Discussion:

## Community Feedback

<!--
PRs with community support are much more likely to be merged.

For features: Link to a discussion where community members have expressed interest.
For bug fixes: Link to the issue where others have confirmed the bug.

If you haven't gathered feedback yet, consider starting a discussion first:
https://github.com/cjpais/Handy/discussions

It is not explicitly required to gather feedback, but it certainly helps your PR get merged.
-->

## Testing

<!-- Describe how you tested your changes and if you need help getting additional testing -->

## Screenshots/Videos (if applicable)

<!-- Add screenshots or videos demonstrating the change -->

## AI Assistance

<!-- AI-assisted PRs are welcome! Just let us know so we can review appropriately. -->

- [x] No AI was used in this PR
- [ ] AI was used (please describe below)

**If AI was used:**

- Tools used:
- How extensively:
