### PR TITLE
return freed transcription buffers to the OS on Linux

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2463,6 +2463,7 @@ dependencies = [
  "handy-keys",
  "hf-hub",
  "hound",
+ "libc",
  "log",
  "natural",
  "objc2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -153,6 +153,7 @@ objc2-service-management = "0.3.2"
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk-layer-shell = { version = "0.8", features = ["v0_6"] }
 gtk = "0.18"
+libc = "0.2"
 transcribe-cpp = { version = "0.1.3", default-features = false, features = [
   "dynamic-backends",
   "vulkan",

--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -40,6 +40,10 @@ impl Drop for FinishGuard {
         if let Some(c) = self.0.try_state::<TranscriptionCoordinator>() {
             c.notify_processing_finished();
         }
+        // The pipeline just freed its large transient buffers (captured PCM,
+        // WAV copy, engine scratch); hand the cached pages back to the OS so
+        // they don't sit in malloc arenas until they get swapped out (#1792).
+        crate::memory::trim_freed_memory();
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ mod helpers;
 mod input;
 mod llm_client;
 mod managers;
+mod memory;
 mod overlay;
 mod paste_tx;
 pub mod portable;
@@ -587,6 +588,11 @@ fn run_headless_transcription(app: &AppHandle, args: &CliArgs) -> i32 {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run(cli_args: CliArgs) {
+    // Pin glibc's dynamic mmap threshold before the first large allocation,
+    // so per-dictation transient buffers are returned to the OS on free
+    // instead of accumulating in malloc arenas (#1792). No-op off Linux/glibc.
+    memory::init_allocator();
+
     // Detect portable mode before anything else
     portable::init();
 

--- a/src-tauri/src/memory.rs
+++ b/src-tauri/src/memory.rs
@@ -1,0 +1,55 @@
+//! glibc allocator tuning (Linux only).
+//!
+//! Each dictation allocates multi-megabyte transient buffers — the captured
+//! 16 kHz PCM (~64 KB per second, held twice: once for transcription, once
+//! for the history WAV) plus the transcription engine's per-run mel/FFT
+//! scratch (~80 KB per second of audio) — all freed within seconds.
+//!
+//! glibc's malloc serves allocations above its "mmap threshold" with a
+//! private mmap that is returned to the OS on free. But the threshold is
+//! *dynamic*: freeing an mmapped block raises it to that block's size (up to
+//! 32 MB), so after the first dictation every later large buffer is served
+//! from malloc arenas instead. Arena memory freed by the app is cached for
+//! reuse, and interleaved small live allocations pin those pages, so the OS
+//! never gets them back: RSS grows by roughly the transient-buffer volume of
+//! each dictation, is never touched again, and slowly migrates to swap
+//! (issue #1792 — measured at ~15 MB retained per 2-minute dictation;
+//! pinning the threshold reduced that to ~0.5 MB).
+//!
+//! Both entry points are no-ops on non-glibc targets (Windows, macOS, musl):
+//! this failure mode is specific to glibc's dynamic-threshold heuristic.
+
+/// Pin glibc's mmap threshold so large transient buffers keep taking the
+/// mmap path and are returned to the OS as soon as they are freed.
+///
+/// Must run before the workload allocates (called at the top of `run()`);
+/// the cost is an mmap/munmap round-trip per multi-MB buffer, which is
+/// negligible at dictation frequency.
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+pub fn init_allocator() {
+    // SAFETY: FFI call with no memory arguments; mallopt only updates
+    // malloc's internal parameters.
+    unsafe {
+        libc::mallopt(libc::M_MMAP_THRESHOLD, 128 * 1024);
+    }
+}
+
+#[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+pub fn init_allocator() {}
+
+/// Return freed-but-cached malloc arena memory to the OS.
+///
+/// Called once per finished transcription pipeline (see `FinishGuard`); it
+/// sweeps whatever smaller-than-threshold churn still accumulates in the
+/// arenas. Takes on the order of a millisecond, off the main thread.
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+pub fn trim_freed_memory() {
+    // SAFETY: FFI call with no memory arguments; malloc_trim releases whole
+    // free pages back to the OS via madvise and is thread-safe.
+    unsafe {
+        libc::malloc_trim(0);
+    }
+}
+
+#[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+pub fn trim_freed_memory() {}


### PR DESCRIPTION
on linux glibc

* give freed heap pages back to the OS after each dictation
* keep big buffers mmap'd so free() returns them to the OS

#1792 