### PR TITLE
fix: Preserve accented characters in Linux direct typing

### DIFF
--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -410,14 +410,27 @@ fn type_text_via_wtype(text: &str) -> Result<(), String> {
     Ok(())
 }
 
+#[cfg(target_os = "linux")]
+const XDOTOOL_TYPE_DELAY_MS: &str = "50";
+
+/// Build xdotool arguments with enough time for targets to process temporary Unicode mappings.
+#[cfg(target_os = "linux")]
+fn xdotool_type_args(text: &str) -> [&str; 6] {
+    [
+        "type",
+        "--clearmodifiers",
+        "--delay",
+        XDOTOOL_TYPE_DELAY_MS,
+        "--",
+        text,
+    ]
+}
+
 /// Type text directly via xdotool on X11.
 #[cfg(target_os = "linux")]
 fn type_text_via_xdotool(text: &str) -> Result<(), String> {
     let output = Command::new("xdotool")
-        .arg("type")
-        .arg("--clearmodifiers")
-        .arg("--")
-        .arg(text)
+        .args(xdotool_type_args(text))
         .output()
         .map_err(|e| format!("Failed to execute xdotool: {}", e))?;
 
@@ -874,6 +887,28 @@ we're using raw keycodes now.
 Syntax: <keycode>:<pressed>
 e.g. 28:1 28:0 means pressing on the Enter button on a standard US keyboard.
 "#;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn generates_xdotool_arguments_with_delay_for_unicode_text() {
+        let text = "Être ou ne pas être, je l'apprends par cœur";
+
+        assert_eq!(
+            xdotool_type_args(text),
+            ["type", "--clearmodifiers", "--delay", "50", "--", text]
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn generates_xdotool_arguments_with_option_terminator_for_leading_hyphen() {
+        let text = "-starts-with-a-hyphen";
+
+        assert_eq!(
+            xdotool_type_args(text),
+            ["type", "--clearmodifiers", "--delay", "50", "--", text]
+        );
+    }
 
     #[cfg(target_os = "linux")]
     #[test]


### PR DESCRIPTION
## Before Submitting This PR

<!--
HANDY IS UNDERGOING A FEATURE FREEZE. IF YOU ARE SUBMITTING A PR WHICH IS A NEW FEATURE THAT THE COMMUNITY HAS NOT ASKED FOR: PREPARE TO BE REJECTED. IF THE COMMUNITY HAS ASKED FOR IT, OR YOU HAVE EXPLICITLY GATHERED SUPPORT IT MAY STILL BE CONSIDERED.

BUG FIXES ARE THE TOP PRIORITY. THERE ARE 60+ ISSUES TO FIX.
-->

**Please submit only one fix or feature per pull request. Pull requests containing multiple fixes or features will likely be closed.**

**Please confirm you have done the following:**

- [ ] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

Adjust only the xdotool Direct-typing command to use an explicit, conservative inter-key delay so terminal applications have time to resolve Unicode key events before xdotool advances or restores its temporary mapping. Keep `--clearmodifiers`, the `--` option terminator, existing modifier cleanup, error propagation, and every non-xdotool backend unchanged. Represent the production command arguments in a small command-shaping helper that is called by `type_text_via_xdotool`, following the existing `ydotool_key_args` pattern in this file; this gives the behavior a production consumer as well as focused coverage.

On Arch Linux, Direct paste intermittently drops characters such as `ê` and `œ`, turning otherwise correct French transcription text into words such as `tre` and `cur`. The reporter confirmed the transcription/history text remains correct and isolated the failure to insertion: graphical editors and lxterminal work, while xterm and Terminator fail most of the time. In the current Linux Direct path, X11 Auto mode prefers `xdotool`, whose text command is constructed in `src-tauri/src/clipboard.rs`; the target-dependent, intermittent loss is consistent with terminal consumers not keeping up with xdotool's temporary Unicode keyboard-map events. The issue is open, unassigned, and has no linked prior or competing pull request.

Fixes #1853

## Related Issues/Discussions

Fixes #
Discussion:

## Community Feedback

Not applicable to this change.

## Testing

Not applicable to this change.

## Screenshots/Videos (if applicable)



## AI Assistance

- [ ] No AI was used in this PR
- [ ] AI was used (please describe below)

**If AI was used:**

- Tools used:
- How extensively:

**AI disclosure**

AI was used for assistance.

- Tools: an AI coding assistant.
