### PR TITLE
fix(qwen): chunk long audio before decoder truncation

### DIFF
--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -38,6 +38,91 @@ use transcribe_rs::{
 
 const STREAM_PERF_LOG_INTERVAL: Duration = Duration::from_secs(5);
 const STREAM_FINALIZE_REPLY_TIMEOUT: Duration = Duration::from_secs(30);
+const QWEN_LONG_AUDIO_TARGET_SAMPLES: usize = 25 * 16_000;
+const QWEN_LONG_AUDIO_MAX_SAMPLES: usize = 30 * 16_000;
+const QWEN_SILENCE_WINDOW_SAMPLES: usize = 16_000 / 10;
+const QWEN_SILENCE_SCAN_STEP_SAMPLES: usize = 16_000 / 100;
+
+fn should_chunk_qwen_audio(is_qwen3_asr: bool, audio_len: usize) -> bool {
+    is_qwen3_asr && audio_len > QWEN_LONG_AUDIO_MAX_SAMPLES
+}
+
+fn qwen_long_audio_ranges(audio: &[f32]) -> Vec<std::ops::Range<usize>> {
+    let mut ranges = Vec::new();
+    let mut start = 0;
+
+    while audio.len().saturating_sub(start) > QWEN_LONG_AUDIO_MAX_SAMPLES {
+        let search_start = start + QWEN_LONG_AUDIO_TARGET_SAMPLES;
+        let search_end = (start + QWEN_LONG_AUDIO_MAX_SAMPLES).min(audio.len());
+        let last_window_start = search_end.saturating_sub(QWEN_SILENCE_WINDOW_SAMPLES);
+
+        let mut quietest_start = search_start;
+        let mut quietest_score = f32::INFINITY;
+        let mut candidate = search_start;
+        while candidate <= last_window_start {
+            let score = audio[candidate..candidate + QWEN_SILENCE_WINDOW_SAMPLES]
+                .iter()
+                .map(|sample| sample.abs())
+                .sum::<f32>();
+            if score < quietest_score {
+                quietest_score = score;
+                quietest_start = candidate;
+            }
+            candidate += QWEN_SILENCE_SCAN_STEP_SAMPLES;
+        }
+
+        let cut = (quietest_start + QWEN_SILENCE_WINDOW_SAMPLES / 2).min(search_end);
+        ranges.push(start..cut);
+        start = cut;
+    }
+
+    if start < audio.len() {
+        ranges.push(start..audio.len());
+    }
+    ranges
+}
+
+fn transcribe_qwen_long_audio<F>(
+    audio: &[f32],
+    ranges: &[std::ops::Range<usize>],
+    mut transcribe_chunk: F,
+) -> Result<(String, Option<String>)>
+where
+    F: FnMut(&[f32]) -> Result<(String, Option<String>)>,
+{
+    let mut transcripts = Vec::new();
+    let mut language_sample_counts: Vec<(String, usize)> = Vec::new();
+    for range in ranges {
+        let range_len = range.end - range.start;
+        let (text, detected_language) = transcribe_chunk(&audio[range.clone()])?;
+        let text = text.trim();
+        if !text.is_empty() {
+            transcripts.push(text.to_string());
+        }
+
+        if let Some(language) = detected_language {
+            if let Some((_, sample_count)) = language_sample_counts
+                .iter_mut()
+                .find(|(candidate, _)| candidate == &language)
+            {
+                *sample_count += range_len;
+            } else {
+                language_sample_counts.push((language, range_len));
+            }
+        }
+    }
+
+    let mut detected_language = None;
+    let mut detected_language_samples = 0;
+    for (language, sample_count) in language_sample_counts {
+        if sample_count > detected_language_samples {
+            detected_language = Some(language);
+            detected_language_samples = sample_count;
+        }
+    }
+
+    Ok((transcripts.join(" "), detected_language))
+}
 
 fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
     if let Some(message) = payload.downcast_ref::<&str>() {
@@ -1220,6 +1305,10 @@ impl TranscriptionManager {
         // with INVALID_ARG, so the whisper extension must be gated on the
         // arch, not on the feature (see #1601).
         let mut model_is_whisper = false;
+        // Qwen3-ASR's transcribe-cpp decoder has a 256-token per-run generation
+        // budget. Long, dense speech must be split before decode or the whole
+        // run returns OUTPUT_TRUNCATED (status 18).
+        let mut model_is_qwen3_asr = false;
 
         // Perform transcription with the appropriate engine.
         // We use catch_unwind to prevent engine panics from poisoning the mutex,
@@ -1261,6 +1350,7 @@ impl TranscriptionManager {
                 let caps = model.capabilities();
                 model_takes_initial_prompt = model.supports(Feature::InitialPrompt);
                 model_is_whisper = model.arch() == "whisper";
+                model_is_qwen3_asr = model.arch() == "qwen3_asr";
                 model_supports_translate = caps.supports_translate;
                 model_languages = caps.languages;
                 debug!(
@@ -1314,17 +1404,36 @@ impl TranscriptionManager {
                             run_options.family.is_some()
                         );
 
-                        session
-                            .run(&audio, &run_options)
-                            .map(|t| {
+                        let mut run_chunk = |pcm: &[f32]| {
+                            session
+                                .run(pcm, &run_options)
+                                .map(|t| (t.text, t.language))
+                                .map_err(|e| {
+                                    anyhow::anyhow!("transcribe-cpp transcription failed: {}", e)
+                                })
+                        };
+
+                        if should_chunk_qwen_audio(model_is_qwen3_asr, audio.len()) {
+                            let ranges = qwen_long_audio_ranges(&audio);
+                            info!(
+                                "Qwen long-audio mode: splitting {:.2}s into {} silence-aware chunks",
+                                audio.len() as f64 / 16_000.0,
+                                ranges.len()
+                            );
+                            transcribe_qwen_long_audio(&audio, &ranges, &mut run_chunk).map(
+                                |(text, detected_language)| {
+                                    model_detected_language = detected_language;
+                                    text
+                                },
+                            )
+                        } else {
+                            run_chunk(&audio).map(|(text, detected_language)| {
                                 // Whisper's audio-based LID (auto mode only;
                                 // `None` when a language hint was passed).
-                                model_detected_language = t.language;
-                                t.text
+                                model_detected_language = detected_language;
+                                text
                             })
-                            .map_err(|e| {
-                                anyhow::anyhow!("transcribe-cpp transcription failed: {}", e)
-                            })
+                        }
                     }
                     LoadedEngine::Parakeet(parakeet_engine) => {
                         let params = ParakeetParams {
@@ -2144,6 +2253,96 @@ mod tests {
 
     fn languages(codes: &[&str]) -> Vec<String> {
         codes.iter().map(|code| (*code).to_string()).collect()
+    }
+
+    #[test]
+    fn qwen_long_audio_ranges_cover_every_sample_with_thirty_second_cap() {
+        let audio = vec![0.25_f32; 1_530_720];
+
+        let ranges = qwen_long_audio_ranges(&audio);
+
+        assert!(ranges.len() > 1);
+        assert_eq!(ranges.first().unwrap().start, 0);
+        assert_eq!(ranges.last().unwrap().end, audio.len());
+        assert!(ranges.windows(2).all(|pair| pair[0].end == pair[1].start));
+        assert!(ranges
+            .iter()
+            .all(|range| range.end - range.start <= 30 * 16_000));
+    }
+
+    #[test]
+    fn qwen_long_audio_ranges_prefer_quiet_boundary_before_hard_cap() {
+        let mut audio = vec![0.5_f32; 40 * 16_000];
+        audio[27 * 16_000..28 * 16_000].fill(0.0);
+
+        let ranges = qwen_long_audio_ranges(&audio);
+
+        assert!((27 * 16_000..=28 * 16_000).contains(&ranges[0].end));
+    }
+
+    #[test]
+    fn qwen_long_audio_transcribes_each_range_and_joins_non_empty_text() {
+        let audio = vec![0.5_f32; 61 * 16_000];
+        let mut calls = 0;
+
+        let ranges = qwen_long_audio_ranges(&audio);
+        let (text, _) = transcribe_qwen_long_audio(&audio, &ranges, |_| {
+            calls += 1;
+            Ok((format!("chunk-{calls}"), None))
+        })
+        .unwrap();
+
+        assert_eq!(calls, 3);
+        assert_eq!(text, "chunk-1 chunk-2 chunk-3");
+    }
+
+    #[test]
+    fn qwen_long_audio_language_detection_prefers_more_audio_and_ignores_none() {
+        let audio = vec![0.5_f32; 30 * 16_000 + 1];
+        let ranges = qwen_long_audio_ranges(&audio);
+        assert_eq!(ranges.len(), 2);
+
+        let mut calls = 0;
+        let (_, language) = transcribe_qwen_long_audio(&audio, &ranges, |_| {
+            calls += 1;
+            Ok((String::new(), (calls == 1).then(|| "ko".to_string())))
+        })
+        .unwrap();
+        assert_eq!(language.as_deref(), Some("ko"));
+
+        calls = 0;
+        let (_, language) = transcribe_qwen_long_audio(&audio, &ranges, |_| {
+            calls += 1;
+            let language = if calls == 1 { "ko" } else { "en" };
+            Ok((String::new(), Some(language.to_string())))
+        })
+        .unwrap();
+        assert_eq!(language.as_deref(), Some("ko"));
+    }
+
+    #[test]
+    fn qwen_long_audio_stops_on_chunk_error_without_partial_result() {
+        let audio = vec![0.5_f32; 61 * 16_000];
+        let ranges = qwen_long_audio_ranges(&audio);
+        let mut calls = 0;
+
+        let result = transcribe_qwen_long_audio(&audio, &ranges, |_| {
+            calls += 1;
+            if calls == 2 {
+                anyhow::bail!("chunk failed");
+            }
+            Ok((format!("chunk-{calls}"), Some("ko".to_string())))
+        });
+
+        assert!(result.is_err());
+        assert_eq!(calls, 2);
+    }
+
+    #[test]
+    fn qwen_long_audio_chunking_gate_excludes_short_and_non_qwen_audio() {
+        assert!(should_chunk_qwen_audio(true, 31 * 16_000));
+        assert!(!should_chunk_qwen_audio(true, 30 * 16_000));
+        assert!(!should_chunk_qwen_audio(false, 95 * 16_000));
     }
 
     #[test]


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [x] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

TODO (human contributor): Please add 2–3 sentences in your own words describing the long-recording failure you experienced and why fixing it matters. This placeholder is intentional and follows the repository's AI contribution policy.

## Related Issues/Discussions

Related: #1627
Related: #1173

This is a narrow resubmission of the Qwen failure mode discussed in #1627. That PR was closed because it accidentally vendored a very large transcribe.cpp change; the maintainer explicitly invited a smaller resubmission or separate changes per repository. Unlike the general/optional chunking work closed in favor of #1173, this PR only activates for `qwen3_asr` input over 30 seconds and leaves all other engines and short Qwen input unchanged.

## Community Feedback

No discussion has been opened. The bug was reproduced locally on Handy v0.9.5 with multiple retained recordings: one 83.22-second recording failed as a single run but both 41.61-second halves succeeded, and a 95.67-second recording failed with `TRANSCRIBE_ERR_OUTPUT_TRUNCATED` / status 18 at the backend's fixed 256-token generation budget.

## Testing

- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml qwen_long_audio --lib` — 6 passed
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 208 passed, 0 failed
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features` — exit 0; only warnings already present on `main`
- [x] Release build: `cargo build --manifest-path src-tauri/Cargo.toml --release --bin handy`
- [x] Real 95.67-second, 16 kHz mono Qwen3-ASR 1.7B fixture: split into 4 silence-aware chunks; exit 0; non-empty 490-character result; no status 18 or truncation
- [x] History row count stayed unchanged during the headless fixture test
- [x] Transcript contents were not inspected or included in logs/PR material

The six added regression tests verify:

1. contiguous full sample coverage with a 30-second maximum chunk size;
2. preference for a quiet boundary near the 25-second target;
3. ordered joining of non-empty chunk results; and
4. the Qwen-only, over-30-second activation gate;
5. sample-duration-weighted language detection that cannot be overwritten by a short final chunk or `None`; and
6. fail-fast error propagation without returning a partial joined transcript.

## Screenshots/Videos (if applicable)

Not applicable; this is a backend-only fix. The relevant runtime log is:

```text
Qwen long-audio mode: splitting 95.67s into 4 silence-aware chunks
```

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Hermes Agent (Nous Research), OpenAI Codex model
- How extensively: AI assisted with root-cause analysis, source inspection, implementation, test generation, build verification, and drafting the non-human-written sections of this PR. The change was validated with the full Rust test suite and a real retained failure fixture. The `Human Written Description` is deliberately left for the human contributor.
