### PR TITLE
fix: emit parseable names for compound shortcut keys

### DIFF
--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -1340,3 +1340,52 @@ pub async fn get_available_accelerators() -> crate::managers::transcription::Ava
         .await
         .expect("get_available_accelerators panicked")
 }
+
+#[cfg(test)]
+mod tests {
+    use handy_keys::Hotkey;
+    use tauri_plugin_global_shortcut::Shortcut;
+
+    /// Compound key names that the Tauri shortcut recorder used to emit with
+    /// spaces (e.g. "scroll lock"). global-hotkey rejects spaced tokens, so
+    /// registration failed (#1848). The frontend now emits compact forms
+    /// (e.g. "scrolllock").
+    ///
+    /// Handy has two keyboard backends. This test locks the invariant that
+    /// the compact names we store are accepted by *both* parsers, so fixing
+    /// Tauri recording does not break HandyKeys (or switching between them).
+    ///
+    /// Only keys in the intersection of both parsers are listed here.
+    /// Excluded on purpose:
+    /// - Menu/ContextMenu: neither backend's string parser accepts it
+    /// - PrintScreen: Tauri yes, handy-keys has no Key variant
+    /// - Numpad keys: backends use different naming (numpad* vs keypad*)
+    #[test]
+    fn compound_shortcut_keys_parse_on_both_backends() {
+        // Compact forms produced by getKeyName after the #1848 fix
+        let keys = ["scrolllock", "capslock", "numlock", "pageup", "pagedown"];
+
+        for key in keys {
+            // Tauri path: tauri_plugin_global_shortcut → global-hotkey
+            assert!(
+                key.parse::<Shortcut>().is_ok(),
+                "tauri/global-hotkey should parse compact key '{key}'"
+            );
+            // HandyKeys path
+            assert!(
+                key.parse::<Hotkey>().is_ok(),
+                "handy-keys should parse compact key '{key}'"
+            );
+        }
+
+        // Spaced forms (pre-fix Tauri emission) must still fail — documents the bug
+        assert!(
+            "scroll lock".parse::<Shortcut>().is_err(),
+            "spaced 'scroll lock' must remain unparseable by Tauri backend"
+        );
+        assert!(
+            "scroll lock".parse::<Hotkey>().is_err(),
+            "spaced 'scroll lock' must remain unparseable by HandyKeys backend"
+        );
+    }
+}

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -1346,14 +1346,12 @@ mod tests {
     use handy_keys::Hotkey;
     use tauri_plugin_global_shortcut::Shortcut;
 
-    /// Compound key names that the Tauri shortcut recorder used to emit with
-    /// spaces (e.g. "scroll lock"). global-hotkey rejects spaced tokens, so
-    /// registration failed (#1848). The frontend now emits compact forms
-    /// (e.g. "scrolllock").
+    /// After #1848 the frontend emits compact compound key names (e.g.
+    /// "scrolllock" instead of "scroll lock") so registration can succeed.
     ///
-    /// Handy has two keyboard backends. This test locks the invariant that
-    /// the compact names we store are accepted by *both* parsers, so fixing
-    /// Tauri recording does not break HandyKeys (or switching between them).
+    /// Handy has two keyboard backends. This test checks that those compact
+    /// names parse on *both*, so fixing the Tauri recorder does not break
+    /// HandyKeys (or switching between them).
     ///
     /// Only keys in the intersection of both parsers are listed here.
     /// Excluded on purpose:
@@ -1377,15 +1375,5 @@ mod tests {
                 "handy-keys should parse compact key '{key}'"
             );
         }
-
-        // Spaced forms (pre-fix Tauri emission) must still fail — documents the bug
-        assert!(
-            "scroll lock".parse::<Shortcut>().is_err(),
-            "spaced 'scroll lock' must remain unparseable by Tauri backend"
-        );
-        assert!(
-            "scroll lock".parse::<Hotkey>().is_err(),
-            "spaced 'scroll lock' must remain unparseable by HandyKeys backend"
-        );
     }
 }

--- a/src/lib/utils/keyboard.test.ts
+++ b/src/lib/utils/keyboard.test.ts
@@ -87,15 +87,12 @@ assert.equal(getKeyName(evt({ code: "AudioVolumeUp" })), "audiovolumeup");
 assert.notEqual(getKeyName(evt({ code: "AudioVolumeUp" })), "audio volume up");
 
 // ---------------------------------------------------------------------------
-// normalizeKey: left/right modifiers + legacy spaced compound names
+// normalizeKey: left/right modifier variants only
 // ---------------------------------------------------------------------------
 assert.equal(normalizeKey("left shift"), "shift");
 assert.equal(normalizeKey("right ctrl"), "ctrl");
-assert.equal(normalizeKey("scroll lock"), "scrolllock");
-assert.equal(normalizeKey("page up"), "pageup");
-assert.equal(normalizeKey("caps lock"), "capslock");
-assert.equal(normalizeKey("scrolllock"), "scrolllock");
 assert.equal(normalizeKey("space"), "space");
+assert.equal(normalizeKey("scrolllock"), "scrolllock");
 
 // ---------------------------------------------------------------------------
 // formatKeyCombination: UI still shows friendly compound labels

--- a/src/lib/utils/keyboard.test.ts
+++ b/src/lib/utils/keyboard.test.ts
@@ -1,0 +1,111 @@
+// Standalone assert check (no JS unit-test runner in this repo). Run with:
+//   bun src/lib/utils/keyboard.test.ts
+import assert from "node:assert";
+import {
+  getKeyName,
+  normalizeKey,
+  formatKeyCombination,
+  type OSType,
+} from "./keyboard";
+
+/** Minimal KeyboardEvent stand-in for getKeyName. */
+const evt = (partial: { code?: string; key?: string }): KeyboardEvent =>
+  partial as KeyboardEvent;
+
+// ---------------------------------------------------------------------------
+// Compound keys must be stored without spaces so both shortcut backends can
+// parse them (global-hotkey: SCROLLLOCK; handy-keys: scrolllock).
+// ---------------------------------------------------------------------------
+const compoundCases: Array<{ code: string; expected: string }> = [
+  { code: "ScrollLock", expected: "scrolllock" },
+  { code: "CapsLock", expected: "capslock" },
+  { code: "NumLock", expected: "numlock" },
+  { code: "PageUp", expected: "pageup" },
+  { code: "PageDown", expected: "pagedown" },
+  { code: "PrintScreen", expected: "printscreen" },
+];
+
+for (const { code, expected } of compoundCases) {
+  assert.equal(
+    getKeyName(evt({ code }), "linux"),
+    expected,
+    `${code} should map to "${expected}" (no spaces)`,
+  );
+}
+
+// Explicit anti-regression: the exact broken strings from #1848
+assert.notEqual(getKeyName(evt({ code: "ScrollLock" })), "scroll lock");
+assert.notEqual(getKeyName(evt({ code: "PageUp" })), "page up");
+assert.notEqual(getKeyName(evt({ code: "CapsLock" })), "caps lock");
+assert.notEqual(getKeyName(evt({ code: "NumLock" })), "num lock");
+assert.notEqual(getKeyName(evt({ code: "PageDown" })), "page down");
+assert.notEqual(getKeyName(evt({ code: "PrintScreen" })), "print screen");
+
+// e.key fallback for CapsLock
+assert.equal(getKeyName(evt({ key: "CapsLock" })), "capslock");
+
+// ---------------------------------------------------------------------------
+// Keys that already work must keep their existing stored names so we do not
+// break existing installs.
+// ---------------------------------------------------------------------------
+const stableCases: Array<{ code: string; expected: string; os?: OSType }> = [
+  { code: "Space", expected: "space" },
+  { code: "Tab", expected: "tab" },
+  { code: "Enter", expected: "enter" },
+  { code: "Escape", expected: "esc" },
+  { code: "Backspace", expected: "backspace" },
+  { code: "Delete", expected: "delete" },
+  { code: "Insert", expected: "insert" },
+  { code: "Home", expected: "home" },
+  { code: "End", expected: "end" },
+  { code: "Pause", expected: "pause" },
+  { code: "ArrowUp", expected: "up" },
+  { code: "ArrowDown", expected: "down" },
+  { code: "ArrowLeft", expected: "left" },
+  { code: "ArrowRight", expected: "right" },
+  { code: "KeyA", expected: "a" },
+  { code: "Digit5", expected: "5" },
+  { code: "F13", expected: "f13" },
+  { code: "ShiftLeft", expected: "shift" },
+  { code: "ControlLeft", expected: "ctrl" },
+  { code: "AltLeft", expected: "alt", os: "linux" },
+  { code: "AltLeft", expected: "option", os: "macos" },
+  { code: "MetaLeft", expected: "super", os: "linux" },
+  { code: "MetaLeft", expected: "command", os: "macos" },
+];
+
+for (const { code, expected, os = "linux" } of stableCases) {
+  assert.equal(
+    getKeyName(evt({ code }), os),
+    expected,
+    `${code} on ${os} must stay "${expected}"`,
+  );
+}
+
+// Unknown CamelCase codes: no space insertion (AudioVolumeUp → audiovolumeup)
+assert.equal(getKeyName(evt({ code: "AudioVolumeUp" })), "audiovolumeup");
+assert.notEqual(getKeyName(evt({ code: "AudioVolumeUp" })), "audio volume up");
+
+// ---------------------------------------------------------------------------
+// normalizeKey: left/right modifiers + legacy spaced compound names
+// ---------------------------------------------------------------------------
+assert.equal(normalizeKey("left shift"), "shift");
+assert.equal(normalizeKey("right ctrl"), "ctrl");
+assert.equal(normalizeKey("scroll lock"), "scrolllock");
+assert.equal(normalizeKey("page up"), "pageup");
+assert.equal(normalizeKey("caps lock"), "capslock");
+assert.equal(normalizeKey("scrolllock"), "scrolllock");
+assert.equal(normalizeKey("space"), "space");
+
+// ---------------------------------------------------------------------------
+// formatKeyCombination: UI still shows friendly compound labels
+// ---------------------------------------------------------------------------
+assert.equal(formatKeyCombination("scrolllock", "linux"), "Scroll Lock");
+assert.equal(formatKeyCombination("ctrl+pageup", "linux"), "Ctrl + Page Up");
+assert.equal(formatKeyCombination("option+space", "macos"), "Option + Space");
+assert.equal(
+  formatKeyCombination("shift_left+f13", "linux"),
+  "Left Shift + F13",
+);
+
+console.log("keyboard: all assertions passed");

--- a/src/lib/utils/keyboard.ts
+++ b/src/lib/utils/keyboard.ts
@@ -4,6 +4,18 @@
 
 export type OSType = "macos" | "windows" | "linux" | "unknown";
 
+// Compound keys are stored without spaces so both backends can parse them
+// (global-hotkey: "SCROLLLOCK", handy-keys: "scrolllock"). UI labels are
+// separate so the settings display still shows "Scroll Lock".
+const COMPOUND_KEY_DISPLAY: Record<string, string> = {
+  capslock: "Caps Lock",
+  numlock: "Num Lock",
+  pageup: "Page Up",
+  pagedown: "Page Down",
+  printscreen: "Print Screen",
+  scrolllock: "Scroll Lock",
+};
+
 /**
  * Extract a consistent key name from a KeyboardEvent
  * This function provides cross-platform keyboard event handling
@@ -66,7 +78,8 @@ export const getKeyName = (
       MetaRight: getModifierName("meta"),
       OSLeft: getModifierName("meta"),
       OSRight: getModifierName("meta"),
-      CapsLock: "caps lock",
+      // Compound keys: no spaces (see COMPOUND_KEY_DISPLAY)
+      CapsLock: "capslock",
       Tab: "tab",
       Enter: "enter",
       Space: "space",
@@ -79,11 +92,11 @@ export const getKeyName = (
       ArrowRight: "right",
       Home: "home",
       End: "end",
-      PageUp: "page up",
-      PageDown: "page down",
+      PageUp: "pageup",
+      PageDown: "pagedown",
       Insert: "insert",
-      PrintScreen: "print screen",
-      ScrollLock: "scroll lock",
+      PrintScreen: "printscreen",
+      ScrollLock: "scrolllock",
       Pause: "pause",
       ContextMenu: "menu",
       NumpadMultiply: "numpad *",
@@ -91,7 +104,7 @@ export const getKeyName = (
       NumpadSubtract: "numpad -",
       NumpadDecimal: "numpad .",
       NumpadDivide: "numpad /",
-      NumLock: "num lock",
+      NumLock: "numlock",
     };
 
     if (modifierMap[code]) {
@@ -117,8 +130,9 @@ export const getKeyName = (
       return punctuationMap[code];
     }
 
-    // For any other codes, try to convert to a reasonable format
-    return code.toLowerCase().replace(/([a-z])([A-Z])/g, "$1 $2");
+    // Lowercase without inserting spaces so names stay parseable
+    // (e.g. AudioVolumeUp -> "audiovolumeup", not "audio volume up")
+    return code.toLowerCase();
   }
 
   // Fallback to e.key if e.code is not available
@@ -134,7 +148,7 @@ export const getKeyName = (
         osType === "macos" ? "command" : osType === "windows" ? "win" : "super",
       OS:
         osType === "macos" ? "command" : osType === "windows" ? "win" : "super",
-      CapsLock: "caps lock",
+      CapsLock: "capslock",
       ArrowUp: "up",
       ArrowDown: "down",
       ArrowLeft: "left",
@@ -164,6 +178,8 @@ const capitalizeKey = (key: string): string => {
   if (/^f\d+$/.test(key)) return key.toUpperCase();
   // Single char: a -> A
   if (key.length === 1) return key.toUpperCase();
+  // Known compound keys stored without spaces
+  if (COMPOUND_KEY_DISPLAY[key]) return COMPOUND_KEY_DISPLAY[key];
   // Multi-word: capitalize first letter of each word
   return key.replace(/\b\w/g, (c) => c.toUpperCase());
 };
@@ -203,7 +219,8 @@ export const formatKeyCombination = (
 };
 
 /**
- * Normalize modifier keys to handle left/right variants
+ * Normalize modifier keys to handle left/right variants, and map legacy
+ * spaced compound-key names to the parseable form used by the backends.
  */
 export const normalizeKey = (key: string): string => {
   // Handle left/right variants of modifier keys
@@ -214,5 +231,12 @@ export const normalizeKey = (key: string): string => {
       return parts[1];
     }
   }
+
+  // Legacy spaced names from older builds → backend-parseable tokens
+  const compacted = key.replace(/\s+/g, "").toLowerCase();
+  if (COMPOUND_KEY_DISPLAY[compacted]) {
+    return compacted;
+  }
+
   return key;
 };

--- a/src/lib/utils/keyboard.ts
+++ b/src/lib/utils/keyboard.ts
@@ -219,8 +219,7 @@ export const formatKeyCombination = (
 };
 
 /**
- * Normalize modifier keys to handle left/right variants, and map legacy
- * spaced compound-key names to the parseable form used by the backends.
+ * Normalize modifier keys to handle left/right variants
  */
 export const normalizeKey = (key: string): string => {
   // Handle left/right variants of modifier keys
@@ -231,12 +230,5 @@ export const normalizeKey = (key: string): string => {
       return parts[1];
     }
   }
-
-  // Legacy spaced names from older builds → backend-parseable tokens
-  const compacted = key.replace(/\s+/g, "").toLowerCase();
-  if (COMPOUND_KEY_DISPLAY[compacted]) {
-    return compacted;
-  }
-
   return key;
 };


### PR DESCRIPTION
## Before Submitting This PR

<!--
HANDY IS UNDERGOING A FEATURE FREEZE. IF YOU ARE SUBMITTING A PR WHICH IS A NEW FEATURE THAT THE COMMUNITY HAS NOT ASKED FOR: PREPARE TO BE REJECTED. IF THE COMMUNITY HAS ASKED FOR IT, OR YOU HAVE EXPLICITLY GATHERED SUPPORT IT MAY STILL BE CONSIDERED.

BUG FIXES ARE THE TOP PRIORITY. THERE ARE 60+ ISSUES TO FIX.
-->

**Please submit only one fix or feature per pull request. Pull requests containing multiple fixes or features will likely be closed.**

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

I decided to see if I could fix #1848 where hotkeys with spaces in them failed to save as a hotkey. I compared the library that we use vs.
how we emit, and then I fixed our emitter. Added tests that proved the bug and then went green when the bug was fixed.

However, one hotkey cannot be fixed here, because "menu" is not something the upstream library recognizes.

This fix will fix all other valid hotkeys with spaces in them, however.

## Related Issues/Discussions

Fixes #1848
Discussion:

## Community Feedback

Bug confirmed by the reporter on Debian/X11 with Handy 0.9.4 (Tauri global shortcuts). Follow-up comment also notes Menu/ContextMenu fails; that key is **not** fixed here (see Testing / notes below) because `global-hotkey` 0.8.0's string parser does not accept `MENU`/`CONTEXTMENU` at all — that needs an upstream change.

## Testing

**Frontend emitter test (standalone bun assert file, same pattern as `portableInstaller.test.ts`):**

```bash
bun src/lib/utils/keyboard.test.ts
```

**Dual-backend parse test (Rust, both registration parsers):**

```bash
cd src-tauri && cargo test --lib shortcut::tests::compound_shortcut_keys_parse_on_both_backends
```

This parses the same compact tokens through `tauri_plugin_global_shortcut::Shortcut` (global-hotkey) *and* `handy_keys::Hotkey`. Only keys in the intersection of both parsers are covered (menu/printscreen/numpad excluded with comments in the test).


- With the fix: passes
- With compound-key maps temporarily reverted to spaced names (`"scroll lock"`, etc.): fails as expected on `ScrollLock should map to "scrolllock"`
- Fix restored: passes again
- Existing `bun src/components/update-checker/portableInstaller.test.ts` still passes

**What the test covers:**

- Compound keys emit compact parseable names: `scrolllock`, `capslock`, `numlock`, `pageup`, `pagedown`, `printscreen`
- Explicit anti-regression against the broken spaced forms from #1848
- Stable keys unchanged for existing installs: `space`, arrows, `esc`, letters, F-keys, modifiers (incl. macOS `option`/`command`)
- Unknown CamelCase codes no longer get spaces inserted (`AudioVolumeUp` → `audiovolumeup`)
- `formatKeyCombination` still shows friendly UI labels (`scrolllock` → `Scroll Lock`)

**Not covered / out of scope (intentionally):**

- **Menu / ContextMenu** (`"menu"`): still fails registration under Tauri; neither `global-hotkey` 0.8.0 nor Handy's `handy-keys` string parsers accept this key. Upstream issue, not fixed by renaming alone.
- **Numpad** keys (`numpad 0`, `numpad *`): different naming between Tauri (`numpad0` / `numpadmultiply`) and handy-keys (`keypad0` / `keypad*`); left alone to avoid cross-backend breakage.
- Full app E2E (Playwright only smoke-tests the Vite shell; registering a real global hotkey needs a packaged Tauri app + OS permissions).

**Manual verification still useful on a real build:**

1. Settings → General → record Transcription Hotkey → press Scroll Lock → should save (no parse error).
2. Same for Page Up / Caps Lock if available.
3. Confirm existing shortcuts (e.g. default / Space-based) still display and work.

## Screenshots/Videos (if applicable)

N/A (parse/registration fix; no intentional UI redesign). Display still shows “Scroll Lock” etc. via label map.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Grok (xAI) coding assistant
- How extensively: Co-written with AI assistance — investigation, implementation, and tests were done collaboratively with human direction and review throughout.


