### PR TITLE
fix(portable): keep Hugging Face models in Data

### DIFF
--- a/src-tauri/src/portable.rs
+++ b/src-tauri/src/portable.rs
@@ -4,7 +4,7 @@
 //! (settings, models, recordings, database, logs) is stored in a `Data/`
 //! directory alongside the executable instead of `%APPDATA%`.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use tauri::Manager;
 
@@ -37,12 +37,21 @@ pub fn init() {
             if !data_dir.exists() {
                 std::fs::create_dir_all(&data_dir).ok()?;
             }
+            let hf_home = hugging_face_home(&data_dir);
+            std::env::set_var("HF_HOME", &hf_home);
             eprintln!("[portable] data dir: {}", data_dir.display());
+            eprintln!("[portable] Hugging Face home: {}", hf_home.display());
             Some(data_dir)
         } else {
             None
         }
     });
+}
+
+/// Keep hf-hub downloads inside the portable data directory. hf-hub appends
+/// its own `hub` component to `HF_HOME` for model snapshots and blobs.
+fn hugging_face_home(data_dir: &Path) -> PathBuf {
+    data_dir.join("huggingface")
 }
 
 /// Returns `true` if running in portable mode.
@@ -162,5 +171,12 @@ mod tests {
         write!(f, "  Handy Portable Mode\n").unwrap();
         assert!(is_valid_portable_marker(&marker));
         std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn test_hugging_face_home_is_inside_portable_data() {
+        let data_dir = Path::new("portable-root").join("Data");
+
+        assert_eq!(hugging_face_home(&data_dir), data_dir.join("huggingface"));
     }
 }


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

This is a focused bug fix for an existing portable-mode behavior and has not previously been rejected.

## Human Written Description

In the portable version, downloaded Hugging Face models were stored in the user profile instead of the Data directory. With my change, the models now remain under Data/huggingface/hub.

## Related Issues/Discussions

Fixes #1629

## Community Feedback

The issue has been confirmed by users, and the maintainer explicitly indicated that contributions are welcome.

## Testing

- Added a unit test for resolving the portable Hugging Face home inside the Data directory.
- Verified `cargo fmt -- --check` passes.
- Verified `git diff --check` passes.
- Attempted `cargo test portable::tests`; compilation was blocked before reaching the tests because CMake is not installed in the local environment and is required by `transcribe-cpp-sys`.
- Confirmed portable initialization runs before every `Cache::from_env()` and `ApiBuilder::from_env()` call used for model discovery and downloads.

## Screenshots/Videos (if applicable)

N/A — backend-only portable path correction.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Codex helped inspect the portable-mode and hf-hub paths, implement the focused fix and unit test, run available checks, and prepare the branch and PR. The contributor supplied the Human Written Description.
