### PR TITLE
fix(audio): skip level meter and resampler while idle in always-on mode

### DIFF
--- a/src-tauri/src/audio_toolkit/audio/recorder.rs
+++ b/src-tauri/src/audio_toolkit/audio/recorder.rs
@@ -797,24 +797,33 @@ fn run_consumer(
             );
         }
 
-        // ---------- spectrum processing ---------------------------------- //
-        if let Some(buckets) = visualizer.feed(&raw) {
-            if let Some(cb) = &level_cb {
-                cb(buckets);
+        // ---------- recording-time processing ---------------------------- //
+        // In always-on mode the capture stream stays open continuously for
+        // zero-latency start, so while idle (not recording) there is nothing to
+        // do with a chunk: handle_frame returns early when not recording, which
+        // means the resampled output would be discarded, and the level meter has
+        // no idle consumer. Skip both the level-meter FFT and the resampler while
+        // idle to avoid doing unnecessary work whose output is thrown away. Both
+        // are reset on Cmd::Start (visualizer.reset() / frame_resampler.reset()),
+        // so they resume cleanly the moment recording begins.
+        if recording {
+            if let Some(buckets) = visualizer.feed(&raw) {
+                if let Some(cb) = &level_cb {
+                    cb(buckets);
+                }
             }
-        }
 
-        // ---------- existing pipeline ------------------------------------ //
-        frame_resampler.push(&raw, &mut |frame: &[f32]| {
-            handle_frame(
-                frame,
-                recording,
-                vad_policy,
-                &vad,
-                &audio_cb,
-                &mut processed_samples,
-            )
-        });
+            frame_resampler.push(&raw, &mut |frame: &[f32]| {
+                handle_frame(
+                    frame,
+                    recording,
+                    vad_policy,
+                    &vad,
+                    &audio_cb,
+                    &mut processed_samples,
+                )
+            });
+        }
 
         if recording {
             if let Some(started) = awaiting_first_captured_chunk.take() {


### PR DESCRIPTION
## Before Submitting This PR

Handy is under a feature freeze. This is a **bug fix** (wasted idle CPU), not a feature, so it fits the "bug fixes are the top priority" guidance.

**One fix per PR:** yes, a single change in one file.

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

Related merged work on the idle / mic-level path, distinguished from this change: #1445 stops idle **frontend** overlay animations after recording; #1444 throttles and #1447 removes a leak in the **mic-level IPC**. This PR targets the **backend** audio processing that keeps running while always-on capture is idle, which none of those touch.

## Human Written Description

I noticed Handy stays warm while sitting idle in always-on mode, even when I'm not recording. The level meter and the sample-rate resampler only matter while a recording is actually running, but they kept processing audio the whole time the mic stream was open. This change skips both until recording starts, so the app shouldn't keep busy for nothing while it's just listening.

## Related Issues/Discussions

Fixes #1872

## Community Feedback

Single-maintainer project. This is a self-contained perf bug with a one-file fix and no feature-freeze concern, so community feedback is not expected to block it. Linked issue: #1872.

## What Changed

One change in `src-tauri/src/audio_toolkit/audio/recorder.rs`, inside the consumer loop. The recording-time processing (level meter + resampler pipeline) now runs only when `recording` is true:

```rust
if recording {
    if let Some(buckets) = visualizer.feed(&raw) {
        if let Some(cb) = &level_cb {
            cb(buckets);
        }
    }

    frame_resampler.push(&raw, &mut |frame: &[f32]| {
        handle_frame(frame, recording, vad_policy, &vad, &audio_cb, &mut processed_samples)
    });
}
```

Before this, while idle each chunk still entered both paths: the level meter ran its FFT and emitted `mic-level` events (only the recording overlay listens), and the resampler ran a Rubato `FftFixedIn` resample at non-16 kHz rates whose output went to `handle_frame`, which returns early when not recording. In always-on mode the stream stays open continuously for zero-latency start, so all of that work was done and then thrown away while idle. `Cmd::Start` already calls `visualizer.reset()` and `frame_resampler.reset()`, so both resume cleanly the moment recording begins. Idle input level is not shown.

## Testing

Automated (run locally on commit `abed823`, rebased on `upstream/main` `09aaf4d`):
- `cargo fmt --check` (in `src-tauri/`): clean.
- `cargo clippy --lib` (in `src-tauri/`): 0 errors; 1 pre-existing warning, outside the changed file (`src/managers/transcription.rs:1178`).
- `cargo test --lib` (in `src-tauri/`): 177 passed, 0 failed.

The change is a pure conditional skip of processing whose output was already discarded while idle, so recording behavior is unchanged (both the resampler and the visualizer are reset on `Cmd::Start`). A runtime before/after idle-CPU check on a build that includes #1445 would quantify the savings: always-on ON, app idle, compare the `Handy` process in Activity Monitor on base vs this branch.

## Screenshots/Videos (if applicable)

A before/after Activity Monitor reading on a current build would help but is optional.

## AI Assistance

- [x] AI was used (please describe below)

**Tools used:** Claude (via Kilo); OpenAI Codex (external review).

**How extensively:** AI wrote the code change and drafted this PR body and the linked bug report, and revised them after an external code review. The human contributor reviewed the change and the draft text, provided the system information, and approved before posting.
