### PR TITLE
fix(i18n): Turkish translation consistency pass

### DIFF
--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -2,8 +2,8 @@
   "tray": {
     "settings": "Ayarlar...",
     "checkUpdates": "Güncellemeleri Kontrol Et...",
-    "copyLastTranscript": "Son transkripti kopyala",
-    "unloadModel": "Modeli boşalt",
+    "copyLastTranscript": "Son Transkripti Kopyala",
+    "unloadModel": "Modeli Boşalt",
     "model": "Model",
     "quit": "Çıkış",
     "cancel": "İptal",
@@ -170,11 +170,11 @@
         "translation": "İngilizce'ye çeviriyi destekleyen modelleri filtrele"
       },
       "noModelsMatch": "Bu filtreyle eşleşen model yok.",
-      "yourModels": "İndirilen modeller",
+      "yourModels": "İndirilen Modeller",
       "availableModels": "İndirilebilir",
       "searchPlaceholder": "Modelleri ada göre ara…",
       "rescan": {
-        "label": "Yeniden tara",
+        "label": "Yeniden Tara",
         "tooltip": "Handy dışında modeller klasörüne veya Hugging Face önbelleğine eklenen modelleri yeniden tara"
       }
     },
@@ -198,7 +198,7 @@
           },
           "transcribe_with_post_process": {
             "name": "Son İşlem Kısayolu",
-            "description": "İsteğe bağlı: Transkripsiyonunuza her zaman AI son işleme uygulayan özel bir kısayol tuşu."
+            "description": "İsteğe bağlı: Transkripsiyonunuza her zaman yapay zekâ ile son işlem uygulayan özel bir kısayol tuşu."
           }
         },
         "errors": {
@@ -261,7 +261,7 @@
         "description": "Hala geliştirme aşamasında olan deneysel özellikleri etkinleştir."
       },
       "lazyStreamClose": {
-        "label": "Transkripsiyonlar arasında mikrofonu açık tut",
+        "label": "Transkripsiyonlar Arasında Mikrofonu Açık Tut",
         "description": "Kayıt durdurulduktan sonra mikrofon akışını 30 saniye açık tutar, ardışık transkripsiyonlarda gecikmeyi azaltır. Etkinken Bluetooth ses kalitesini düşürebilir."
       },
       "acceleration": {
@@ -286,7 +286,7 @@
         "description": "Bilgisayara giriş yaptığınızda Handy otomatik olarak başlatılır."
       },
       "showTrayIcon": {
-        "label": "Tepsi simgesini göster",
+        "label": "Tepsi Simgesini Göster",
         "description": "Handy simgesini sistem tepsisinde göster."
       },
       "overlay": {
@@ -300,8 +300,8 @@
           }
         },
         "position": {
-          "title": "Overlay Konumu",
-          "description": "Kayıt ve transkripsiyon sırasında görsel geri bildirim kaplamasını gösterir. Linux'ta 'Yok' önerilir.",
+          "title": "Yer Paylaşımı Konumu",
+          "description": "Yer paylaşımının kayıt ve transkripsiyon sırasında ekranda nerede görüneceğini belirler.",
           "options": {
             "bottom": "Alt",
             "top": "Üst"
@@ -323,9 +323,9 @@
       },
       "typingTool": {
         "title": "Yazma Aracı",
-        "description": "Doğrudan yapıştırma yöntemi için hangi Linux yazma aracının kullanılacağını seçin. Auto, sisteminiz için mevcut en iyi aracı otomatik olarak algılar ve kullanır.",
+        "description": "Doğrudan yapıştırma yöntemi için hangi Linux yazma aracının kullanılacağını seçin. Otomatik seçeneği, sisteminiz için mevcut en iyi aracı algılar ve kullanır.",
         "options": {
-          "auto": "Auto (Önerilen)"
+          "auto": "Otomatik (Önerilen)"
         }
       },
       "clipboardHandling": {
@@ -348,8 +348,8 @@
         }
       },
       "translateToEnglish": {
-        "label": "İngilizceye Çevir",
-        "description": "Transkripsiyon sırasında diğer dillerden İngilizceye otomatik olarak çevirir."
+        "label": "İngilizce'ye Çevir",
+        "description": "Transkripsiyon sırasında diğer dillerden İngilizce'ye otomatik olarak çevirir."
       },
       "modelUnload": {
         "title": "Modeli Boşalt",
@@ -378,7 +378,7 @@
         "description": "Kayıtlardaki sessizliği filtreler. Akış destekli modeller daha uzun bir VAD kuyruğu kullanır; VAD devre dışı bırakıldığında ham ses kaydedilir."
       },
       "fillerWordRemoval": {
-        "title": "Dolgu sözcüklerini kaldır",
+        "title": "Dolgu Sözcüklerini Kaldır",
         "description": "Transkripsiyonlardaki yaygın duraksama sözcüklerini kaldırır. Bunları korumak için kapatın."
       }
     },
@@ -415,7 +415,7 @@
         }
       },
       "prompts": {
-        "title": "İstem",
+        "title": "Prompt",
         "selectedPrompt": {
           "title": "Seçili Prompt",
           "description": "Transkripsiyonları iyileştirmek için bir şablon seçin veya yeni bir tane oluşturun. Yakalanan transkripte referans vermek için prompt metni içinde ${output} kullanın."
@@ -433,7 +433,7 @@
         "createPrompt": "Prompt Oluştur",
         "cancel": "İptal",
         "selectToEdit": "Ayrıntılarını görüntülemek ve düzenlemek için yukarıdan bir prompt seçin.",
-        "createFirst": "İlk son işlem prompt'unuzu oluşturmak için yukarıdaki “Yeni Prompt Oluştur” seçeneğine tıklayın."
+        "createFirst": "İlk son işlem promptunuzu oluşturmak için yukarıdaki “Yeni Prompt Oluştur” seçeneğine tıklayın."
       }
     },
     "history": {
@@ -446,10 +446,10 @@
       "unsave": "Kaydedilenlerden kaldır",
       "delete": "Kaydı sil",
       "deleteError": "Kayıt silinemedi. Lütfen tekrar deneyin.",
-      "retranscribe": "Yeniden yazıya dök",
-      "retranscribeError": "Yeniden yazıya dökme başarısız oldu. Lütfen tekrar deneyin.",
-      "transcribing": "Yazıya döküyor...",
-      "transcriptionFailed": "Transkripsiyon başarısız oldu. Yeniden deneme simgesini kullanarak tekrar yazıya dökebilirsiniz."
+      "retranscribe": "Yeniden transkribe et",
+      "retranscribeError": "Yeniden transkripsiyon başarısız oldu. Lütfen tekrar deneyin.",
+      "transcribing": "Transkribe ediliyor...",
+      "transcriptionFailed": "Transkripsiyon başarısız oldu. Yeniden deneme simgesini kullanarak tekrar transkribe edebilirsiniz."
     },
     "debug": {
       "title": "Hata Ayıklama",
@@ -530,19 +530,19 @@
         "settings": "Ayarlar:"
       },
       "pasteDelay": {
-        "title": "Yapıştırma gecikmesi (önce)",
+        "title": "Yapıştırma Gecikmesi (Önce)",
         "description": "Metin kopyalandıktan sonra, yapıştırma tuşu gönderilmeden önceki gecikme (milisaniye cinsinden). Hiçbir şey yapıştırılmıyorsa artırın."
       },
       "pasteDelayAfter": {
-        "title": "Yapıştırma gecikmesi (sonra)",
-        "description": "Yapıştırma tuşundan sonra, önceki panonuz geri yüklenmeden önceki gecikme (milisaniye cinsinden). Yazıya dökülen metin yerine eski pano içeriği yapıştırılıyorsa artırın."
+        "title": "Yapıştırma Gecikmesi (Sonra)",
+        "description": "Yapıştırma tuşundan sonra, önceki panonuz geri yüklenmeden önceki gecikme (milisaniye cinsinden). Transkripsiyon yerine eski pano içeriği yapıştırılıyorsa artırın."
       },
       "reliablePaste": {
-        "title": "Güvenilir yapıştırma (Beta)",
-        "description": "Panoyu sabit bir gecikmenin ardından değil, hedef uygulama yazıya dökülen metni gerçekten okuduktan sonra geri yükler. Sistem yükü altında eski pano içeriğinin yapıştırılması sorununu gidermeyi amaçlar. Pano üzerinden çalışan bir yapıştırma yöntemi gerektirir; yalnızca macOS ve Windows."
+        "title": "Güvenilir Yapıştırma (Beta)",
+        "description": "Panoyu sabit bir gecikmenin ardından değil, hedef uygulama transkripsiyonu gerçekten okuduktan sonra geri yükler. Sistem yükü altında eski pano içeriğinin yapıştırılması sorununu gidermeyi amaçlar. Pano üzerinden çalışan bir yapıştırma yöntemi gerektirir; yalnızca macOS ve Windows."
       },
       "recordingBuffer": {
-        "title": "Ekstra kayıt tamponu",
+        "title": "Ekstra Kayıt Tamponu",
         "description": "Tuşu bıraktıktan sonra arka plandaki sesi yakalamak için kaydı sürdürme süresi (milisaniye). 0 = ekstra tampon yok."
       },
       "keyboardDiagnostic": {
@@ -658,7 +658,7 @@
     "description": "Handy arayüzünün dilini değiştirin"
   },
   "theme": {
-    "title": "Uygulama teması",
+    "title": "Uygulama Teması",
     "description": "Handy'nin sistem temasını izlemesini ya da açık veya koyu kalmasını seçin",
     "options": {
       "system": "Sistem",


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

Not a previously closed/rejected change. Not a new feature — this is an improvement to an existing translation, as described in [CONTRIBUTING_TRANSLATIONS.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING_TRANSLATIONS.md#improving-existing-translations).

## Human Written Description

I'm a native Turkish speaker and I use Handy in Turkish every day. Going through the UI I fixed writing mistakes, awkward/inverted sentences and some setting descriptions so that they are easier to understand.

_(Original, in my own words: "yazım hataları, devrik cümleler, açıklama düzeltmeleri yaptım daha iyi anlaşılabilir olması için.")_

The concrete things I changed:

- **One term per concept.** The same thing was named differently depending on the panel: `transkripsiyon` vs `yazıya dökme` for transcription, `yer paylaşımı` vs `kaplama` vs untranslated `Overlay`, `AI` vs `yapay zekâ`, `İstem` vs `Prompt`. The typing-tool option said `Auto` while the language and GPU pickers right next to it said `Otomatik`.
- **Title casing.** 12 titles/labels were sentence case while English and the rest of the Turkish file use Title Case (e.g. `İndirilen modeller` → `İndirilen Modeller`).
- **`settings.advanced.overlay.position.description` was wrong.** English says where the overlay appears on screen; the Turkish said what the overlay is, and also carried a stray "On Linux 'None' is recommended" sentence that belongs to the overlay *style* setting above it.
- **Apostrophe.** `İngilizceye` → `İngilizce'ye`, per TDK (proper nouns take an apostrophe before case suffixes). 3 of the 5 occurrences already had it.

## Related Issues/Discussions

None — translation-only improvement.

## Community Feedback

None gathered; this is a translation fix rather than a feature.

## Testing

- Values only: no keys, no `{{variables}}`, no JSON structure touched.
- Verified with a script that `tr` still has exactly the same key set as `en` (425/425) and that every string's `{{placeholder}}` set matches `en`.
- The diff is 27 changed lines in a single file.
- Not visually verified in a running build — I don't have the toolchain set up on this machine right now. Happy to do that if you'd like before merging.

## Screenshots/Videos (if applicable)

N/A — text-only change.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: I used it to diff the Turkish locale against the English source, list every place where terminology or casing was inconsistent, and apply the edits. The wording decisions and the final review are mine as a native speaker.
