### PR TITLE
feat: add opt-in always-toggle shortcut alongside push-to-talk

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -915,6 +915,13 @@ pub static ACTION_MAP: Lazy<HashMap<String, Arc<dyn ShortcutAction>>> = Lazy::ne
             post_process: false,
         }) as Arc<dyn ShortcutAction>,
     );
+    // Same action as "transcribe"; the shortcut is forced to toggle mode in shortcut::handler.
+    map.insert(
+        "transcribe_toggle".to_string(),
+        Arc::new(TranscribeAction {
+            post_process: false,
+        }) as Arc<dyn ShortcutAction>,
+    );
     map.insert(
         "transcribe_with_post_process".to_string(),
         Arc::new(TranscribeAction { post_process: true }) as Arc<dyn ShortcutAction>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -605,6 +605,7 @@ pub fn run(cli_args: CliArgs) {
             shortcut::change_binding,
             shortcut::reset_binding,
             shortcut::change_ptt_setting,
+            shortcut::change_transcribe_toggle_enabled_setting,
             shortcut::change_audio_feedback_setting,
             shortcut::change_audio_feedback_volume_setting,
             shortcut::change_sound_theme_setting,

--- a/src-tauri/src/secure_input.rs
+++ b/src-tauri/src/secure_input.rs
@@ -515,6 +515,9 @@ mod imp {
                 if id == "transcribe_with_post_process" && !settings.post_process_enabled {
                     continue;
                 }
+                if id == "transcribe_toggle" && !settings.transcribe_toggle_enabled {
+                    continue;
+                }
 
                 if register_fallback_binding(app, id, binding, &mut next) {
                     immune += 1;

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -349,6 +349,10 @@ pub struct AppSettings {
     pub bindings: HashMap<String, ShortcutBinding>,
     #[serde(default = "default_push_to_talk")]
     pub push_to_talk: bool,
+    /// Enables the separate "transcribe_toggle" shortcut, which always
+    /// operates in toggle mode regardless of `push_to_talk`.
+    #[serde(default)]
+    pub transcribe_toggle_enabled: bool,
     #[serde(default)]
     pub audio_feedback: bool,
     #[serde(default = "default_audio_feedback_volume")]
@@ -845,10 +849,28 @@ pub fn get_default_settings() -> AppSettings {
         },
     );
 
+    #[cfg(target_os = "macos")]
+    let default_toggle_shortcut = "ctrl+shift+space";
+    #[cfg(not(target_os = "macos"))]
+    let default_toggle_shortcut = "ctrl+alt+space";
+
+    bindings.insert(
+        "transcribe_toggle".to_string(),
+        ShortcutBinding {
+            id: "transcribe_toggle".to_string(),
+            name: "Toggle Recording".to_string(),
+            description: "Press once to start recording, press again to stop and transcribe."
+                .to_string(),
+            default_binding: default_toggle_shortcut.to_string(),
+            current_binding: default_toggle_shortcut.to_string(),
+        },
+    );
+
     AppSettings {
         settings_schema_version: default_settings_schema_version(),
         bindings,
         push_to_talk: default_push_to_talk(),
+        transcribe_toggle_enabled: false,
         audio_feedback: false,
         audio_feedback_volume: default_audio_feedback_volume(),
         sound_theme: default_sound_theme(),

--- a/src-tauri/src/shortcut/handler.rs
+++ b/src-tauri/src/shortcut/handler.rs
@@ -37,7 +37,9 @@ pub fn handle_shortcut_event(
     // Transcribe bindings are handled by the coordinator.
     if is_transcribe_binding(binding_id) {
         if let Some(coordinator) = app.try_state::<TranscriptionCoordinator>() {
-            coordinator.send_input(binding_id, hotkey_string, is_pressed, settings.push_to_talk);
+            // "transcribe_toggle" always behaves as a toggle, regardless of the setting.
+            let push_to_talk = binding_id != "transcribe_toggle" && settings.push_to_talk;
+            coordinator.send_input(binding_id, hotkey_string, is_pressed, push_to_talk);
         } else {
             warn!("TranscriptionCoordinator is not initialized");
         }

--- a/src-tauri/src/shortcut/handy_keys.rs
+++ b/src-tauri/src/shortcut/handy_keys.rs
@@ -437,6 +437,10 @@ pub fn init_shortcuts(app: &AppHandle) -> Result<(), String> {
         if id == "transcribe_with_post_process" && !user_settings.post_process_enabled {
             continue;
         }
+        // Skip toggle shortcut when the feature is disabled
+        if id == "transcribe_toggle" && !user_settings.transcribe_toggle_enabled {
+            continue;
+        }
 
         let binding = user_settings
             .bindings

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -258,6 +258,9 @@ pub fn resume_all_shortcuts(app: &AppHandle) {
         if id == "transcribe_with_post_process" && !settings.post_process_enabled {
             continue;
         }
+        if id == "transcribe_toggle" && !settings.transcribe_toggle_enabled {
+            continue;
+        }
         if let Err(e) = register_shortcut(app, binding.clone()) {
             debug!("resume_all_shortcuts: could not register '{}': {}", id, e);
         }
@@ -451,6 +454,11 @@ fn register_all_shortcuts_for_implementation(
             continue;
         }
 
+        // Skip toggle shortcut when the feature is disabled
+        if id == "transcribe_toggle" && !current_settings.transcribe_toggle_enabled {
+            continue;
+        }
+
         let mut binding = current_settings
             .bindings
             .get(id)
@@ -529,6 +537,15 @@ fn initialize_handy_keys_with_rollback(app: &AppHandle) -> Result<bool, String> 
 pub fn change_ptt_setting(app: AppHandle, enabled: bool) -> Result<(), String> {
     let mut settings = settings::get_settings(&app);
     settings.push_to_talk = enabled;
+    // The toggle shortcut is a companion to push-to-talk (without it, the
+    // main transcribe shortcut already toggles), so disabling push-to-talk
+    // disables the toggle shortcut too.
+    if !enabled && settings.transcribe_toggle_enabled {
+        settings.transcribe_toggle_enabled = false;
+        if let Some(binding) = settings.bindings.get("transcribe_toggle").cloned() {
+            let _ = unregister_shortcut(&app, binding);
+        }
+    }
     settings::write_settings(&app, settings);
     Ok(())
 }
@@ -985,6 +1002,29 @@ pub fn change_post_process_enabled_setting(app: AppHandle, enabled: bool) -> Res
         .get("transcribe_with_post_process")
         .cloned()
     {
+        if enabled {
+            let _ = register_shortcut(&app, binding);
+        } else {
+            let _ = unregister_shortcut(&app, binding);
+        }
+    }
+
+    crate::secure_input::reconcile_fallback(&app);
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn change_transcribe_toggle_enabled_setting(
+    app: AppHandle,
+    enabled: bool,
+) -> Result<(), String> {
+    let mut settings = settings::get_settings(&app);
+    settings.transcribe_toggle_enabled = enabled;
+    settings::write_settings(&app, settings.clone());
+
+    // Register or unregister the toggle shortcut
+    if let Some(binding) = settings.bindings.get("transcribe_toggle").cloned() {
         if enabled {
             let _ = register_shortcut(&app, binding);
         } else {

--- a/src-tauri/src/shortcut/tauri_impl.rs
+++ b/src-tauri/src/shortcut/tauri_impl.rs
@@ -27,6 +27,10 @@ pub fn init_shortcuts(app: &AppHandle) {
         if id == "transcribe_with_post_process" && !user_settings.post_process_enabled {
             continue;
         }
+        // Skip toggle shortcut when the feature is disabled
+        if id == "transcribe_toggle" && !user_settings.transcribe_toggle_enabled {
+            continue;
+        }
         let binding = user_settings
             .bindings
             .get(&id)

--- a/src-tauri/src/transcription_coordinator.rs
+++ b/src-tauri/src/transcription_coordinator.rs
@@ -76,7 +76,7 @@ pub struct TranscriptionCoordinator {
 }
 
 pub fn is_transcribe_binding(id: &str) -> bool {
-    id == "transcribe" || id == "transcribe_with_post_process"
+    id == "transcribe" || id == "transcribe_with_post_process" || id == "transcribe_toggle"
 }
 
 impl TranscriptionCoordinator {

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -29,6 +29,14 @@ async changePttSetting(enabled: boolean) : Promise<Result<null, string>> {
     else return { status: "error", error: e  as any };
 }
 },
+async changeTranscribeToggleEnabledSetting(enabled: boolean) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("change_transcribe_toggle_enabled_setting", { enabled }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async changeAudioFeedbackSetting(enabled: boolean) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("change_audio_feedback_setting", { enabled }) };
@@ -933,7 +941,12 @@ settings_schema_version?: number;
  * Defaults to empty on partial stores; the load path merges in the
  * default bindings for any missing keys before the settings are used.
  */
-bindings?: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk?: boolean; audio_feedback?: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; show_whats_new_on_update?: boolean; 
+bindings?: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk?: boolean; 
+/**
+ * Enables the separate "transcribe_toggle" shortcut, which always
+ * operates in toggle mode regardless of `push_to_talk`.
+ */
+transcribe_toggle_enabled?: boolean; audio_feedback?: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; show_whats_new_on_update?: boolean; 
 /**
  * The app version whose What's New the user has already seen. Fresh installs
  * default to the current version (nothing is "new" to them). Existing users

--- a/src/components/settings/general/GeneralSettings.tsx
+++ b/src/components/settings/general/GeneralSettings.tsx
@@ -8,6 +8,7 @@ import { SettingsGroup } from "../../ui/SettingsGroup";
 import { OutputDeviceSelector } from "../OutputDeviceSelector";
 import { PushToTalk } from "../PushToTalk";
 import { AudioFeedback } from "../AudioFeedback";
+import { ToggleSwitch } from "../../ui/ToggleSwitch";
 import { useSettings } from "../../../hooks/useSettings";
 import { VolumeSlider } from "../VolumeSlider";
 import { MuteWhileRecording } from "../MuteWhileRecording";
@@ -15,16 +16,38 @@ import { ModelSettingsCard } from "./ModelSettingsCard";
 
 export const GeneralSettings: React.FC = () => {
   const { t } = useTranslation();
-  const { audioFeedbackEnabled, getSetting } = useSettings();
+  const { audioFeedbackEnabled, getSetting, updateSetting, isUpdating } =
+    useSettings();
   const pushToTalk = getSetting("push_to_talk");
+  const toggleShortcutEnabled =
+    getSetting("transcribe_toggle_enabled") || false;
   const isLinux = type() === "linux";
   return (
     <div className="max-w-3xl w-full mx-auto space-y-6">
       <SettingsGroup title={t("settings.general.title")}>
         <ShortcutInput shortcutId="transcribe" grouped={true} />
         <PushToTalk descriptionMode="tooltip" grouped={true} />
-        {/* Cancel shortcut is hidden with push-to-talk (release key cancels) and on Linux (dynamic shortcut instability) */}
-        {!isLinux && !pushToTalk && (
+        {/* The toggle shortcut only complements push-to-talk (without it, the
+            transcribe shortcut already toggles); disabling push-to-talk also
+            disables it (see change_ptt_setting) */}
+        {pushToTalk && (
+          <ToggleSwitch
+            checked={toggleShortcutEnabled}
+            onChange={(enabled) =>
+              updateSetting("transcribe_toggle_enabled", enabled)
+            }
+            isUpdating={isUpdating("transcribe_toggle_enabled")}
+            label={t("settings.general.toggleShortcut.label")}
+            description={t("settings.general.toggleShortcut.description")}
+            descriptionMode="tooltip"
+            grouped={true}
+          />
+        )}
+        {pushToTalk && toggleShortcutEnabled && (
+          <ShortcutInput shortcutId="transcribe_toggle" grouped={true} />
+        )}
+        {/* Cancel shortcut is hidden on Linux (dynamic shortcut instability) and when no shortcut can start a toggle-mode recording */}
+        {!isLinux && (!pushToTalk || toggleShortcutEnabled) && (
           <ShortcutInput shortcutId="cancel" grouped={true} />
         )}
       </SettingsGroup>

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -179,6 +179,10 @@
           "transcribe_with_post_process": {
             "name": "Post-Processing Hotkey",
             "description": "Optional: A dedicated hotkey that always applies AI post-processing to your transcription."
+          },
+          "transcribe_toggle": {
+            "name": "Toggle Recording Shortcut",
+            "description": "Press once to start recording, press again to stop and transcribe."
           }
         },
         "errors": {
@@ -197,6 +201,10 @@
       "pushToTalk": {
         "label": "Push To Talk",
         "description": "Hold to record, release to stop"
+      },
+      "toggleShortcut": {
+        "label": "Toggle Recording",
+        "description": "Adds a second shortcut that always toggles recording, for use alongside Push To Talk"
       }
     },
     "models": {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -93,6 +93,8 @@ const settingUpdaters: {
   whats_new_last_seen_version: (value) =>
     commands.changeWhatsNewLastSeenVersionSetting(value as string),
   push_to_talk: (value) => commands.changePttSetting(value as boolean),
+  transcribe_toggle_enabled: (value) =>
+    commands.changeTranscribeToggleEnabledSetting(value as boolean),
   selected_microphone: (value) =>
     commands.setSelectedMicrophone(
       (value as string) === "Default" || value === null


### PR DESCRIPTION
## Before Submitting This PR

  **Please confirm you have done the following:**

  - [X ] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull
  requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
  - [X ] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

  ## Human Written Description

I just downloaded Handy today and after using it for a few hours it was the first feature I noticed that was missing.
There's definitely times where I want to be able to just quickly pop something in and other times where a longer bit of text is needed and therefore having the ability to do both is good.

The main thing that I didn't do here that I would have preferred to do is to change the push-to-talk pill control from the current `toggle | PTT` behaviour, to instead be `disabled | enabled`, with the separate control for the toggle feature.
The one other thing that I didn't do was make the default binding as unset - as it seems like that's not currently supported. That becomes more useful with the independent controls. 

I did see the [discussion early in the year](https://github.com/cjpais/Handy/discussions/211#discussioncomment-15656742) around the fact that you weren't sure about adding this at the time, so fair enough if you want to reject it! 

  ## Related Issues/Discussions

  Related to #147 — implements the two-shortcut variant proposed in the comments
  (a separate toggle shortcut alongside push-to-talk), rather than the
  press-vs-hold hybrid in the original post.

  **Design decisions worth flagging:**

  - Opt-in and off by default: a new `transcribe_toggle_enabled` setting gates
    registration exactly the way `post_process_enabled` gates the post-process
    shortcut, so existing users see zero change (the frozen v0.9 settings-store
    test still passes; the new field is `#[serde(default)]`, no migration).
  - With Push To Talk **off**, the main transcribe shortcut already toggles, so
    enabling this one is redundant (though harmless). It is deliberately *not*
    gated on `push_to_talk` — that would couple registration to two settings and
    create hidden-active-shortcut edge cases for a cosmetic gain. Happy to add
    that gating as a follow-up if preferred; per-binding modes seem better left
    to the keyboard rewrite mentioned in #147.
  - The Cancel shortcut row is now shown whenever any shortcut can start a
    toggle-mode recording (previously hidden whenever Push To Talk was on).

  ## Community Feedback

  In #147, @cjpais said "I like the feature you're describing", and @codepunkt /
  @samleibowitz specifically asked for "defining two shortcuts, one for push to
  talk and one for toggle" — which is what this PR adds.

  ## Testing

  - `cargo check`, `cargo clippy`, `cargo fmt --check` clean (no new warnings)
  - `cargo test`: 177 passed, including the frozen v0.9 settings-store
    compatibility test
  - `bun run lint`, `tsc`, `prettier --check`, `vite build` all pass
  - Manual on macOS: tested with new toggle both enabled and disables to confirm correct behaviour. Also tested both states of PTT with the new explicit toggle key combo.

<img width="510" height="180" alt="image" src="https://github.com/user-attachments/assets/989733f0-38a7-4ffe-84f9-5148c48074d6" />
<img width="498" height="268" alt="image" src="https://github.com/user-attachments/assets/a5a9baa3-7e15-430d-b9f6-28864261dcee" />

  ## AI Assistance

  - [ ] No AI was used in this PR
  - [x] AI was used (please describe below)

  **If AI was used:**

  - Tools used: Claude Code (Sonnet 5 wrote the initial implementation; Fable 5 reviewed and reworked it)
  - How extensively: code and commit message AI-written under human direction; human reviewed the diff, ran all
  checks, and manually tested the feature