### PR TITLE
feat(nix): auto-enable Handy Cachix binary cache for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,24 @@ The process is entirely local:
 
 For detailed build instructions including platform-specific requirements, see [BUILD.md](BUILD.md).
 
+### Nix
+
+Handy ships a [Nix](https://nixos.org) flake (`flake.nix`). The packaged build is **Linux-only** (x86_64-linux and aarch64-linux) — the same platforms covered by the flake's `supportedSystems`.
+
+Prebuilt binaries are published to the **`handy-computer` Cachix cache** (`https://handy-computer.cachix.org`), so most users can skip the ~25 minute local build:
+
+- **Flake builds** (`nix build` / `nix develop` / `nixos-rebuild --flake`) pick up the cache automatically via the flake's `nixConfig` — no extra setup needed.
+- **NixOS**: enabling `programs.handy.enable` also adds the substituter for you.
+- **First build / build problems**: if you want to be explicit (or you are not using the flake's `nixConfig`, e.g. a non-flake build), pass the cache on the command line so the initial build also pulls from Cachix instead of compiling the heavy native dependencies from source:
+
+  ```bash
+  nix build .#handy \
+    --extra-substituters https://handy-computer.cachix.org \
+    --extra-trusted-public-keys handy-computer.cachix.org-1:Sihzctn6DC0CJM5QeL+9nBEL3CL8c33m777C+eIv748=
+  ```
+
+  (Replace `nix build` with `nix develop`/`nix shell` as needed.)
+
 ## Integrations
 
 <a href="https://www.raycast.com/mattiacolombomc/handy" title="Install Handy Raycast Extension"><img src="https://www.raycast.com/mattiacolombomc/handy/install_button@2x.png?v=1.1" height="64" style="height: 64px;" alt="Install handy Raycast Extension" /></a>

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,16 @@
 {
   description = "Handy - A free, open source, and extensible speech-to-text application that works completely offline";
 
+  # Pull pre-built binaries from the Handy Cachix cache (populated by CI in
+  # .github/workflows/nix-check.yml) so users skip the ~25 min local build.
+  # `extra-*` settings append to the user's defaults instead of replacing them.
+  nixConfig = {
+    extra-substituters = [ "https://handy-computer.cachix.org" ];
+    extra-trusted-public-keys = [
+      "handy-computer.cachix.org-1:Sihzctn6DC0CJM5QeL+9nBEL3CL8c33m777C+eIv748="
+    ];
+  };
+
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -38,6 +38,14 @@ in
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
 
+    # Pull pre-built binaries from the Handy Cachix cache (populated by CI in
+    # .github/workflows/nix-check.yml) so users skip the ~25 min local build.
+    # `extra-*` options append to the system defaults instead of replacing them.
+    nix.extraOptions = ''
+      extra-substituters = https://handy-computer.cachix.org
+      extra-trusted-public-keys = handy-computer.cachix.org-1:Sihzctn6DC0CJM5QeL+9nBEL3CL8c33m777C+eIv748=
+    '';
+
     # rdev grab() creates virtual input devices via /dev/uinput.
     # Default permissions are crw------- root root — open it to the input group.
     services.udev.extraRules = ''


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched existing issues and pull requests (including closed ones) to ensure this isn't a duplicate
- [x] I have read CONTRIBUTING.md

## Human Written Description

This is follow-up to PR  #1237.
Handy's CI already pushes builds to a Cachix cache, but until now every user
had to copy the substituter and public key into their own Nix config to
actually use those prebuilt binaries. This wires the cache up automatically
(flake `nixConfig` + the NixOS `programs.handy` module) and documents it in
the README, so installing Handy via Nix no longer means a ~25-minute wait or
fighting native dependency builds.

## Related Issues/Discussions

Fixes #
Discussion:
Related: #1237 (adds the Cachix CI cache; this PR is its planned follow-up to auto-expose the substituter)

## Community Feedback


## Testing

- `nix flake metadata .` succeeds with the new `nixConfig`, confirming Nix 2.34.8 accepts the `extra-substituters` / `extra-trusted-public-keys` settings.
- README documents the cache and a copy-paste `nix build` command using the same public key.

## Screenshots/Videos

N/A

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Kimi Code CLI (model Hy3)
- How extensively: AI drafted the `flake.nix` `nixConfig`, the NixOS module `nix.extraOptions`, and the README Nix section; the changes were reviewed and the Nix config was validated together with the human.