### PR TITLE
fix: refresh custom sounds when opening sound selector

### DIFF
--- a/src/components/settings/SoundPicker.tsx
+++ b/src/components/settings/SoundPicker.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useCallback } from "react";
 import { Button } from "../ui/Button";
 import { Dropdown, DropdownOption } from "../ui/Dropdown";
 import { PlayIcon } from "lucide-react";
@@ -22,36 +22,15 @@ export const SoundPicker: React.FC<SoundPickerProps> = ({
     (state) => state.checkCustomSounds,
   );
 
-  const [isChecking, setIsChecking] = useState(false);
-  const [hasChecked, setHasChecked] = useState(false);
-
   const selectedTheme = getSetting("sound_theme") ?? "marimba";
 
   const handleRefresh = useCallback(async () => {
-    setIsChecking(true);
-    try {
-      await checkCustomSounds();
-    } finally {
-      setIsChecking(false);
-      setHasChecked(true);
-    }
+    await checkCustomSounds();
   }, [checkCustomSounds]);
 
   useEffect(() => {
     handleRefresh();
   }, [handleRefresh]);
-
-  // Fall back to "marimba" if "custom" is selected but required sound files do not exist (only after checking)
-  useEffect(() => {
-    if (
-      hasChecked &&
-      !isChecking &&
-      selectedTheme === "custom" &&
-      (!customSounds.start || !customSounds.stop)
-    ) {
-      updateSetting("sound_theme", "marimba");
-    }
-  }, [hasChecked, isChecking, selectedTheme, customSounds, updateSetting]);
 
   const options: DropdownOption[] = [
     { value: "marimba", label: "Marimba" },
@@ -82,7 +61,7 @@ export const SoundPicker: React.FC<SoundPickerProps> = ({
             updateSetting("sound_theme", value as "marimba" | "pop" | "custom")
           }
           options={options}
-          onRefresh={handleRefresh}
+          onOpen={handleRefresh}
         />
         <Button
           variant="ghost"

--- a/src/components/settings/SoundPicker.tsx
+++ b/src/components/settings/SoundPicker.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import { Button } from "../ui/Button";
 import { Dropdown, DropdownOption } from "../ui/Dropdown";
 import { PlayIcon } from "lucide-react";
@@ -18,8 +18,40 @@ export const SoundPicker: React.FC<SoundPickerProps> = ({
   const { getSetting, updateSetting } = useSettings();
   const playTestSound = useSettingsStore((state) => state.playTestSound);
   const customSounds = useSettingsStore((state) => state.customSounds);
+  const checkCustomSounds = useSettingsStore(
+    (state) => state.checkCustomSounds,
+  );
+
+  const [isChecking, setIsChecking] = useState(false);
+  const [hasChecked, setHasChecked] = useState(false);
 
   const selectedTheme = getSetting("sound_theme") ?? "marimba";
+
+  const handleRefresh = useCallback(async () => {
+    setIsChecking(true);
+    try {
+      await checkCustomSounds();
+    } finally {
+      setIsChecking(false);
+      setHasChecked(true);
+    }
+  }, [checkCustomSounds]);
+
+  useEffect(() => {
+    handleRefresh();
+  }, [handleRefresh]);
+
+  // Fall back to "marimba" if "custom" is selected but required sound files do not exist (only after checking)
+  useEffect(() => {
+    if (
+      hasChecked &&
+      !isChecking &&
+      selectedTheme === "custom" &&
+      (!customSounds.start || !customSounds.stop)
+    ) {
+      updateSetting("sound_theme", "marimba");
+    }
+  }, [hasChecked, isChecking, selectedTheme, customSounds, updateSetting]);
 
   const options: DropdownOption[] = [
     { value: "marimba", label: "Marimba" },
@@ -50,6 +82,7 @@ export const SoundPicker: React.FC<SoundPickerProps> = ({
             updateSetting("sound_theme", value as "marimba" | "pop" | "custom")
           }
           options={options}
+          onRefresh={handleRefresh}
         />
         <Button
           variant="ghost"

--- a/src/components/ui/Dropdown.tsx
+++ b/src/components/ui/Dropdown.tsx
@@ -14,6 +14,8 @@ interface DropdownProps {
   onSelect: (value: string) => void;
   placeholder?: string;
   disabled?: boolean;
+  onOpen?: () => void;
+  /** @deprecated Use onOpen instead */
   onRefresh?: () => void;
 }
 
@@ -24,6 +26,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
   className = "",
   placeholder = "Select an option...",
   disabled = false,
+  onOpen,
   onRefresh,
 }) => {
   const { t } = useTranslation();
@@ -54,7 +57,10 @@ export const Dropdown: React.FC<DropdownProps> = ({
 
   const handleToggle = () => {
     if (disabled) return;
-    if (!isOpen && onRefresh) onRefresh();
+    if (!isOpen) {
+      onOpen?.();
+      onRefresh?.();
+    }
     setIsOpen(!isOpen);
   };
 

--- a/src/components/ui/Dropdown.tsx
+++ b/src/components/ui/Dropdown.tsx
@@ -58,8 +58,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
   const handleToggle = () => {
     if (disabled) return;
     if (!isOpen) {
-      onOpen?.();
-      onRefresh?.();
+      (onOpen ?? onRefresh)?.();
     }
     setIsOpen(!isOpen);
   };


### PR DESCRIPTION
## Before Submitting This PR

**Please submit only one fix or feature per pull request. Pull requests containing multiple fixes or features will likely be closed.**

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md

## Human Written Description

I noticed that custom sounds were not showing up in the sound selector after adding them. This was confusing because it made it look like the feature was broken. I changed it to refresh the available sounds in AppData when the dropdown is opened instead.

## Related Issues/Discussions

Fixes #
Discussion:

## Community Feedback

This is a bug fix, so I have not gathered additional community feedback.

## Testing

I tested this locally by adding a custom sound while Handy was running and then opening the sound selector. The new sound appeared in the selector without needing to restart Handy.

I also tested the existing dropdowns to make sure the changes to the shared `Dropdown` component did not affect their existing behavior. Dropdowns that do not use the new `onOpen` callback continue to work as before, and the existing `onRefresh` behavior remains supported.

Finally, I reopened the sound selector multiple times to verify that the available sounds are refreshed each time the dropdown is opened.

## Screenshots/Videos (if applicable)

Not applicable.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: ChatGPT
- How extensively: AI was used to review the implementation and help prepare this PR description.