### PR TITLE
docs: note that fn/Globe shortcuts only work on Apple keyboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ This project is actively being developed and has some [known issues](https://git
 
 Using a Bluetooth headset microphone on macOS may temporarily reduce playback quality or volume while recording because Bluetooth switches to bidirectional audio. Keep your headphones as the output device and select your Mac's built-in or an external microphone in Handy to avoid this.
 
+### fn and Globe Key Shortcuts (macOS)
+
+Shortcuts that include the `fn` (Globe) key **only work on Apple keyboards** — your Mac's built-in keyboard or an Apple external keyboard. They will never trigger on a third-party keyboard, even while it is connected to the same Mac.
+
+This is a hardware limitation rather than a Handy bug. `fn` is not part of the standard USB HID keyboard specification: Apple reports it through a vendor-specific usage that macOS honors only from Apple devices, while third-party keyboards handle their `Fn` key entirely in firmware and send nothing to the computer. There is no event for Handy to listen for.
+
+If you switch between a MacBook keyboard and an external one, pick a shortcut built from standard modifiers (`ctrl`, `option`, `shift`, `command`) or a regular key instead.
+
 ### Major Issues (Help Wanted)
 
 **Whisper Model Crashes:**


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

Not applicable — this is a documentation addition, not a previously rejected change.

## Human Written Description

As a Handy user, I was confused by the fact that the Transcribe shortcut I configured (fn + ^) only triggered the actual transcription when pressed on my Mac's actual keyboard - and not when it was pressed on my external keyboard.

While investigating the situation, I learned that there are certain buttons that are not/cannot be properly mapped between the external & native keyboards - and I happened to have picked one such button (i.e. the `fn`).

This PR aims to enhance the UX of setting up the Transcribe shortcut.

## Related Issues/Discussions

Addresses #1925.

Not marked as `Fixes` on purpose: #1925 also proposed a conditional inline note in the shortcut recorder, and @cjpais decided in the issue thread that a README note is the right scope for now. This PR is the documentation half only, so the issue is left open for that separate conversation.

A companion PR documenting the same limitation on [handy.computer](https://github.com/cjpais/handy.computer) will follow, as requested in the issue thread.

## Community Feedback

Discussed and scoped directly with the maintainer in #1925, where @cjpais confirmed: *"I think the best thing we can do for now is a README note."*

Related prior context: the `fn`/Globe key has been requested and implemented repeatedly (#47, #136, #163, #401, #520, #573, #581, #608), which is exactly why the hardware constraint is worth writing down — the feature works correctly, it just cannot physically work on non-Apple keyboards.

## Testing

Documentation-only change; no code paths touched, so no build or runtime testing applies.

The behavior being documented was verified on hardware: macOS 26.4.1 (Apple M4 Pro), Handy 0.9.4, Handy Keys backend. A transcribe shortcut of `fn + ctrl` triggers reliably from the built-in MacBook keyboard and never triggers from a Logitech MX Keys Mini connected to the same machine, with nothing recorded in the logs from the external keyboard.

Markdown rendering of the new section was checked against the surrounding "Known Issues & Current Limitations" subsections for consistent heading level and tone.

## Screenshots/Videos (if applicable)

Not applicable — no UI changes.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Used to research the root cause (the Apple vendor-specific HID usage behind `fn`), to search existing issues, PRs and discussions for duplicates, and to draft the wording of the README section. The underlying problem was encountered firsthand on the hardware described above, and the final text was reviewed by a human before submission.
