### PR TITLE
fix(onboarding): recover from stalled permission checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "format:frontend": "prettier --write .",
     "format:backend": "cd src-tauri && cargo fmt",
     "test:playwright": "playwright test",
+    "test:permission-polling": "bun src/components/onboarding/permissionPolling.test.ts",
     "test:playwright:ui": "playwright test --ui",
     "check:translations": "bun scripts/check-translations.ts",
     "postinstall": "bun scripts/check-nix-deps.ts"

--- a/src/components/onboarding/AccessibilityOnboarding.tsx
+++ b/src/components/onboarding/AccessibilityOnboarding.tsx
@@ -12,12 +12,16 @@ import { commands } from "@/bindings";
 import { useSettingsStore } from "@/stores/settingsStore";
 import HandyTextLogo from "../icons/HandyTextLogo";
 import { Keyboard, Mic, Check, Loader2 } from "lucide-react";
+import {
+  permissionPollingErrorOutcome,
+  permissionPollOutcome,
+  type PermissionStatus,
+} from "./permissionPolling";
 
 interface AccessibilityOnboardingProps {
   onComplete: () => void;
 }
 
-type PermissionStatus = "checking" | "needed" | "waiting" | "granted";
 type PermissionPlatform = "macos" | "windows" | "other";
 
 interface PermissionsState {
@@ -44,7 +48,21 @@ const AccessibilityOnboarding: React.FC<AccessibilityOnboardingProps> = ({
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const errorCountRef = useRef<number>(0);
-  const MAX_POLLING_ERRORS = 3;
+  const pollingInFlightRef = useRef(false);
+  const permissionsRef = useRef(permissions);
+  const waitingSinceRef = useRef<{
+    accessibility: number | null;
+    microphone: number | null;
+  }>({ accessibility: null, microphone: null });
+
+  const updatePermissions = useCallback(
+    (updater: (current: PermissionsState) => PermissionsState) => {
+      const next = updater(permissionsRef.current);
+      permissionsRef.current = next;
+      setPermissions(next);
+    },
+    [],
+  );
 
   const isMacOS = permissionPlatform === "macos";
   const isWindows = permissionPlatform === "windows";
@@ -117,7 +135,7 @@ const AccessibilityOnboarding: React.FC<AccessibilityOnboardingProps> = ({
             microphone: microphoneGranted ? "granted" : "needed",
           };
 
-          setPermissions(newState);
+          updatePermissions(() => newState);
 
           if (accessibilityGranted && microphoneGranted) {
             await completeOnboarding();
@@ -125,10 +143,10 @@ const AccessibilityOnboarding: React.FC<AccessibilityOnboardingProps> = ({
         } catch (error) {
           console.error("Failed to check macOS permissions:", error);
           toast.error(t("onboarding.permissions.errors.checkFailed"));
-          setPermissions({
+          updatePermissions(() => ({
             accessibility: "needed",
             microphone: "needed",
-          });
+          }));
         }
 
         return;
@@ -137,38 +155,55 @@ const AccessibilityOnboarding: React.FC<AccessibilityOnboardingProps> = ({
       try {
         const microphoneGranted = await hasWindowsMicrophoneAccess();
 
-        setPermissions({
+        updatePermissions(() => ({
           accessibility: "granted",
           microphone: microphoneGranted ? "granted" : "needed",
-        });
+        }));
 
         if (microphoneGranted) {
           await completeOnboarding();
         }
       } catch (error) {
         console.warn("Failed to check Windows microphone permissions:", error);
-        setPermissions({
+        updatePermissions(() => ({
           accessibility: "granted",
           microphone: "granted",
-        });
+        }));
         await completeOnboarding();
       }
     };
 
     checkInitial();
-  }, [completeOnboarding, hasWindowsMicrophoneAccess, onComplete, t]);
+  }, [
+    completeOnboarding,
+    hasWindowsMicrophoneAccess,
+    onComplete,
+    t,
+    updatePermissions,
+  ]);
 
   // Polling for permissions after user clicks a button
   const startPolling = useCallback(() => {
     if (pollingRef.current || permissionPlatform === null) return;
 
+    errorCountRef.current = permissionPollingErrorOutcome(
+      errorCountRef.current,
+      "start",
+    ).consecutiveErrors;
+
     pollingRef.current = setInterval(async () => {
+      if (pollingInFlightRef.current) return;
+      pollingInFlightRef.current = true;
+
       try {
         if (permissionPlatform === "windows") {
           const microphoneGranted = await hasWindowsMicrophoneAccess();
 
           if (microphoneGranted) {
-            setPermissions((prev) => ({ ...prev, microphone: "granted" }));
+            updatePermissions((prev) => ({
+              ...prev,
+              microphone: "granted",
+            }));
 
             if (pollingRef.current) {
               clearInterval(pollingRef.current);
@@ -178,7 +213,10 @@ const AccessibilityOnboarding: React.FC<AccessibilityOnboardingProps> = ({
             await completeOnboarding();
           }
 
-          errorCountRef.current = 0;
+          errorCountRef.current = permissionPollingErrorOutcome(
+            errorCountRef.current,
+            "success",
+          ).consecutiveErrors;
           return;
         }
 
@@ -187,53 +225,102 @@ const AccessibilityOnboarding: React.FC<AccessibilityOnboardingProps> = ({
           checkMicrophonePermission(),
         ]);
 
-        setPermissions((prev) => {
-          const newState = { ...prev };
+        const now = Date.now();
+        const outcome = permissionPollOutcome(
+          permissionsRef.current,
+          {
+            accessibility: accessibilityGranted,
+            microphone: microphoneGranted,
+          },
+          waitingSinceRef.current,
+          now,
+        );
 
-          if (accessibilityGranted && prev.accessibility !== "granted") {
-            newState.accessibility = "granted";
-            // Initialize Enigo and shortcuts when accessibility is granted
-            Promise.all([
-              commands.initializeEnigo(),
-              commands.initializeShortcuts(),
-            ]).catch((e) => {
-              console.warn("Failed to initialize after permission grant:", e);
-            });
-          }
+        if (
+          accessibilityGranted &&
+          permissionsRef.current.accessibility !== "granted"
+        ) {
+          // Initialize Enigo and shortcuts when accessibility is granted
+          Promise.all([
+            commands.initializeEnigo(),
+            commands.initializeShortcuts(),
+          ]).catch((e) => {
+            console.warn("Failed to initialize after permission grant:", e);
+          });
+        }
 
-          if (microphoneGranted && prev.microphone !== "granted") {
-            newState.microphone = "granted";
-          }
+        updatePermissions(() => outcome.permissions);
 
-          return newState;
-        });
+        if (accessibilityGranted || outcome.timedOut.accessibility) {
+          waitingSinceRef.current.accessibility = null;
+        }
+        if (microphoneGranted || outcome.timedOut.microphone) {
+          waitingSinceRef.current.microphone = null;
+        }
+
+        if (outcome.timedOut.accessibility || outcome.timedOut.microphone) {
+          toast.error(t("onboarding.permissions.errors.checkFailed"));
+        }
 
         // If both granted, stop polling, refresh audio devices, and proceed
-        if (accessibilityGranted && microphoneGranted) {
+        if (outcome.allGranted) {
           if (pollingRef.current) {
             clearInterval(pollingRef.current);
             pollingRef.current = null;
           }
           await completeOnboarding();
+        } else if (
+          waitingSinceRef.current.accessibility === null &&
+          waitingSinceRef.current.microphone === null
+        ) {
+          if (pollingRef.current) {
+            clearInterval(pollingRef.current);
+            pollingRef.current = null;
+          }
         }
 
         // Reset error count on success
-        errorCountRef.current = 0;
+        errorCountRef.current = permissionPollingErrorOutcome(
+          errorCountRef.current,
+          "success",
+        ).consecutiveErrors;
       } catch (error) {
         console.error("Error checking permissions:", error);
-        errorCountRef.current += 1;
+        const errorOutcome = permissionPollingErrorOutcome(
+          errorCountRef.current,
+          "failure",
+        );
+        errorCountRef.current = errorOutcome.consecutiveErrors;
 
-        if (errorCountRef.current >= MAX_POLLING_ERRORS) {
+        if (errorOutcome.shouldStop) {
           // Stop polling after too many consecutive errors
           if (pollingRef.current) {
             clearInterval(pollingRef.current);
             pollingRef.current = null;
           }
+          waitingSinceRef.current = {
+            accessibility: null,
+            microphone: null,
+          };
+          updatePermissions((prev) => ({
+            accessibility:
+              prev.accessibility === "waiting" ? "needed" : prev.accessibility,
+            microphone:
+              prev.microphone === "waiting" ? "needed" : prev.microphone,
+          }));
           toast.error(t("onboarding.permissions.errors.checkFailed"));
         }
+      } finally {
+        pollingInFlightRef.current = false;
       }
     }, 1000);
-  }, [completeOnboarding, hasWindowsMicrophoneAccess, permissionPlatform, t]);
+  }, [
+    completeOnboarding,
+    hasWindowsMicrophoneAccess,
+    permissionPlatform,
+    t,
+    updatePermissions,
+  ]);
 
   // Cleanup polling and timeouts on unmount
   useEffect(() => {
@@ -250,7 +337,11 @@ const AccessibilityOnboarding: React.FC<AccessibilityOnboardingProps> = ({
   const handleGrantAccessibility = async () => {
     try {
       await requestAccessibilityPermission();
-      setPermissions((prev) => ({ ...prev, accessibility: "waiting" }));
+      waitingSinceRef.current.accessibility = Date.now();
+      updatePermissions((prev) => ({
+        ...prev,
+        accessibility: "waiting",
+      }));
       startPolling();
     } catch (error) {
       console.error("Failed to request accessibility permission:", error);
@@ -266,7 +357,10 @@ const AccessibilityOnboarding: React.FC<AccessibilityOnboardingProps> = ({
         await requestMicrophonePermission();
       }
 
-      setPermissions((prev) => ({ ...prev, microphone: "waiting" }));
+      if (!isWindows) {
+        waitingSinceRef.current.microphone = Date.now();
+      }
+      updatePermissions((prev) => ({ ...prev, microphone: "waiting" }));
       startPolling();
     } catch (error) {
       console.error("Failed to request microphone permission:", error);

--- a/src/components/onboarding/permissionPolling.test.ts
+++ b/src/components/onboarding/permissionPolling.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert";
+import {
+  PERMISSION_POLL_TIMEOUT_MS,
+  permissionPollOutcome,
+  permissionPollingErrorOutcome,
+  permissionStatusAfterPoll,
+} from "./permissionPolling";
+
+assert.equal(
+  permissionStatusAfterPoll(
+    "waiting",
+    false,
+    1_000,
+    1_000 + PERMISSION_POLL_TIMEOUT_MS - 1,
+  ),
+  "waiting",
+  "a pending request should keep waiting before the timeout",
+);
+
+assert.equal(
+  permissionStatusAfterPoll(
+    "waiting",
+    false,
+    1_000,
+    1_000 + PERMISSION_POLL_TIMEOUT_MS,
+  ),
+  "needed",
+  "an undetected permission should become retryable at the timeout",
+);
+
+assert.equal(
+  permissionStatusAfterPoll("waiting", true, 1_000, 1_001),
+  "granted",
+  "a granted permission should complete immediately",
+);
+
+assert.equal(
+  permissionStatusAfterPoll("needed", false, null, 99_000),
+  "needed",
+  "a permission that was not requested should remain idle",
+);
+
+assert.equal(
+  permissionStatusAfterPoll("granted", false, null, 99_000),
+  "granted",
+  "a transient false poll must not revoke a grant already observed by this screen",
+);
+
+const preservedGrantCompletion = permissionPollOutcome(
+  { accessibility: "granted", microphone: "waiting" },
+  { accessibility: false, microphone: true },
+  { accessibility: null, microphone: 1_000 },
+  2_000,
+);
+
+assert.deepEqual(
+  preservedGrantCompletion.permissions,
+  { accessibility: "granted", microphone: "granted" },
+  "the combined outcome should preserve a previously observed grant",
+);
+assert.equal(
+  preservedGrantCompletion.allGranted,
+  true,
+  "completion must use the resulting permission state rather than raw poll booleans",
+);
+
+const firstStaggeredPoll = permissionPollOutcome(
+  { accessibility: "waiting", microphone: "waiting" },
+  { accessibility: true, microphone: false },
+  { accessibility: 1_000, microphone: 1_000 },
+  2_000,
+);
+assert.deepEqual(firstStaggeredPoll.permissions, {
+  accessibility: "granted",
+  microphone: "waiting",
+});
+assert.equal(firstStaggeredPoll.allGranted, false);
+
+const onePermissionTimeout = permissionPollOutcome(
+  firstStaggeredPoll.permissions,
+  { accessibility: false, microphone: false },
+  { accessibility: null, microphone: 1_000 },
+  1_000 + PERMISSION_POLL_TIMEOUT_MS,
+);
+assert.deepEqual(onePermissionTimeout.timedOut, {
+  accessibility: false,
+  microphone: true,
+});
+assert.deepEqual(onePermissionTimeout.permissions, {
+  accessibility: "granted",
+  microphone: "needed",
+});
+
+const simultaneousGrant = permissionPollOutcome(
+  { accessibility: "waiting", microphone: "waiting" },
+  { accessibility: true, microphone: true },
+  { accessibility: 1_000, microphone: 1_000 },
+  1_001,
+);
+assert.equal(simultaneousGrant.allGranted, true);
+
+let errorState = permissionPollingErrorOutcome(0, "failure");
+assert.deepEqual(errorState, { consecutiveErrors: 1, shouldStop: false });
+errorState = permissionPollingErrorOutcome(
+  errorState.consecutiveErrors,
+  "failure",
+);
+errorState = permissionPollingErrorOutcome(
+  errorState.consecutiveErrors,
+  "failure",
+);
+assert.deepEqual(errorState, { consecutiveErrors: 3, shouldStop: true });
+
+errorState = permissionPollingErrorOutcome(
+  errorState.consecutiveErrors,
+  "start",
+);
+assert.deepEqual(
+  errorState,
+  { consecutiveErrors: 0, shouldStop: false },
+  "a retry must start with a fresh consecutive-error budget",
+);
+errorState = permissionPollingErrorOutcome(
+  errorState.consecutiveErrors,
+  "failure",
+);
+assert.deepEqual(
+  errorState,
+  { consecutiveErrors: 1, shouldStop: false },
+  "the first failure after retry must not stop polling",
+);
+
+console.log("permissionPolling: all assertions passed");

--- a/src/components/onboarding/permissionPolling.ts
+++ b/src/components/onboarding/permissionPolling.ts
@@ -1,0 +1,97 @@
+export const PERMISSION_POLL_TIMEOUT_MS = 15_000;
+export const MAX_PERMISSION_POLLING_ERRORS = 3;
+
+export type PermissionStatus = "checking" | "needed" | "waiting" | "granted";
+
+export interface PermissionPair<T> {
+  accessibility: T;
+  microphone: T;
+}
+
+export interface PermissionPollOutcome {
+  permissions: PermissionPair<PermissionStatus>;
+  timedOut: PermissionPair<boolean>;
+  allGranted: boolean;
+}
+
+export type PermissionPollingErrorEvent = "start" | "success" | "failure";
+
+export interface PermissionPollingErrorOutcome {
+  consecutiveErrors: number;
+  shouldStop: boolean;
+}
+
+export function permissionPollingErrorOutcome(
+  currentErrorCount: number,
+  event: PermissionPollingErrorEvent,
+): PermissionPollingErrorOutcome {
+  const consecutiveErrors = event === "failure" ? currentErrorCount + 1 : 0;
+
+  return {
+    consecutiveErrors,
+    shouldStop:
+      event === "failure" && consecutiveErrors >= MAX_PERMISSION_POLLING_ERRORS,
+  };
+}
+
+export function permissionStatusAfterPoll(
+  current: PermissionStatus,
+  granted: boolean,
+  waitingSince: number | null,
+  now: number,
+): PermissionStatus {
+  if (granted) return "granted";
+
+  if (
+    current === "waiting" &&
+    waitingSince !== null &&
+    now - waitingSince >= PERMISSION_POLL_TIMEOUT_MS
+  ) {
+    return "needed";
+  }
+
+  return current;
+}
+
+export function permissionPollOutcome(
+  current: PermissionPair<PermissionStatus>,
+  granted: PermissionPair<boolean>,
+  waitingSince: PermissionPair<number | null>,
+  now: number,
+): PermissionPollOutcome {
+  const permissions = {
+    accessibility: permissionStatusAfterPoll(
+      current.accessibility,
+      granted.accessibility,
+      waitingSince.accessibility,
+      now,
+    ),
+    microphone: permissionStatusAfterPoll(
+      current.microphone,
+      granted.microphone,
+      waitingSince.microphone,
+      now,
+    ),
+  };
+
+  const timedOut = {
+    accessibility:
+      current.accessibility === "waiting" &&
+      !granted.accessibility &&
+      waitingSince.accessibility !== null &&
+      now - waitingSince.accessibility >= PERMISSION_POLL_TIMEOUT_MS,
+    microphone:
+      current.microphone === "waiting" &&
+      !granted.microphone &&
+      waitingSince.microphone !== null &&
+      now - waitingSince.microphone >= PERMISSION_POLL_TIMEOUT_MS,
+  };
+
+  return {
+    permissions,
+    timedOut,
+    allGranted:
+      permissions.accessibility === "granted" &&
+      permissions.microphone === "granted",
+  };
+}


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Human Written Description

> TODO (human contributor): In 2–3 sentences, describe how Handy remained on “Waiting...” after Accessibility was enabled and why returning to a retryable state is better than an endless spinner.

## Related Issues/Discussions

Addresses the indefinite permission waiting state reported in #1618.

Discussion: N/A — this is a bug fix for an existing issue.

## Community Feedback

Issue #1618 and its follow-up comment both report permission onboarding remaining stuck when macOS does not recognize the current app identity.

## Testing

- [x] Added a standalone regression test for permission polling state transitions
- [x] Observed RED before implementation: missing `permissionPolling` module, exit 1
- [x] `bun src/components/onboarding/permissionPolling.test.ts`
- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run check:translations`
- [x] `bun run build`
- [x] Full independent code review completed before push

The assertions cover waiting before the timeout, returning only the timed-out permission to a retryable state, immediate and staggered grants, preserving an observed grant through a transient false poll, and completing from the resulting combined state. The first independent review rejected an earlier implementation because it decided completion from raw poll booleans; this version unifies state and completion in one tested outcome and was re-reviewed after the fix.

## Screenshots/Videos (if applicable)

Not included. The behavioral change is the existing localized error toast and permission button returning after 15 seconds instead of an indefinite spinner.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Hermes Agent
- How extensively: AI traced the polling state machine, designed and ran the RED→GREEN regression test, implemented the bounded retry behavior, and ran the frontend quality gates. The human contributor reproduced the original stuck state and confirmed the scoped TCC recovery on macOS.
