### PR TITLE
feat: add structured remote control commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ Settings are stored using Tauri's store plugin with reactive updates:
 
 ### Single Instance Architecture
 
-The app enforces single instance behavior — launching when already running brings the settings window to front rather than creating a new process. Remote control flags (`--toggle-transcription`, etc.) work by launching a second instance that sends args to the running instance via `tauri_plugin_single_instance`, then exits.
+The app enforces single instance behavior — launching when already running brings the settings window to front rather than creating a new process. Remote control commands (`recording ...`, `transcript ...`, and the legacy toggle flags) work by launching a second instance that sends args to the running instance via `tauri_plugin_single_instance`, then exits.
 
 ## Internationalization (i18n)
 
@@ -173,22 +173,29 @@ For translation contribution guidelines, see [CONTRIBUTING_TRANSLATIONS.md](CONT
 
 Handy supports command-line parameters on all platforms for integration with scripts, window managers, and autostart configurations.
 
-**Implementation:** `cli.rs` (definitions), `main.rs` (parsing), `lib.rs` (applying), `signal_handle.rs` (shared logic)
+**Implementation:** `cli.rs` defines the interface; `lib.rs` routes second-instance arguments to `remote_control.rs`, which delegates recording lifecycle work to the coordinator and transcript delivery to history and clipboard services.
 
-| Flag                     | Description                                                |
-| ------------------------ | ---------------------------------------------------------- |
-| `--toggle-transcription` | Toggle recording on/off on a running instance              |
-| `--toggle-post-process`  | Toggle recording with post-processing on/off               |
-| `--cancel`               | Cancel the current operation on a running instance         |
-| `--start-hidden`         | Launch without showing the main window (tray icon visible) |
-| `--no-tray`              | Launch without system tray (closing window quits the app)  |
-| `--debug`                | Enable debug mode with verbose (Trace) logging             |
+| Command/flag                         | Description                                                  |
+| ------------------------------------ | ------------------------------------------------------------ |
+| `recording start [--post-process]`   | Start recording if idle                                      |
+| `recording stop`                     | Stop the active recording                                    |
+| `recording toggle [--post-process]`  | Start if idle, otherwise stop                                |
+| `recording cancel`                   | Cancel the current recording or transcription                |
+| `transcript clipboard`               | Copy the latest completed transcript                         |
+| `transcript paste [--method METHOD]` | Paste the latest transcript with an optional method override |
+| `--toggle-transcription`             | Legacy alias for `recording toggle`                          |
+| `--toggle-post-process`              | Legacy alias for `recording toggle --post-process`           |
+| `--cancel`                           | Legacy alias for `recording cancel`                          |
+| `--start-hidden`                     | Launch without showing the main window (tray icon visible)   |
+| `--no-tray`                          | Launch without system tray (closing window quits the app)    |
+| `--debug`                            | Enable debug mode with verbose (Trace) logging               |
 
 **Key design decisions:**
 
-- CLI flags are runtime-only overrides — they do NOT modify persisted settings
-- Remote control flags work via `tauri_plugin_single_instance`: second instance sends args, then exits
-- `send_transcription_input()` in `signal_handle.rs` is shared between signal handlers and CLI
+- CLI options are runtime-only overrides — they do NOT modify persisted settings
+- Remote control commands work via `tauri_plugin_single_instance`: second instance sends args, then exits
+- `start` and `stop` are idempotent; `stop` preserves the mode used to start the active recording
+- Transcript paste reuses the normal paste pipeline; `--method` only overrides the paste method for that invocation
 
 ## Debug Mode
 

--- a/README.md
+++ b/README.md
@@ -82,13 +82,32 @@ Handy includes an advanced debug mode for development and troubleshooting. Acces
 
 Handy supports command-line flags for controlling a running instance and customizing startup behavior. These work on all platforms (macOS, Windows, Linux).
 
-**Remote control flags** (sent to an already-running instance via the single-instance plugin):
+**Remote control commands** (sent to an already-running instance via the single-instance plugin):
 
 ```bash
-handy --toggle-transcription    # Toggle recording on/off
-handy --toggle-post-process     # Toggle recording with post-processing on/off
-handy --cancel                  # Cancel the current operation
+handy recording start                         # Start recording if idle
+handy recording start --post-process          # Start with post-processing if idle
+handy recording stop                          # Stop the active recording
+handy recording toggle                        # Start if idle, otherwise stop
+handy recording toggle --post-process         # Toggle, using post-processing when starting
+handy recording cancel                        # Cancel the current operation
+
+handy transcript clipboard                    # Copy the latest completed transcript
+handy transcript paste                        # Paste with the configured method
+handy transcript paste --method ctrl_shift_v  # Override the method once
 ```
+
+The optional one-shot paste method uses Handy's existing setting names:
+`ctrl_v`, `ctrl_shift_v`, `shift_insert`, `direct`, `none`, or
+`external_script`. Hyphenated spellings are also accepted. Omitting `--method`
+uses the saved setting, and an override never changes it. The existing
+`--toggle-transcription`, `--toggle-post-process`, and `--cancel` flags remain
+available as aliases.
+
+Transcript commands operate on the most recent completed entry and prefer
+post-processed text when available, matching the tray's Copy Last Transcript
+action. Paste commands use Handy's normal paste pipeline and settings;
+`--method` changes only the paste method for that invocation.
 
 **Startup flags:**
 

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -1,4 +1,5 @@
-use clap::Parser;
+use crate::settings::PasteMethod;
+use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
 #[derive(Parser, Debug, Clone, Default)]
@@ -27,6 +28,10 @@ pub struct CliArgs {
     /// Enable debug mode with verbose logging
     #[arg(long)]
     pub debug: bool,
+
+    /// Control a running Handy instance from scripts and external devices
+    #[command(subcommand)]
+    pub command: Option<RemoteCommand>,
 
     /// Transcribe this WAV (16 kHz mono) headlessly and exit. Runs the same
     /// batch transcription path as the app — no mic, no VAD, no download
@@ -60,4 +65,218 @@ pub struct CliArgs {
     /// Emit --transcribe-file results as JSON.
     #[arg(long)]
     pub json: bool,
+}
+
+#[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
+pub enum RemoteCommand {
+    /// Control the recording lifecycle
+    Recording {
+        #[command(subcommand)]
+        action: RecordingCommand,
+    },
+
+    /// Deliver a transcript from Handy's history
+    Transcript {
+        #[command(subcommand)]
+        action: TranscriptCommand,
+    },
+}
+
+#[derive(Subcommand, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecordingCommand {
+    /// Start recording if Handy is idle
+    Start {
+        /// Apply the configured post-processing when the recording stops
+        #[arg(long)]
+        post_process: bool,
+    },
+
+    /// Stop the active recording, preserving the mode it was started with
+    Stop,
+
+    /// Start recording when idle, or stop the active recording
+    Toggle {
+        /// Apply the configured post-processing when starting a recording
+        #[arg(long)]
+        post_process: bool,
+    },
+
+    /// Cancel the current recording or transcription operation
+    Cancel,
+}
+
+#[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
+pub enum TranscriptCommand {
+    /// Copy the most recent completed transcript to the clipboard
+    Clipboard,
+
+    /// Paste the most recent completed transcript into the active application
+    Paste {
+        /// Override Handy's configured paste method for this invocation
+        #[arg(long, value_enum)]
+        method: Option<CliPasteMethod>,
+    },
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CliPasteMethod {
+    #[value(name = "ctrl_v", alias = "ctrl-v")]
+    CtrlV,
+    #[value(name = "ctrl_shift_v", alias = "ctrl-shift-v")]
+    CtrlShiftV,
+    #[value(name = "shift_insert", alias = "shift-insert")]
+    ShiftInsert,
+    Direct,
+    None,
+    #[value(name = "external_script", alias = "external-script")]
+    ExternalScript,
+}
+
+impl From<CliPasteMethod> for PasteMethod {
+    fn from(method: CliPasteMethod) -> Self {
+        match method {
+            CliPasteMethod::CtrlV => Self::CtrlV,
+            CliPasteMethod::CtrlShiftV => Self::CtrlShiftV,
+            CliPasteMethod::ShiftInsert => Self::ShiftInsert,
+            CliPasteMethod::Direct => Self::Direct,
+            CliPasteMethod::None => Self::None,
+            CliPasteMethod::ExternalScript => Self::ExternalScript,
+        }
+    }
+}
+
+impl CliArgs {
+    /// Resolve either the structured subcommands or their legacy flag aliases.
+    pub fn remote_command(&self) -> Option<RemoteCommand> {
+        if let Some(command) = &self.command {
+            return Some(command.clone());
+        }
+
+        if self.toggle_transcription {
+            Some(RemoteCommand::Recording {
+                action: RecordingCommand::Toggle {
+                    post_process: false,
+                },
+            })
+        } else if self.toggle_post_process {
+            Some(RemoteCommand::Recording {
+                action: RecordingCommand::Toggle { post_process: true },
+            })
+        } else if self.cancel {
+            Some(RemoteCommand::Recording {
+                action: RecordingCommand::Cancel,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_recording_toggle_with_post_processing() {
+        let args = CliArgs::try_parse_from(["handy", "recording", "toggle", "--post-process"])
+            .expect("structured recording command should parse");
+
+        assert_eq!(
+            args.remote_command(),
+            Some(RemoteCommand::Recording {
+                action: RecordingCommand::Toggle { post_process: true }
+            })
+        );
+    }
+
+    #[test]
+    fn parses_idempotent_recording_commands() {
+        let start = CliArgs::try_parse_from(["handy", "recording", "start"])
+            .expect("recording start should parse");
+        let stop = CliArgs::try_parse_from(["handy", "recording", "stop"])
+            .expect("recording stop should parse");
+        let cancel = CliArgs::try_parse_from(["handy", "recording", "cancel"])
+            .expect("recording cancel should parse");
+
+        assert_eq!(
+            start.remote_command(),
+            Some(RemoteCommand::Recording {
+                action: RecordingCommand::Start {
+                    post_process: false
+                }
+            })
+        );
+        assert_eq!(
+            stop.remote_command(),
+            Some(RemoteCommand::Recording {
+                action: RecordingCommand::Stop
+            })
+        );
+        assert_eq!(
+            cancel.remote_command(),
+            Some(RemoteCommand::Recording {
+                action: RecordingCommand::Cancel
+            })
+        );
+    }
+
+    #[test]
+    fn parses_transcript_with_terminal_paste() {
+        let args =
+            CliArgs::try_parse_from(["handy", "transcript", "paste", "--method", "ctrl_shift_v"])
+                .expect("structured transcript command should parse");
+
+        assert_eq!(
+            args.remote_command(),
+            Some(RemoteCommand::Transcript {
+                action: TranscriptCommand::Paste {
+                    method: Some(CliPasteMethod::CtrlShiftV)
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn paste_method_accepts_hyphenated_alias() {
+        let args =
+            CliArgs::try_parse_from(["handy", "transcript", "paste", "--method", "ctrl-shift-v"])
+                .expect("hyphenated paste method alias should parse");
+
+        assert_eq!(
+            args.remote_command(),
+            Some(RemoteCommand::Transcript {
+                action: TranscriptCommand::Paste {
+                    method: Some(CliPasteMethod::CtrlShiftV)
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn legacy_toggle_flag_maps_to_structured_command() {
+        let args = CliArgs::try_parse_from(["handy", "--toggle-transcription"])
+            .expect("legacy toggle flag should still parse");
+
+        assert_eq!(
+            args.remote_command(),
+            Some(RemoteCommand::Recording {
+                action: RecordingCommand::Toggle {
+                    post_process: false
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn transcript_paste_defaults_to_configured_method() {
+        let args = CliArgs::try_parse_from(["handy", "transcript", "paste"])
+            .expect("transcript paste should parse");
+
+        assert_eq!(
+            args.remote_command(),
+            Some(RemoteCommand::Transcript {
+                action: TranscriptCommand::Paste { method: None }
+            })
+        );
+    }
 }

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -611,8 +611,17 @@ fn should_send_auto_submit(auto_submit: bool, paste_method: PasteMethod) -> bool
 }
 
 pub fn paste(text: String, app_handle: AppHandle) -> Result<(), String> {
+    paste_with_method_override(text, app_handle, None)
+}
+
+/// Paste text with an optional per-invocation method that does not modify settings.
+pub(crate) fn paste_with_method_override(
+    text: String,
+    app_handle: AppHandle,
+    paste_method_override: Option<PasteMethod>,
+) -> Result<(), String> {
     let settings = get_settings(&app_handle);
-    let paste_method = settings.paste_method;
+    let paste_method = paste_method_override.unwrap_or(settings.paste_method);
     let paste_delay_ms = settings.paste_delay_ms;
     let paste_delay_after_ms = settings.paste_delay_after_ms;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ mod managers;
 mod overlay;
 mod paste_tx;
 pub mod portable;
+mod remote_control;
 mod secure_input;
 mod settings;
 mod shortcut;
@@ -29,6 +30,7 @@ pub use cli::CliArgs;
 use specta_typescript::{BigIntExportBehavior, Typescript};
 use tauri_specta::{collect_commands, collect_events, Builder};
 
+use clap::Parser;
 use env_filter::Builder as EnvFilterBuilder;
 use managers::audio::AudioRecordingManager;
 use managers::history::HistoryManager;
@@ -792,14 +794,15 @@ pub fn run(cli_args: CliArgs) {
     // instance instead.
     if !headless_mode {
         builder = builder.plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
-            if args.iter().any(|a| a == "--toggle-transcription") {
-                signal_handle::send_transcription_input(app, "transcribe", "CLI");
-            } else if args.iter().any(|a| a == "--toggle-post-process") {
-                signal_handle::send_transcription_input(app, "transcribe_with_post_process", "CLI");
-            } else if args.iter().any(|a| a == "--cancel") {
-                crate::utils::cancel_current_operation(app);
-            } else {
-                show_main_window(app);
+            match CliArgs::try_parse_from(args) {
+                Ok(cli_args) => match cli_args.remote_command() {
+                    Some(command) => remote_control::dispatch(app, command),
+                    None => show_main_window(app),
+                },
+                Err(err) => {
+                    log::warn!("Failed to parse arguments from second instance: {err}");
+                    show_main_window(app);
+                }
             }
         }));
     }

--- a/src-tauri/src/managers/history.rs
+++ b/src-tauri/src/managers/history.rs
@@ -532,6 +532,13 @@ impl HistoryManager {
         Self::get_latest_completed_entry_with_conn(&conn)
     }
 
+    /// Get the latest completed transcript, preferring post-processed text.
+    pub fn get_latest_completed_transcript(&self) -> Result<Option<String>> {
+        Ok(self
+            .get_latest_completed_entry()?
+            .and_then(|entry| preferred_transcript_text(&entry).map(str::to_owned)))
+    }
+
     fn get_latest_completed_entry_with_conn(conn: &Connection) -> Result<Option<HistoryEntry>> {
         let mut stmt = conn.prepare(
             "SELECT
@@ -649,6 +656,14 @@ impl HistoryManager {
     }
 }
 
+fn preferred_transcript_text(entry: &HistoryEntry) -> Option<&str> {
+    let text = entry
+        .post_processed_text
+        .as_deref()
+        .unwrap_or(&entry.transcription_text);
+    (!text.trim().is_empty()).then_some(text)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -699,6 +714,20 @@ mod tests {
         .expect("insert history entry");
     }
 
+    fn build_entry(transcription: &str, post_processed: Option<&str>) -> HistoryEntry {
+        HistoryEntry {
+            id: 1,
+            file_name: "handy-1.wav".to_string(),
+            timestamp: 0,
+            saved: false,
+            title: "Recording".to_string(),
+            transcription_text: transcription.to_string(),
+            post_processed_text: post_processed.map(str::to_owned),
+            post_process_prompt: None,
+            post_process_requested: post_processed.is_some(),
+        }
+    }
+
     #[test]
     fn get_latest_entry_returns_none_when_empty() {
         let conn = setup_conn();
@@ -733,5 +762,17 @@ mod tests {
 
         assert_eq!(entry.timestamp, 100);
         assert_eq!(entry.transcription_text, "completed");
+    }
+
+    #[test]
+    fn preferred_transcript_uses_post_processed_text_when_available() {
+        let entry = build_entry("raw", Some("processed"));
+        assert_eq!(preferred_transcript_text(&entry), Some("processed"));
+    }
+
+    #[test]
+    fn preferred_transcript_falls_back_to_raw_text() {
+        let entry = build_entry("raw", None);
+        assert_eq!(preferred_transcript_text(&entry), Some("raw"));
     }
 }

--- a/src-tauri/src/remote_control.rs
+++ b/src-tauri/src/remote_control.rs
@@ -1,0 +1,79 @@
+use crate::cli::{RecordingCommand, RemoteCommand, TranscriptCommand};
+use crate::managers::history::HistoryManager;
+use crate::transcription_coordinator::RecordingControl;
+use crate::{clipboard, utils, TranscriptionCoordinator};
+use log::{error, warn};
+use std::sync::Arc;
+use tauri::{AppHandle, Emitter, Manager};
+use tauri_plugin_clipboard_manager::ClipboardExt;
+
+const SOURCE: &str = "CLI";
+const STANDARD_BINDING: &str = "transcribe";
+const POST_PROCESS_BINDING: &str = "transcribe_with_post_process";
+
+pub(crate) fn dispatch(app: &AppHandle, command: RemoteCommand) {
+    if let Err(err) = execute(app, command) {
+        error!("Failed to execute remote command: {err}");
+    }
+}
+
+fn execute(app: &AppHandle, command: RemoteCommand) -> Result<(), String> {
+    match command {
+        RemoteCommand::Recording { action } => execute_recording(app, action),
+        RemoteCommand::Transcript { action } => execute_transcript(app, action),
+    }
+}
+
+fn execute_recording(app: &AppHandle, action: RecordingCommand) -> Result<(), String> {
+    let (control, post_process) = match action {
+        RecordingCommand::Start { post_process } => (RecordingControl::Start, post_process),
+        RecordingCommand::Stop => (RecordingControl::Stop, false),
+        RecordingCommand::Toggle { post_process } => (RecordingControl::Toggle, post_process),
+        RecordingCommand::Cancel => {
+            utils::cancel_current_operation(app);
+            return Ok(());
+        }
+    };
+    let binding_id = if post_process {
+        POST_PROCESS_BINDING
+    } else {
+        STANDARD_BINDING
+    };
+
+    let coordinator = app
+        .try_state::<TranscriptionCoordinator>()
+        .ok_or("TranscriptionCoordinator not initialized")?;
+    coordinator.send_recording_control(control, binding_id, SOURCE);
+    Ok(())
+}
+
+fn execute_transcript(app: &AppHandle, action: TranscriptCommand) -> Result<(), String> {
+    let history_manager = app.state::<Arc<HistoryManager>>();
+    let Some(text) = history_manager
+        .get_latest_completed_transcript()
+        .map_err(|err| format!("Failed to fetch last completed transcription entry: {err}"))?
+    else {
+        warn!("No completed transcription history entry is available");
+        return Ok(());
+    };
+
+    match action {
+        TranscriptCommand::Clipboard => app
+            .clipboard()
+            .write_text(text)
+            .map_err(|err| format!("Failed to copy transcript to clipboard: {err}")),
+        TranscriptCommand::Paste { method } => {
+            let method_override = method.map(Into::into);
+            let app_handle = app.clone();
+            app.run_on_main_thread(move || {
+                if let Err(err) =
+                    clipboard::paste_with_method_override(text, app_handle.clone(), method_override)
+                {
+                    error!("Failed to paste transcript: {err}");
+                    let _ = app_handle.emit("paste-error", ());
+                }
+            })
+            .map_err(|err| format!("Failed to schedule transcript paste: {err}"))
+        }
+    }
+}

--- a/src-tauri/src/transcription_coordinator.rs
+++ b/src-tauri/src/transcription_coordinator.rs
@@ -34,6 +34,11 @@ enum Command {
     Cancel {
         recording_was_active: bool,
     },
+    RemoteRecording {
+        action: RecordingControl,
+        binding_id: String,
+        source: String,
+    },
     ProcessingFinished,
 }
 
@@ -42,6 +47,32 @@ enum Stage {
     Idle,
     Recording(String), // binding_id
     Processing,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RecordingControl {
+    Start,
+    Stop,
+    Toggle,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum RecordingDecision {
+    Start,
+    Stop(String),
+    Ignore,
+}
+
+fn decide_recording_control(stage: &Stage, action: RecordingControl) -> RecordingDecision {
+    match (stage, action) {
+        (Stage::Idle, RecordingControl::Start | RecordingControl::Toggle) => {
+            RecordingDecision::Start
+        }
+        (Stage::Recording(binding_id), RecordingControl::Stop | RecordingControl::Toggle) => {
+            RecordingDecision::Stop(binding_id.clone())
+        }
+        _ => RecordingDecision::Ignore,
+    }
 }
 
 fn classify_ptt_event(
@@ -199,6 +230,25 @@ impl TranscriptionCoordinator {
                                 stage = Stage::Idle;
                             }
                         }
+                        Command::RemoteRecording {
+                            action,
+                            binding_id,
+                            source,
+                        } => match decide_recording_control(&stage, action) {
+                            RecordingDecision::Start => {
+                                pending_release = None;
+                                start(&app, &mut stage, &binding_id, &source);
+                            }
+                            RecordingDecision::Stop(active_binding_id) => {
+                                pending_release = None;
+                                stop(&app, &mut stage, &active_binding_id, &source);
+                            }
+                            RecordingDecision::Ignore => {
+                                debug!(
+                                    "Ignoring remote recording command '{action:?}': pipeline busy or already in requested state"
+                                );
+                            }
+                        },
                         Command::ProcessingFinished => {
                             stage = Stage::Idle;
                         }
@@ -242,6 +292,26 @@ impl TranscriptionCoordinator {
             .tx
             .send(Command::Cancel {
                 recording_was_active,
+            })
+            .is_err()
+        {
+            warn!("Transcription coordinator channel closed");
+        }
+    }
+
+    /// Queue an idempotent recording-control command.
+    pub(crate) fn send_recording_control(
+        &self,
+        action: RecordingControl,
+        binding_id: &str,
+        source: &str,
+    ) {
+        if self
+            .tx
+            .send(Command::RemoteRecording {
+                action,
+                binding_id: binding_id.to_string(),
+                source: source.to_string(),
             })
             .is_err()
         {
@@ -344,6 +414,55 @@ mod tests {
         assert_eq!(
             classify_ptt_event(Some("transcribe"), true, true, "transcribe", None),
             PttAction::CancelRelease
+        );
+    }
+
+    #[test]
+    fn remote_start_only_starts_from_idle() {
+        assert_eq!(
+            decide_recording_control(&Stage::Idle, RecordingControl::Start),
+            RecordingDecision::Start
+        );
+        assert_eq!(
+            decide_recording_control(
+                &Stage::Recording("transcribe".to_string()),
+                RecordingControl::Start
+            ),
+            RecordingDecision::Ignore
+        );
+    }
+
+    #[test]
+    fn remote_stop_preserves_the_active_recording_mode() {
+        assert_eq!(
+            decide_recording_control(
+                &Stage::Recording("transcribe_with_post_process".to_string()),
+                RecordingControl::Stop
+            ),
+            RecordingDecision::Stop("transcribe_with_post_process".to_string())
+        );
+        assert_eq!(
+            decide_recording_control(&Stage::Idle, RecordingControl::Stop),
+            RecordingDecision::Ignore
+        );
+    }
+
+    #[test]
+    fn remote_toggle_starts_or_stops_but_not_during_processing() {
+        assert_eq!(
+            decide_recording_control(&Stage::Idle, RecordingControl::Toggle),
+            RecordingDecision::Start
+        );
+        assert_eq!(
+            decide_recording_control(
+                &Stage::Recording("transcribe".to_string()),
+                RecordingControl::Toggle
+            ),
+            RecordingDecision::Stop("transcribe".to_string())
+        );
+        assert_eq!(
+            decide_recording_control(&Stage::Processing, RecordingControl::Toggle),
+            RecordingDecision::Ignore
         );
     }
 

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,4 +1,4 @@
-use crate::managers::history::{HistoryEntry, HistoryManager};
+use crate::managers::history::HistoryManager;
 use crate::managers::model::ModelManager;
 use crate::managers::transcription::TranscriptionManager;
 use crate::settings;
@@ -335,13 +335,6 @@ pub fn update_tray_menu(app: &AppHandle, locale: Option<&str>) {
     let _ = tray.set_tooltip(Some(tooltip));
 }
 
-fn last_transcript_text(entry: &HistoryEntry) -> &str {
-    entry
-        .post_processed_text
-        .as_deref()
-        .unwrap_or(&entry.transcription_text)
-}
-
 pub fn set_tray_visibility(app: &AppHandle, visible: bool) {
     let tray = app.state::<TrayIcon>();
     if let Err(e) = tray.set_visible(visible) {
@@ -353,8 +346,8 @@ pub fn set_tray_visibility(app: &AppHandle, visible: bool) {
 
 pub fn copy_last_transcript(app: &AppHandle) {
     let history_manager = app.state::<Arc<HistoryManager>>();
-    let entry = match history_manager.get_latest_completed_entry() {
-        Ok(Some(entry)) => entry,
+    let text = match history_manager.get_latest_completed_transcript() {
+        Ok(Some(text)) => text,
         Ok(None) => {
             warn!("No completed transcription history entries available for tray copy.");
             return;
@@ -368,13 +361,7 @@ pub fn copy_last_transcript(app: &AppHandle) {
         }
     };
 
-    let text = last_transcript_text(&entry);
-    if text.trim().is_empty() {
-        warn!("Last completed transcription is empty; skipping tray copy.");
-        return;
-    }
-
-    if let Err(err) = app.clipboard().write_text(text) {
+    if let Err(err) = app.clipboard().write_text(&text) {
         error!("Failed to copy last transcript to clipboard: {}", err);
         return;
     }
@@ -384,34 +371,7 @@ pub fn copy_last_transcript(app: &AppHandle) {
 
 #[cfg(test)]
 mod tests {
-    use super::{last_transcript_text, load_tray_icon};
-    use crate::managers::history::HistoryEntry;
-
-    fn build_entry(transcription: &str, post_processed: Option<&str>) -> HistoryEntry {
-        HistoryEntry {
-            id: 1,
-            file_name: "handy-1.wav".to_string(),
-            timestamp: 0,
-            saved: false,
-            title: "Recording".to_string(),
-            transcription_text: transcription.to_string(),
-            post_processed_text: post_processed.map(|text| text.to_string()),
-            post_process_prompt: None,
-            post_process_requested: false,
-        }
-    }
-
-    #[test]
-    fn uses_post_processed_text_when_available() {
-        let entry = build_entry("raw", Some("processed"));
-        assert_eq!(last_transcript_text(&entry), "processed");
-    }
-
-    #[test]
-    fn falls_back_to_raw_transcription() {
-        let entry = build_entry("raw", None);
-        assert_eq!(last_transcript_text(&entry), "raw");
-    }
+    use super::load_tray_icon;
 
     #[test]
     fn tray_icon_resolution_failure_is_returned_instead_of_panicking() {


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [x] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

This is my first time collaborating, but I wanted to say thanks for Handy. I use it on Windows every day. I have an elgator streamdeck, and I was thinking how useful it would be to use it with Handy -- one button toggles recording, another button copies a transcript, another button pastes, etc.

## Related Issues/Discussions

Discussion: https://github.com/cjpais/Handy/discussions/211#discussioncomment-17875101

Related PRs: #792 established Handy's existing single-instance CLI controls. #659 addressed a similar latest-transcript retrieval use case through a new global shortcut; this proposal instead keeps bindings outside Handy and adds no shortcut or settings UI.

## Community Feedback

This draft is being shared alongside a proposal in Discussion #211 to gather feedback before requesting review. I am happy to narrow or revise the command surface based on maintainer and community direction.

## What Changed

- Add structured, typed commands for idempotent recording start/stop/toggle/cancel actions.
- Add commands to copy or paste the most recent completed transcript, preferring post-processed text when available.
- Allow a one-shot override using Handy's existing paste-method names without changing saved settings.
- Preserve the existing `--toggle-transcription`, `--toggle-post-process`, and `--cancel` flags as aliases.
- Reuse the existing single-instance transport, transcription coordinator, history manager, and paste pipeline; no new shortcut, UI, settings, server, or network surface is introduced.

## Testing

All automated development and verification ran in Docker using Ubuntu 24.04:

- `cargo test`: 171 passed
- `cargo fmt -- --check`
- `cargo clippy --all-targets` (only pre-existing warnings remain)
- `bun run check:translations`
- `bun run lint`
- `bunx prettier --check .`
- `bun run build`
- Inspected generated CLI help and nested command parsing

Windows runtime and Stream Deck focus/paste behavior have not yet been validated. I would appreciate help using the draft PR's Windows build artifact for that target-platform testing before this is considered ready for review.

## Screenshots/Videos (if applicable)

N/A — this is a CLI-only change with no new UI.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Codex helped research the existing architecture and maintainer context, design and implement the change, refine the code and tests, run Docker-isolated verification, and draft the non-human-written sections of this description. I directed the design and reviewed the command interface and public proposal. And I should add that I hand-reviewed all the code, did a few rounds with it, and also worked through all the messaging. I use AI a ton, but I own all my stuff and try not to lob vibe-coded slop. Hopefully I did that right here and please be as critical as needed.
