### PR TITLE
fix(linux): clear stale modifier latch after xdotool type (#1817)

### DIFF
--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -426,6 +426,37 @@ fn type_text_via_xdotool(text: &str) -> Result<(), String> {
         return Err(format!("xdotool failed: {}", stderr));
     }
 
+    // `--clearmodifiers` snapshots any held modifiers, releases them for the
+    // duration of typing, then re-presses the snapshot afterwards. This paste
+    // runs after a multi-second async transcription, so the snapshot can be
+    // stale: the user may have released the modifier (e.g. the Ctrl of a
+    // Ctrl+Space push-to-talk binding) in the meantime. The synthetic re-press
+    // then lands on the XTEST keyboard with no matching release, latching the
+    // modifier system-wide until it is pressed and released again (#1817).
+    //
+    // Release the push-style modifiers explicitly so a stale restore can never
+    // leave anything latched. `xdotool keyup` injects via the XTEST extension
+    // (the same device the restore wrote to), so this clears the latch.
+    //
+    // Two intentional trade-offs:
+    //  - Only ctrl/shift/alt/super are released. `--clearmodifiers` also tracks
+    //    Meta, ISO_Level3_Shift (AltGr), mouse buttons and caps/num/scroll lock;
+    //    the lock keys are skipped on purpose (they toggle on key events) and
+    //    the rest are out of scope for the reported Ctrl-latch bug.
+    //  - The release is unconditional. Because X modifier state is not
+    //    reference-counted per device, this can also drop a modifier the user is
+    //    physically holding across the paste. That case is rare (the common
+    //    workflow is a push-to-talk binding, not a modifier held for subsequent
+    //    typing); if it regresses someone we should switch to querying actual
+    //    state (e.g. xinput) and releasing only latched keys.
+    // Releasing a modifier that is not held is a no-op on X11, so this is safe
+    // when nothing was held. The result is ignored on purpose: the text was
+    // already typed successfully, and a failed cleanup must not fail the paste.
+    let _ = Command::new("xdotool")
+        .arg("keyup")
+        .args(["ctrl", "shift", "alt", "super"])
+        .output();
+
     Ok(())
 }
 

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -421,41 +421,51 @@ fn type_text_via_xdotool(text: &str) -> Result<(), String> {
         .output()
         .map_err(|e| format!("Failed to execute xdotool: {}", e))?;
 
+    // `--clearmodifiers` restores the modifiers that were held when xdotool
+    // started. If the user releases one while xdotool is typing, that synthetic
+    // restore can leave the modifier latched on the XTEST keyboard (#1817).
+    // Release both sides of Handy's supported push-style modifiers to clear any
+    // stale restore. Lock keys are intentionally excluded because key events
+    // toggle them.
+    //
+    // The release is unconditional, so it can make a modifier that is still
+    // physically held appear released until the next physical event. This is
+    // preferable to leaving a synthetic modifier latched system-wide.
+    //
+    // Clean up before checking the typing status because xdotool may have
+    // changed modifier state before returning an error. Cleanup remains
+    // best-effort because the text may already have been partially or fully
+    // typed, but failures are logged so they can be diagnosed.
+    match Command::new("xdotool")
+        .arg("keyup")
+        .args([
+            "Control_L",
+            "Control_R",
+            "Shift_L",
+            "Shift_R",
+            "Alt_L",
+            "Alt_R",
+            "Super_L",
+            "Super_R",
+        ])
+        .output()
+    {
+        Ok(cleanup_output) if !cleanup_output.status.success() => {
+            let stderr = String::from_utf8_lossy(&cleanup_output.stderr);
+            log::warn!(
+                "xdotool modifier cleanup failed with status {:?}: {}",
+                cleanup_output.status.code(),
+                stderr.trim()
+            );
+        }
+        Err(error) => log::warn!("Failed to execute xdotool modifier cleanup: {}", error),
+        _ => {}
+    }
+
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(format!("xdotool failed: {}", stderr));
     }
-
-    // `--clearmodifiers` snapshots any held modifiers, releases them for the
-    // duration of typing, then re-presses the snapshot afterwards. This paste
-    // runs after a multi-second async transcription, so the snapshot can be
-    // stale: the user may have released the modifier (e.g. the Ctrl of a
-    // Ctrl+Space push-to-talk binding) in the meantime. The synthetic re-press
-    // then lands on the XTEST keyboard with no matching release, latching the
-    // modifier system-wide until it is pressed and released again (#1817).
-    //
-    // Release the push-style modifiers explicitly so a stale restore can never
-    // leave anything latched. `xdotool keyup` injects via the XTEST extension
-    // (the same device the restore wrote to), so this clears the latch.
-    //
-    // Two intentional trade-offs:
-    //  - Only ctrl/shift/alt/super are released. `--clearmodifiers` also tracks
-    //    Meta, ISO_Level3_Shift (AltGr), mouse buttons and caps/num/scroll lock;
-    //    the lock keys are skipped on purpose (they toggle on key events) and
-    //    the rest are out of scope for the reported Ctrl-latch bug.
-    //  - The release is unconditional. Because X modifier state is not
-    //    reference-counted per device, this can also drop a modifier the user is
-    //    physically holding across the paste. That case is rare (the common
-    //    workflow is a push-to-talk binding, not a modifier held for subsequent
-    //    typing); if it regresses someone we should switch to querying actual
-    //    state (e.g. xinput) and releasing only latched keys.
-    // Releasing a modifier that is not held is a no-op on X11, so this is safe
-    // when nothing was held. The result is ignored on purpose: the text was
-    // already typed successfully, and a failed cleanup must not fail the paste.
-    let _ = Command::new("xdotool")
-        .arg("keyup")
-        .args(["ctrl", "shift", "alt", "super"])
-        .output();
 
     Ok(())
 }


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

Not a duplicate: #1487 fixed the same class of bug (modifiers left latched) on the **wtype** (Wayland paste) path; this is the **xdotool** (X11 direct-typing) path, which #1487 didn't touch. One fix per PR — a single addition in one function (`type_text_via_xdotool`). Bug fix, not a feature → fits the feature-freeze "bug fixes are top priority" guidance.

## Human Written Description

@arturo-jc reported in #1817 that on X11 the Ctrl key can get "virtually stuck" after a push-to-talk dictation with Ctrl+Space — it acts held-down everywhere until you press and release it again. They traced it to `xdotool type --clearmodifiers`: it snapshots the held modifiers, releases them for the duration of typing, then re-presses the snapshot afterward. Since this paste runs after a multi-second transcription, the user has usually let go by then, so the synthetic re-press latches the key with nothing to release it. This change releases the common modifiers right after typing so a stale snapshot can't leave the key stuck.

I wrote this fix purely from reading the code and @arturo-jc's analysis — I'm on macOS and couldn't reproduce or test the X11 behavior myself. If someone on X11 can confirm it helps (or that it doesn't), that'd be welcome; I understand it's not formally mergeable without that verification, I'm leaving it here in case it's useful.

## Related Issues/Discussions

Fixes #1817

## Community Feedback

Single-maintainer project, one-file X11 typing-path fix. The reporter @arturo-jc did the root-cause legwork (xinput trace, narrowed it to `--clearmodifiers`) in #1817 — much appreciated, that's what made this a quick one.

## Testing

**Root cause (matches @arturo-jc's analysis in #1817):** `xdotool type --clearmodifiers` does snapshot → release → type → **restore (re-press)**. The restore re-presses whatever was held at snapshot time. This paste runs after a multi-second async transcription, so the snapshot is usually stale — the user released the push-to-talk modifier meanwhile. The synthetic key-down lands on the XTEST keyboard with no matching release, so the modifier reads as held system-wide (confirmed by the reporter via `xinput query-state`: Control_L down on the XTEST device, nothing held on the physical keyboard). Self-sustaining — the next dictation re-snapshots the latched key.

**What changed:** one addition in `type_text_via_xdotool` (`src-tauri/src/clipboard.rs`). After a successful `xdotool type`, explicitly release the push-style modifiers with `xdotool keyup ctrl shift alt super`. `xdotool keyup` injects through the XTEST extension (the same device the restore wrote to), so it clears the latch. Typing itself is unchanged.

**Intentional trade-offs (in the code comment):**
- Only the four push-modifiers (ctrl/shift/alt/super) are released. `--clearmodifiers` also tracks Meta / ISO_Level3_Shift (AltGr) / mouse buttons / lock keys; lock keys are skipped on purpose (they toggle on key events), the rest are out of scope for this Ctrl-latch bug.
- The release is unconditional, so it can also drop a modifier the user is physically holding across the paste. That's rare (the usual workflow is a push-to-talk binding, not a modifier held for subsequent typing); if it bites someone, the right move is to query actual modifier state (e.g. `xinput`) and release only latched keys.

**Verification I could do:** `cargo fmt --check` is clean. The function is `#[cfg(target_os = "linux")]`, so `cargo clippy` on macOS doesn't exercise it.

**Verification I need help with:** I'm on macOS and can't test X11. @arturo-jc — if you get a moment, a build of this branch + your original repro (hold Ctrl+Space, dictate, release Space, keep Ctrl held through the transcription) would be ace. The fix is tiny and this is volunteer-time, so any confirmation that Ctrl no longer latches — or a `xinput query-state` showing Control_L up afterward — would be hugely appreciated. Genuinely no rush.

## Screenshots/Videos

N/A — it's a key-state bug, not visual.

## AI Assistance

This PR was drafted with AI assistance (code + this description). The fix and the `--clearmodifiers`/XTEST reasoning were checked against the official xdotool man page, and the patch was reviewed by two independent local code models plus a manual pass over the call chain. The X11 runtime behavior was not machine-tested by me — see the verification request above.
