### PR TITLE
feat: Add microphone selection to system tray menu

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -307,6 +307,25 @@ fn initialize_core_logic(app_handle: &AppHandle) {
                     tray::update_tray_menu(&app_clone, None);
                 });
             }
+            id if id.starts_with("mic_select:") => {
+                let mic_id = id.strip_prefix("mic_select:").unwrap().to_string();
+                let current_mic = commands::audio::get_selected_microphone(app.clone()).unwrap_or_else(|_| "default".to_string());
+                if mic_id == current_mic {
+                    return;
+                }
+                let app_clone = app.clone();
+                std::thread::spawn(move || {
+                    match commands::audio::set_selected_microphone(app_clone.clone(), mic_id.clone()) {
+                        Ok(()) => {
+                            log::info!("Microphone switched to {} via tray.", mic_id);
+                        }
+                        Err(e) => {
+                            log::error!("Failed to switch microphone via tray: {}", e);
+                        }
+                    }
+                    tray::update_tray_menu(&app_clone, None);
+                });
+            }
             _ => {}
         })
         .build(app_handle)

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -271,6 +271,28 @@ pub fn update_tray_menu(app: &AppHandle, locale: Option<&str>) {
         submenu
     };
 
+    let microphone_submenu = {
+        let submenu = Submenu::with_id(app, "microphone_submenu", &strings.microphone, true)
+            .expect("failed to create microphone submenu");
+            
+        let available_mics = crate::commands::audio::get_available_microphones().unwrap_or_default();
+        let selected_mic = crate::commands::audio::get_selected_microphone(app.clone()).unwrap_or_else(|_| "default".to_string());
+        
+        for mic in &available_mics {
+            let is_active = if selected_mic == "default" {
+                mic.index == "default"
+            } else {
+                mic.name == selected_mic
+            };
+            
+            let item_id = format!("mic_select:{}", if mic.index == "default" { "default" } else { &mic.name });
+            let item = CheckMenuItem::with_id(app, &item_id, &mic.name, true, is_active, None::<&str>)
+                .expect("failed to create mic item");
+            let _ = submenu.append(&item);
+        }
+        submenu
+    };
+
     let unload_model_i = MenuItem::with_id(
         app,
         "unload_model",
@@ -310,6 +332,7 @@ pub fn update_tray_menu(app: &AppHandle, locale: Option<&str>) {
                 &separator(),
                 &model_submenu,
                 &unload_model_i,
+                &microphone_submenu,
                 &separator(),
                 &settings_i,
                 &check_updates_i,

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -7,7 +7,8 @@
     "model": "Model",
     "quit": "Quit",
     "cancel": "Cancel",
-    "secureInputWarning": "⚠ Shortcuts blocked by Secure Input"
+    "secureInputWarning": "⚠ Shortcuts blocked by Secure Input",
+    "microphone": "Microphone"
   },
   "sidebar": {
     "general": "General",

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -7,7 +7,8 @@
     "model": "Модель",
     "quit": "Выход",
     "cancel": "Отмена",
-    "secureInputWarning": "⚠ Сочетания клавиш заблокированы Secure Input"
+    "secureInputWarning": "⚠ Сочетания клавиш заблокированы Secure Input",
+    "microphone": "Микрофон"
   },
   "sidebar": {
     "general": "Общие",


### PR DESCRIPTION
Hi! Thanks for the amazing app. 

I found myself frequently needing to switch input devices, so I added a dynamic "Microphone" submenu to the system tray (placed right below the Model selection). 

**Changes included:**
* Added a tray menu builder for available microphones in `tray.rs`.
* Reused the existing `commands::audio::get_available_microphones` and `set_selected_microphone` to handle the logic.
* Added `mic_select:*` event handling in `lib.rs` to seamlessly switch the active microphone and refresh the tray UI.
* Added the "Microphone" translation key to both English and Russian locales.

Tested locally and works perfectly. Let me know if any adjustments are needed!