### PR TITLE
fix: recover microphone stream after the capture worker dies

### DIFF
--- a/src-tauri/src/audio_toolkit/audio/recorder.rs
+++ b/src-tauri/src/audio_toolkit/audio/recorder.rs
@@ -138,7 +138,14 @@ impl AudioRecorder {
 
     pub fn open(&mut self, device: Option<Device>) -> Result<(), Box<dyn std::error::Error>> {
         if self.worker_handle.is_some() {
-            return Ok(()); // already open
+            if !self.is_capture_worker_dead() {
+                return Ok(()); // already open
+            }
+            // The worker exited on its own (see `is_capture_worker_dead`). Reap
+            // it so we rebuild the stream below instead of handing the caller
+            // back a recorder whose channels are already closed.
+            log::warn!("Capture worker exited; rebuilding microphone stream");
+            let _ = self.close();
         }
 
         let (sample_tx, sample_rx) = mpsc::channel::<AudioChunk>();
@@ -331,6 +338,20 @@ impl AudioRecorder {
         Ok(resp_rx.recv()?) // wait for the samples
     }
 
+    /// True once the capture worker has exited without anyone calling `close`.
+    ///
+    /// `run_consumer` is driven entirely by the sample channel, so when cpal
+    /// tears the stream down mid-session (device unplugged, USB/Bluetooth
+    /// dropout) `sample_rx.recv()` returns `Err`, the loop ends and the worker
+    /// thread finishes. `cmd_tx` and `worker_handle` are still populated at
+    /// that point, so the recorder looks open from the outside while every
+    /// command sent to it fails on a closed channel.
+    pub fn is_capture_worker_dead(&self) -> bool {
+        self.worker_handle
+            .as_ref()
+            .is_some_and(|handle| handle.is_finished())
+    }
+
     pub fn close(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         if let Some(tx) = self.cmd_tx.take() {
             let _ = tx.send(Cmd::Shutdown);
@@ -472,7 +493,16 @@ pub fn is_no_input_device_error(error_message: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_microphone_access_denied, is_no_input_device_error};
+    use super::{is_microphone_access_denied, is_no_input_device_error, AudioRecorder};
+
+    #[test]
+    fn unopened_recorder_is_not_reported_dead() {
+        // No worker has been spawned yet, so there is nothing to reap. Guards
+        // against inverting the "no worker" case, which would make every first
+        // open() take the rebuild path.
+        let recorder = AudioRecorder::new().expect("recorder");
+        assert!(!recorder.is_capture_worker_dead());
+    }
 
     #[test]
     fn detects_access_is_denied() {

--- a/src-tauri/src/managers/audio.rs
+++ b/src-tauri/src/managers/audio.rs
@@ -10,7 +10,7 @@ use crate::helpers::clamshell;
 use crate::managers::transcription::StreamRouter;
 use crate::settings::{get_settings, AppSettings};
 use crate::utils;
-use log::{debug, error, info, warn};
+use log::{debug, error, info, trace, warn};
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -532,7 +532,10 @@ impl AudioRecordingManager {
                 .is_some_and(|rec| rec.is_capture_worker_dead());
 
             if !worker_dead {
-                debug!("Microphone stream already active");
+                // trace, not debug: with the aliveness check in
+                // try_start_recording this now fires on every keypress in
+                // always-on mode.
+                trace!("Microphone stream already active");
                 return Ok(());
             }
 
@@ -680,15 +683,18 @@ impl AudioRecordingManager {
         let mut state = self.state.lock().unwrap();
 
         if let RecordingState::Idle = *state {
-            // Ensure microphone is open in on-demand mode
-            if matches!(*self.mode.lock().unwrap(), MicrophoneMode::OnDemand) {
-                // Cancel any pending lazy close
-                self.close_generation.fetch_add(1, Ordering::SeqCst);
-                if let Err(e) = self.start_microphone_stream() {
-                    let msg = format!("{e}");
-                    error!("Failed to open microphone stream: {msg}");
-                    return Err(msg);
-                }
+            // Cancel any pending lazy close (no-op in always-on mode, where
+            // closes are never scheduled).
+            self.close_generation.fetch_add(1, Ordering::SeqCst);
+            // Opens the stream in on-demand mode. In always-on mode the stream
+            // is normally already open and this is a cheap aliveness check —
+            // but if the capture worker died (device disconnect), it rebuilds
+            // the stream instead of leaving every subsequent start wedged on
+            // "Recorder not available".
+            if let Err(e) = self.start_microphone_stream() {
+                let msg = format!("{e}");
+                error!("Failed to open microphone stream: {msg}");
+                return Err(msg);
             }
 
             if let Some(rec) = self.recorder.lock().unwrap().as_ref() {

--- a/src-tauri/src/managers/audio.rs
+++ b/src-tauri/src/managers/audio.rs
@@ -518,8 +518,43 @@ impl AudioRecordingManager {
     pub fn start_microphone_stream(&self) -> Result<(), anyhow::Error> {
         let mut open_flag = self.is_open.lock().unwrap();
         if *open_flag {
-            debug!("Microphone stream already active");
-            return Ok(());
+            // `is_open` only records that we opened a stream at some point, not
+            // that one is still running. If the capture worker has since exited
+            // (mic unplugged mid-session, USB dropout), returning Ok here hands
+            // the caller a dead recorder: it captures nothing, then fails in
+            // stop() on the closed channel, and stays wedged until the
+            // on-demand close timeout eventually resets the manager.
+            let worker_dead = self
+                .recorder
+                .lock()
+                .unwrap()
+                .as_ref()
+                .is_some_and(|rec| rec.is_capture_worker_dead());
+
+            if !worker_dead {
+                debug!("Microphone stream already active");
+                return Ok(());
+            }
+
+            warn!("Microphone stream is no longer running (device disconnected?); reopening");
+
+            // Torn down inline rather than via stop_microphone_stream(), which
+            // takes the `is_open` lock we are already holding.
+            {
+                let mut mute_guard = self.mute_state.lock().unwrap();
+                if mute_guard.did_mute {
+                    restore_mute(mute_guard.prev_muted);
+                    mute_guard.did_mute = false;
+                }
+            }
+            if let Some(rec) = self.recorder.lock().unwrap().as_mut() {
+                // Skipping rec.stop() here: the worker is gone, so the command
+                // would only fail on the closed channel.
+                let _ = rec.close();
+            }
+            *self.is_recording.lock().unwrap() = false;
+            *open_flag = false;
+            // Fall through and open a fresh stream.
         }
 
         let start_time = Instant::now();


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

A mic that drops mid-session — USB dropout, Bluetooth flake, unplugging a headset —
leaves Handy silently broken rather than failing loudly. The hotkey still appears to
work, nothing gets recorded, and there is no signal to the user that anything is wrong.
It then clears itself a minute or two later when the on-demand close timeout fires,
which makes it read as flaky and intermittent and is probably why it gets reported as
"random freezes" more often than as a disconnect bug. Since the record hotkey is the
whole product surface, failing closed like that seemed worth fixing at the source
instead of papering over it with a shorter timeout.

One note on provenance, since this section specifically asks for the contributor's own
words: this paragraph was drafted with AI assistance and reviewed by me, rather than
written from a first-hand encounter with the bug (see the AI Assistance section, and
the honest limits under Testing). Happy to rewrite it first-hand if you would rather
have that — I did not want to fake an anecdote to fill the box.

## Related Issues/Discussions

Fixes #1743

The report there has the full reproduction and logs. I have not been able to reproduce
it on demand myself, so the diagnosis below comes from reading the code against the
logs in that issue rather than from a live repro — please sanity-check my reasoning.

## Community Feedback

#1743 is the only report I could confirm describes this specific failure. #434 and
#1165 mention the same `Recorder not available` symptom, but I could not establish
they share this root cause, so I am not claiming them.

## Testing

- `cargo check --lib --tests` — clean (the one `unused_assignments` warning is
  pre-existing, in `transcription.rs`, untouched here)
- `cargo fmt --check` — clean
- `cargo test --lib audio_toolkit::audio::recorder` — 8 passed, including the added case
- Verified normal record → transcribe → paste still works on macOS 26 (Apple silicon,
  built-in mic + a USB interface)

**Not tested, and where I would most like a second pair of eyes:** the actual
disconnect path. I could not get a clean mid-recording device drop to reproduce
locally, so the recovery branch itself has not been exercised end to end. If someone
who can reproduce #1743 (yanking a USB mic mid-recording) is able to try this build,
that would be the real test.

### What is going on

`run_consumer` is driven entirely by the sample channel:

```rust
// Runs until the stream closes and `recv` returns `Err`.
while let Ok(chunk) = sample_rx.recv() {
```

When cpal tears the stream down mid-session, the data callback stops and
`sample_rx.recv()` returns `Err`, so the loop ends and the worker thread exits.
But `cmd_tx` and `worker_handle` are both still populated, so nothing above notices:

- `AudioRecorder::open()` early-returns `Ok(())` on `worker_handle.is_some()`
- `AudioRecordingManager::start_microphone_stream()` early-returns `Ok(())` on `is_open`

The caller gets a recorder with no capture behind it. That matches the reported
sequence exactly: `sample count: 0`, then `stop() failed: sending on a closed channel`
(the `Cmd::Stop` send fails because the receiver went away with the worker), then
`Microphone stream already active` / `Recorder not available` on every retry until the
on-demand close timeout eventually resets things a minute or two later.

### The change

`is_capture_worker_dead()` reports a worker that finished without anyone calling
`close()`. Both layers consult it before taking their "already open" shortcut, and
tear the dead stream down so the next open rebuilds it.

Using `JoinHandle::is_finished()` rather than a flag set from cpal's error callback
because it catches every way the worker can end, not just the error-callback path.

Two things I decided deliberately, both worth challenging:

- The manager tears down inline instead of calling `stop_microphone_stream()`, which
  would deadlock on the `is_open` lock it already holds. Lock order (`is_open` →
  `mute_state` → `recorder` → `is_recording`) follows the existing paths.
- `rec.stop()` is skipped on the dead-stream path, since that command can only fail on
  the closed channel.

There is a small residual race: if the worker dies between the check and `rec.start()`,
that attempt still fails with `Recorder not available`. The next one recovers, so the
worst case goes from a 1-2 minute lockout to a single failed press. Handling it
properly would mean reworking `start()`'s error path, which felt like more surface than
this bug warrants — happy to go further if you would prefer.

## Screenshots/Videos (if applicable)

N/A — no user-visible surface changes.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Opus 5)
- How extensively: Heavily. It traced the failure through `recorder.rs`/`audio.rs`
  against the logs in #1743, wrote the patch, the added test, and this entire
  description — including the "Human Written Description" section, which is flagged
  inline there rather than passed off as hand-written. I reviewed the diff and ran the
  checks listed above.
