### PR TITLE
docs: explain macOS Accessibility after local rebuilds

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -165,9 +165,15 @@ Grant Accessibility again when prompted. This does not reset Microphone or other
 services, and official releases normally do not need it.
 
 For optional diagnosis, compare the designated requirements of the previous and rebuilt
-bundles with `codesign -dr - /path/to/Handy.app 2>&1`. An ad-hoc requirement contains a
-`cdhash`; a changed requirement confirms the rebuild is not covered by the old grant.
-The reset procedure does not require this check.
+bundles:
+
+```bash
+codesign -dr - /path/to/previous/Handy.app 2>&1
+codesign -dr - /Applications/Handy.app 2>&1
+```
+
+An ad-hoc requirement contains a `cdhash`; a changed requirement confirms the rebuild is
+not covered by the old grant. The reset procedure does not require this check.
 
 See [issue #1618](https://github.com/cjpais/Handy/issues/1618) for the related onboarding
 and stale-permission report.

--- a/BUILD.md
+++ b/BUILD.md
@@ -146,42 +146,28 @@ Resources only need re-copying if they change upstream (new icons, sounds, model
 
 ## Troubleshooting
 
-### macOS Accessibility stays enabled but a local rebuild is not trusted
+### macOS Accessibility remains enabled after a local rebuild
 
-Handy's current `signingIdentity: "-"` configuration produces an ad-hoc signature unless
-you provide a stable signing identity. For an ad-hoc signature, macOS may use the bundle's
-CDHash as its designated requirement. That hash changes when the rebuilt executable's
-signed contents change, even though the app name, install path, and bundle identifier
-(`com.pais.handy`) stay the same.
+Local builds use the ad-hoc `signingIdentity: "-"`. A rebuild can have a new macOS code
+identity while the old **System Settings > Privacy & Security > Accessibility** entry
+remains visibly enabled, leaving Handy on `Waiting...`.
 
-The old `Handy.app` row can therefore remain enabled in **System Settings > Privacy &
-Security > Accessibility** while the newly built process still reports that Accessibility
-is not granted. This is especially confusing when onboarding remains on `Waiting...`.
-
-First install the final bundle at `/Applications/Handy.app`; do not grant permissions to an
-intermediate build path. Confirm that the current build has a different designated
-requirement from the previously approved build:
+After installing the final bundle at `/Applications/Handy.app`, quit Handy, clear only its
+stale Accessibility record, then reopen it:
 
 ```bash
-codesign -dr - /path/to/previous/Handy.app 2>&1
-codesign -dr - /Applications/Handy.app 2>&1
-codesign -dv --verbose=4 /Applications/Handy.app 2>&1 | grep -E 'Signature=|CDHash=|Identifier='
-```
-
-If the app is ad-hoc signed, the CDHash changed, and the installed app still cannot detect
-Accessibility despite the visible enabled row, clear only Handy's stale Accessibility
-record:
-
-```bash
+osascript -e 'tell application id "com.pais.handy" to quit' || true
 tccutil reset Accessibility com.pais.handy
-osascript -e 'tell application id "com.pais.handy" to quit'
 open /Applications/Handy.app
 ```
 
-Grant Accessibility again when macOS prompts. Do not reset Microphone or unrelated TCC
-services unless those permissions are independently failing. Do not run the reset
-speculatively: official releases signed with the same Developer ID normally retain a
-stable code requirement across updates.
+Grant Accessibility again when prompted. This does not reset Microphone or other TCC
+services, and official releases normally do not need it.
+
+For optional diagnosis, compare the designated requirements of the previous and rebuilt
+bundles with `codesign -dr - /path/to/Handy.app 2>&1`. An ad-hoc requirement contains a
+`cdhash`; a changed requirement confirms the rebuild is not covered by the old grant.
+The reset procedure does not require this check.
 
 See [issue #1618](https://github.com/cjpais/Handy/issues/1618) for the related onboarding
 and stale-permission report.

--- a/BUILD.md
+++ b/BUILD.md
@@ -146,6 +146,46 @@ Resources only need re-copying if they change upstream (new icons, sounds, model
 
 ## Troubleshooting
 
+### macOS Accessibility stays enabled but a local rebuild is not trusted
+
+Handy's current `signingIdentity: "-"` configuration produces an ad-hoc signature unless
+you provide a stable signing identity. For an ad-hoc signature, macOS may use the bundle's
+CDHash as its designated requirement. That hash changes when the rebuilt executable's
+signed contents change, even though the app name, install path, and bundle identifier
+(`com.pais.handy`) stay the same.
+
+The old `Handy.app` row can therefore remain enabled in **System Settings > Privacy &
+Security > Accessibility** while the newly built process still reports that Accessibility
+is not granted. This is especially confusing when onboarding remains on `Waiting...`.
+
+First install the final bundle at `/Applications/Handy.app`; do not grant permissions to an
+intermediate build path. Confirm that the current build has a different designated
+requirement from the previously approved build:
+
+```bash
+codesign -dr - /path/to/previous/Handy.app 2>&1
+codesign -dr - /Applications/Handy.app 2>&1
+codesign -dv --verbose=4 /Applications/Handy.app 2>&1 | grep -E 'Signature=|CDHash=|Identifier='
+```
+
+If the app is ad-hoc signed, the CDHash changed, and the installed app still cannot detect
+Accessibility despite the visible enabled row, clear only Handy's stale Accessibility
+record:
+
+```bash
+tccutil reset Accessibility com.pais.handy
+osascript -e 'tell application id "com.pais.handy" to quit'
+open /Applications/Handy.app
+```
+
+Grant Accessibility again when macOS prompts. Do not reset Microphone or unrelated TCC
+services unless those permissions are independently failing. Do not run the reset
+speculatively: official releases signed with the same Developer ID normally retain a
+stable code requirement across updates.
+
+See [issue #1618](https://github.com/cjpais/Handy/issues/1618) for the related onboarding
+and stale-permission report.
+
 ### AppImage build fails on Arch / rolling-release distros
 
 `linuxdeploy` bundles its own `strip` binary which is too old to process system libraries built with newer toolchains on rolling-release distros (Arch, CachyOS, Manjaro, EndeavourOS).


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Human Written Description

> TODO (human contributor): In 2–3 sentences, describe the stale Accessibility entry you encountered after installing a locally rebuilt Handy bundle and why documenting the recovery matters.

## Related Issues/Discussions

Related to #1618. This documentation PR does not close the user-facing onboarding issue.

Discussion: N/A — this documents a verified local-build troubleshooting case.

## Community Feedback

Issue #1618 reports stale macOS Accessibility entries after update/reinstall. A commenter independently reported the same class of TCC/signature mismatch and reset workaround.

## Testing

- [x] `git diff --check`
- [x] `bun x prettier --check BUILD.md`
- [x] Verified the procedure against two real ad-hoc Handy bundles with different designated CDHash requirements
- [x] Confirmed `tccutil reset Accessibility com.pais.handy` followed by relaunch and human reapproval resolved `AXIsProcessTrusted() == false`
- [x] Confirmed the instructions reset only Accessibility, not Microphone or unrelated TCC services
- [x] Independent technical/safety review completed before push

## Screenshots/Videos (if applicable)

Not applicable; documentation-only.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Hermes Agent
- How extensively: AI compared the previous and current bundle signing requirements, traced the permission check to `AXIsProcessTrusted()`, reproduced the stale TCC behavior, drafted the troubleshooting section, and ran formatting and safety checks. The human contributor reproduced the issue, granted the final permission, and confirmed the recovery worked.
