### PR TITLE
feat: pick OpenRouter upstream provider for post-processing

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -190,6 +190,13 @@ async fn post_process_transcription(settings: &AppSettings, transcription: &str)
     // field the endpoint understands and retries without it if rejected.
     let disable_reasoning = matches!(provider.id.as_str(), "custom" | "openrouter");
 
+    // Pin the gateway's upstream provider for this model (OpenRouter) so the
+    // request is reliable and always hits the same prompt cache.
+    let pinned_provider = settings.upstream_provider_for(&provider.id, &model);
+    if let Some(slug) = pinned_provider {
+        debug!("Pinning upstream provider '{}'", slug);
+    }
+
     if provider.supports_structured_output {
         debug!("Using structured outputs for provider '{}'", provider.id);
 
@@ -261,6 +268,7 @@ async fn post_process_transcription(settings: &AppSettings, transcription: &str)
             Some(system_prompt),
             Some(json_schema),
             disable_reasoning,
+            pinned_provider,
         )
         .await
         {
@@ -317,6 +325,7 @@ async fn post_process_transcription(settings: &AppSettings, transcription: &str)
         &model,
         processed_prompt,
         disable_reasoning,
+        pinned_provider,
     )
     .await
     {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -648,6 +648,8 @@ pub fn run(cli_args: CliArgs) {
             shortcut::change_post_process_model_setting,
             shortcut::set_post_process_provider,
             shortcut::fetch_post_process_models,
+            shortcut::change_post_process_upstream_provider_setting,
+            shortcut::fetch_post_process_upstream_providers,
             shortcut::add_post_process_prompt,
             shortcut::update_post_process_prompt,
             shortcut::delete_post_process_prompt,

--- a/src-tauri/src/llm_client.rs
+++ b/src-tauri/src/llm_client.rs
@@ -1,5 +1,5 @@
 use crate::settings::PostProcessProvider;
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE, REFERER, USER_AGENT};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -10,7 +10,66 @@ use std::sync::{Mutex, OnceLock};
 #[derive(Debug, Serialize)]
 struct ChatMessage {
     role: String,
-    content: String,
+    /// Plain string for most endpoints; OpenRouter gets a content-part array
+    /// so the system prompt can carry a `cache_control` breakpoint.
+    content: Value,
+}
+
+/// Build the system message. On routing gateways the prompt is wrapped as a
+/// text part with an ephemeral `cache_control` breakpoint: the prompt is
+/// identical across dictations and always sits at the top of the request, so
+/// upstreams that need explicit breakpoints (Anthropic) cache it, while
+/// implicit-caching upstreams (OpenAI, Gemini, DeepSeek) ignore the marker.
+fn system_message(provider: &PostProcessProvider, system: String) -> ChatMessage {
+    let content = if provider.supports_provider_routing {
+        serde_json::json!([{
+            "type": "text",
+            "text": system,
+            "cache_control": { "type": "ephemeral" }
+        }])
+    } else {
+        Value::String(system)
+    };
+    ChatMessage {
+        role: "system".to_string(),
+        content,
+    }
+}
+
+/// Prefix for routing strategies stored in place of a provider slug
+/// (`sort:throughput`, `sort:latency`, `sort:price`).
+pub const SORT_PREFIX: &str = "sort:";
+const SORT_STRATEGIES: [&str; 3] = ["throughput", "latency", "price"];
+
+/// OpenRouter-style provider-routing object
+/// (https://openrouter.ai/docs/features/provider-routing).
+///
+/// * `sort:<strategy>` routes each request to whichever upstream currently
+///   leads on throughput (tokens/s), latency (time to first token) or price.
+///   `require_parameters` keeps the router on upstreams that accept the fields
+///   we send (notably `response_format`).
+/// * Any other value is a provider slug pinned with `allow_fallbacks: false`,
+///   so the request never silently lands on a different upstream (which would
+///   also miss that upstream's prompt cache).
+fn provider_routing(provider: &PostProcessProvider, pinned: Option<&str>) -> Option<Value> {
+    let value = pinned.map(str::trim).filter(|s| !s.is_empty())?;
+    if !provider.supports_provider_routing {
+        return None;
+    }
+    if let Some(strategy) = value.strip_prefix(SORT_PREFIX) {
+        if !SORT_STRATEGIES.contains(&strategy) {
+            warn!("Ignoring unknown upstream routing strategy '{}'", value);
+            return None;
+        }
+        return Some(serde_json::json!({
+            "sort": strategy,
+            "require_parameters": true
+        }));
+    }
+    Some(serde_json::json!({
+        "order": [value],
+        "allow_fallbacks": false
+    }))
 }
 
 #[derive(Debug, Serialize)]
@@ -118,6 +177,9 @@ struct ChatCompletionRequest {
     response_format: Option<ResponseFormat>,
     #[serde(flatten)]
     reasoning: ReasoningParams,
+    /// OpenRouter provider routing (https://openrouter.ai/docs/features/provider-routing)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    provider: Option<Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -303,6 +365,7 @@ pub async fn send_chat_completion(
     model: &str,
     prompt: String,
     disable_reasoning: bool,
+    pinned_provider: Option<&str>,
 ) -> Result<Option<String>, String> {
     send_chat_completion_with_schema(
         provider,
@@ -312,6 +375,7 @@ pub async fn send_chat_completion(
         None,
         None,
         disable_reasoning,
+        pinned_provider,
     )
     .await
 }
@@ -326,6 +390,10 @@ pub async fn send_chat_completion(
 /// upstreams reject with 400), so a 400/422 answer to such a request triggers
 /// one retry without the fields, and the rejection is remembered per
 /// (base_url, model) so later requests skip the failing attempt entirely.
+///
+/// `pinned_provider` is an upstream slug (e.g. "google-ai-studio") for
+/// providers with `supports_provider_routing`; ignored for every other provider.
+#[allow(clippy::too_many_arguments)]
 pub async fn send_chat_completion_with_schema(
     provider: &PostProcessProvider,
     api_key: String,
@@ -334,6 +402,7 @@ pub async fn send_chat_completion_with_schema(
     system_prompt: Option<String>,
     json_schema: Option<Value>,
     disable_reasoning: bool,
+    pinned_provider: Option<&str>,
 ) -> Result<Option<String>, String> {
     let base_url = provider.base_url.trim_end_matches('/');
     let url = format!("{}/chat/completions", base_url);
@@ -349,17 +418,15 @@ pub async fn send_chat_completion_with_schema(
     let mut messages = Vec::new();
 
     // Add system prompt if provided
+    // The system prompt goes first so the stable prefix is cacheable.
     if let Some(system) = system_prompt {
-        messages.push(ChatMessage {
-            role: "system".to_string(),
-            content: system,
-        });
+        messages.push(system_message(provider, system));
     }
 
     // Add user message
     messages.push(ChatMessage {
         role: "user".to_string(),
-        content: user_content,
+        content: Value::String(user_content),
     });
 
     // Build response_format if schema is provided
@@ -385,6 +452,7 @@ pub async fn send_chat_completion_with_schema(
         stream: false,
         response_format,
         reasoning,
+        provider: provider_routing(provider, pinned_provider),
     };
 
     let mut response = client
@@ -461,28 +529,27 @@ pub async fn send_chat_completion_with_schema(
         .and_then(|choice| choice.message.content.clone()))
 }
 
-/// Fetch available models from an OpenAI-compatible API
-/// Returns a list of model IDs
-pub async fn fetch_models(
+/// GET `url` with the provider's auth headers and decode the JSON body.
+/// `what` names the resource for log and error messages.
+async fn get_json(
     provider: &PostProcessProvider,
-    api_key: String,
-) -> Result<Vec<String>, String> {
-    let base_url = provider.base_url.trim_end_matches('/');
-    let url = format!("{}/models", base_url);
+    api_key: &str,
+    url: &str,
+    what: &str,
+) -> Result<Value, String> {
+    debug!("Fetching {} from: {}", what, sanitized_url_for_log(url));
 
-    debug!("Fetching models from: {}", sanitized_url_for_log(&url));
-
-    let client = create_client(provider, &api_key)?;
-
+    let client = create_client(provider, api_key)?;
     let response = client
-        .get(&url)
+        .get(url)
         .send()
         .await
-        .map_err(|e| report_reqwest_error("Failed to fetch models", &e))?;
+        .map_err(|e| report_reqwest_error(&format!("Failed to fetch {what}"), &e))?;
 
     let status = response.status();
     debug!(
-        "Model list response received with status {} over {:?} from {}",
+        "{} response received with status {} over {:?} from {}",
+        what,
         status,
         response.version(),
         sanitized_url(response.url())
@@ -491,17 +558,28 @@ pub async fn fetch_models(
         let error_text = response
             .text()
             .await
-            .unwrap_or_else(|e| report_reqwest_error("Failed to read model list error", &e));
+            .unwrap_or_else(|e| report_reqwest_error(&format!("Failed to read {what} error"), &e));
         return Err(format!(
-            "Model list request failed ({}): {}",
-            status, error_text
+            "{} request failed ({}): {}",
+            what, status, error_text
         ));
     }
 
-    let parsed: serde_json::Value = response
+    response
         .json()
         .await
-        .map_err(|e| report_reqwest_error("Failed to parse model list response", &e))?;
+        .map_err(|e| report_reqwest_error(&format!("Failed to parse {what} response"), &e))
+}
+
+/// Fetch available models from an OpenAI-compatible API
+/// Returns a list of model IDs
+pub async fn fetch_models(
+    provider: &PostProcessProvider,
+    api_key: String,
+) -> Result<Vec<String>, String> {
+    let base_url = provider.base_url.trim_end_matches('/');
+    let url = format!("{}/models", base_url);
+    let parsed = get_json(provider, &api_key, &url, "model list").await?;
 
     let mut models = Vec::new();
 
@@ -525,6 +603,122 @@ pub async fn fetch_models(
     }
 
     Ok(models)
+}
+
+/// One upstream provider serving a model on OpenRouter.
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+pub struct OpenRouterEndpoint {
+    /// Slug accepted by the `provider.order` routing field (e.g. "google-ai-studio").
+    pub slug: String,
+    /// Human readable provider name (e.g. "Google AI Studio").
+    pub name: String,
+    pub context_length: Option<f64>,
+    /// USD per input token, as reported by OpenRouter.
+    pub prompt_price: Option<f64>,
+    /// USD per output token.
+    pub completion_price: Option<f64>,
+    /// USD per cached input token; present when the upstream supports prompt caching.
+    pub cache_read_price: Option<f64>,
+    /// Upstream caches the prompt prefix without explicit `cache_control`.
+    pub supports_implicit_caching: bool,
+    /// Accepts `response_format` (structured outputs); without it Handy falls
+    /// back to legacy plain-text mode on every request.
+    pub supports_structured_output: bool,
+    /// Uptime over the last 30 minutes, in percent.
+    pub uptime_pct: Option<f64>,
+    /// OpenRouter health status; negative means degraded/deranked.
+    pub status: Option<f64>,
+    /// Mean time to first token over the last 30 minutes, in ms (when reported).
+    pub latency_ms: Option<f64>,
+    /// Mean generation speed over the last 30 minutes, tokens/s (when reported).
+    pub throughput_tps: Option<f64>,
+}
+
+fn parse_price(value: Option<&Value>) -> Option<f64> {
+    match value? {
+        Value::String(s) => s.trim().parse().ok(),
+        Value::Number(n) => n.as_f64(),
+        _ => None,
+    }
+}
+
+/// Fetch the upstream providers that serve `model` on OpenRouter.
+/// Uses `GET {base_url}/models/{author}/{slug}/endpoints`.
+pub async fn fetch_openrouter_endpoints(
+    provider: &PostProcessProvider,
+    api_key: String,
+    model: &str,
+) -> Result<Vec<OpenRouterEndpoint>, String> {
+    let model = model.trim();
+    if model.is_empty() {
+        return Err("Select a model first".to_string());
+    }
+    // Variant suffixes (":free", ":nitro") are routing hints, not part of the
+    // model path the endpoints API expects.
+    let model_path = model.split(':').next().unwrap_or(model);
+    let base_url = provider.base_url.trim_end_matches('/');
+    let url = format!("{}/models/{}/endpoints", base_url, model_path);
+    let parsed = get_json(provider, &api_key, &url, "endpoint list").await?;
+
+    Ok(parse_openrouter_endpoints(&parsed))
+}
+
+fn parse_openrouter_endpoints(parsed: &Value) -> Vec<OpenRouterEndpoint> {
+    let Some(entries) = parsed
+        .get("data")
+        .and_then(|d| d.get("endpoints"))
+        .and_then(|e| e.as_array())
+    else {
+        return Vec::new();
+    };
+
+    let mut seen: HashSet<&str> = HashSet::new();
+    entries
+        .iter()
+        .filter_map(|entry| {
+            // `tag` is the routing slug; `provider_name` is the display name.
+            let slug = entry
+                .get("tag")
+                .and_then(|t| t.as_str())
+                .map(str::trim)
+                .filter(|t| !t.is_empty())?;
+            if !seen.insert(slug) {
+                return None;
+            }
+            let name = entry
+                .get("provider_name")
+                .and_then(|n| n.as_str())
+                .unwrap_or(slug)
+                .to_string();
+            let pricing = entry.get("pricing");
+            let number = |key: &str| entry.get(key).and_then(|v| v.as_f64());
+            let flag = |key: &str| entry.get(key).and_then(|v| v.as_bool()).unwrap_or(false);
+            let supports_structured_output = entry
+                .get("supported_parameters")
+                .and_then(|p| p.as_array())
+                .map(|params| {
+                    params.iter().any(|p| {
+                        p.as_str() == Some("structured_outputs")
+                            || p.as_str() == Some("response_format")
+                    })
+                })
+                .unwrap_or(false);
+            Some(OpenRouterEndpoint {
+                slug: slug.to_string(),
+                name,
+                context_length: number("context_length"),
+                prompt_price: parse_price(pricing.and_then(|p| p.get("prompt"))),
+                completion_price: parse_price(pricing.and_then(|p| p.get("completion"))),
+                cache_read_price: parse_price(pricing.and_then(|p| p.get("input_cache_read"))),
+                supports_implicit_caching: flag("supports_implicit_caching"),
+                supports_structured_output,
+                uptime_pct: number("uptime_last_30m"),
+                status: number("status"),
+                latency_ms: number("latency_last_30m"),
+                throughput_tps: number("throughput_last_30m"),
+            })
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -561,6 +755,7 @@ mod tests {
             allow_base_url_edit: true,
             models_endpoint: None,
             supports_structured_output: false,
+            supports_provider_routing: false,
         }
     }
 
@@ -569,11 +764,12 @@ mod tests {
             model: "test-model".to_string(),
             messages: vec![ChatMessage {
                 role: "user".to_string(),
-                content: "hi".to_string(),
+                content: Value::String("hi".to_string()),
             }],
             stream: false,
             response_format: None,
             reasoning,
+            provider: None,
         };
         serde_json::to_value(&request).unwrap()
     }
@@ -683,6 +879,69 @@ mod tests {
         assert_eq!(json["reasoning_effort"], "none");
         assert!(json.get("reasoning").is_none());
         assert!(json.get("thinking").is_none());
+    }
+
+    fn routing_provider() -> PostProcessProvider {
+        PostProcessProvider {
+            supports_provider_routing: true,
+            ..provider("openrouter", "https://openrouter.ai/api/v1")
+        }
+    }
+
+    #[test]
+    fn routing_gateway_system_prompt_carries_cache_breakpoint() {
+        let msg = system_message(&routing_provider(), "rules".to_string());
+        let json = serde_json::to_value(&msg).unwrap();
+        assert_eq!(json["role"], "system");
+        assert_eq!(json["content"][0]["text"], "rules");
+        assert_eq!(json["content"][0]["cache_control"]["type"], "ephemeral");
+
+        let plain = system_message(
+            &provider("openai", "https://api.openai.com/v1"),
+            "rules".into(),
+        );
+        assert_eq!(serde_json::to_value(&plain).unwrap()["content"], "rules");
+    }
+
+    #[test]
+    fn provider_routing_only_applies_to_routing_gateways_with_a_slug() {
+        let or = routing_provider();
+        let routing = provider_routing(&or, Some("google-ai-studio")).unwrap();
+        assert_eq!(routing["order"][0], "google-ai-studio");
+        assert_eq!(routing["allow_fallbacks"], false);
+        assert!(provider_routing(&or, Some("  ")).is_none());
+        let sorted = provider_routing(&or, Some("sort:throughput")).unwrap();
+        assert_eq!(sorted["sort"], "throughput");
+        assert_eq!(sorted["require_parameters"], true);
+        assert!(sorted.get("order").is_none());
+        assert!(provider_routing(&or, Some("sort:bogus")).is_none());
+        assert!(provider_routing(&or, None).is_none());
+        assert!(provider_routing(&provider("openai", "x"), Some("google-ai-studio")).is_none());
+    }
+
+    #[test]
+    fn endpoints_response_is_parsed_and_deduped() {
+        let body = serde_json::json!({ "data": { "endpoints": [
+            { "tag": "google-ai-studio", "provider_name": "Google AI Studio",
+              "context_length": 1000000, "uptime_last_30m": 99.5, "status": 0,
+              "supports_implicit_caching": true,
+              "supported_parameters": ["response_format", "structured_outputs"],
+              "pricing": { "prompt": "0.0000003", "completion": "0.0000025", "input_cache_read": "0.000000075" } },
+            { "tag": "google-vertex", "provider_name": "Google Vertex", "pricing": { "prompt": "0.0000003" } },
+            { "tag": "google-vertex", "provider_name": "dup" },
+            { "provider_name": "no tag" }
+        ]}});
+        let endpoints = parse_openrouter_endpoints(&body);
+        assert_eq!(endpoints.len(), 2);
+        assert_eq!(endpoints[0].slug, "google-ai-studio");
+        assert_eq!(endpoints[0].name, "Google AI Studio");
+        assert_eq!(endpoints[0].cache_read_price, Some(0.000000075));
+        assert_eq!(endpoints[0].context_length, Some(1000000.0));
+        assert_eq!(endpoints[1].cache_read_price, None);
+        assert!(endpoints[0].supports_structured_output);
+        assert!(endpoints[0].supports_implicit_caching);
+        assert_eq!(endpoints[0].uptime_pct, Some(99.5));
+        assert!(!endpoints[1].supports_structured_output);
     }
 
     #[test]

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -104,6 +104,10 @@ pub struct PostProcessProvider {
     pub models_endpoint: Option<String>,
     #[serde(default)]
     pub supports_structured_output: bool,
+    /// Gateway that fronts several upstream providers (OpenRouter): accepts the
+    /// `provider` routing object and `cache_control` content-part breakpoints.
+    #[serde(default)]
+    pub supports_provider_routing: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Type)]
@@ -423,6 +427,12 @@ pub struct AppSettings {
     pub post_process_api_keys: SecretMap,
     #[serde(default = "default_post_process_models")]
     pub post_process_models: HashMap<String, String>,
+    /// provider id -> (model id -> pinned upstream provider slug, e.g.
+    /// "google-ai-studio") for providers with `supports_provider_routing`.
+    /// Missing/empty means the gateway's default routing. Pinning keeps every
+    /// request on one upstream so its prompt cache hits.
+    #[serde(default)]
+    pub post_process_upstream_providers: HashMap<String, HashMap<String, String>>,
     #[serde(default = "default_post_process_prompts")]
     pub post_process_prompts: Vec<LLMPrompt>,
     #[serde(default)]
@@ -623,6 +633,7 @@ fn default_post_process_providers() -> Vec<PostProcessProvider> {
             allow_base_url_edit: false,
             models_endpoint: Some("/models".to_string()),
             supports_structured_output: true,
+            supports_provider_routing: false,
         },
         PostProcessProvider {
             id: "zai".to_string(),
@@ -631,6 +642,7 @@ fn default_post_process_providers() -> Vec<PostProcessProvider> {
             allow_base_url_edit: false,
             models_endpoint: Some("/models".to_string()),
             supports_structured_output: true,
+            supports_provider_routing: false,
         },
         PostProcessProvider {
             id: "openrouter".to_string(),
@@ -639,6 +651,7 @@ fn default_post_process_providers() -> Vec<PostProcessProvider> {
             allow_base_url_edit: false,
             models_endpoint: Some("/models".to_string()),
             supports_structured_output: true,
+            supports_provider_routing: true,
         },
         PostProcessProvider {
             id: "anthropic".to_string(),
@@ -647,6 +660,7 @@ fn default_post_process_providers() -> Vec<PostProcessProvider> {
             allow_base_url_edit: false,
             models_endpoint: Some("/models".to_string()),
             supports_structured_output: false,
+            supports_provider_routing: false,
         },
         PostProcessProvider {
             id: "groq".to_string(),
@@ -655,6 +669,7 @@ fn default_post_process_providers() -> Vec<PostProcessProvider> {
             allow_base_url_edit: false,
             models_endpoint: Some("/models".to_string()),
             supports_structured_output: false,
+            supports_provider_routing: false,
         },
         PostProcessProvider {
             id: "cerebras".to_string(),
@@ -663,6 +678,7 @@ fn default_post_process_providers() -> Vec<PostProcessProvider> {
             allow_base_url_edit: false,
             models_endpoint: Some("/models".to_string()),
             supports_structured_output: true,
+            supports_provider_routing: false,
         },
     ];
 
@@ -679,6 +695,7 @@ fn default_post_process_providers() -> Vec<PostProcessProvider> {
             allow_base_url_edit: false,
             models_endpoint: None,
             supports_structured_output: true,
+            supports_provider_routing: false,
         });
     }
 
@@ -690,6 +707,7 @@ fn default_post_process_providers() -> Vec<PostProcessProvider> {
         allow_base_url_edit: false,
         models_endpoint: Some("/models".to_string()),
         supports_structured_output: true,
+        supports_provider_routing: false,
     });
 
     // Custom provider always comes last
@@ -700,6 +718,7 @@ fn default_post_process_providers() -> Vec<PostProcessProvider> {
         allow_base_url_edit: true,
         models_endpoint: Some("/models".to_string()),
         supports_structured_output: false,
+        supports_provider_routing: false,
     });
 
     providers
@@ -783,6 +802,10 @@ fn ensure_post_process_defaults(settings: &mut AppSettings) -> bool {
                         provider.supports_structured_output
                     );
                     existing.supports_structured_output = provider.supports_structured_output;
+                    changed = true;
+                }
+                if existing.supports_provider_routing != provider.supports_provider_routing {
+                    existing.supports_provider_routing = provider.supports_provider_routing;
                     changed = true;
                 }
             }
@@ -912,6 +935,7 @@ pub fn get_default_settings() -> AppSettings {
         post_process_providers: default_post_process_providers(),
         post_process_api_keys: default_post_process_api_keys(),
         post_process_models: default_post_process_models(),
+        post_process_upstream_providers: HashMap::new(),
         post_process_prompts: default_post_process_prompts(),
         post_process_selected_prompt_id: None,
         mute_while_recording: false,
@@ -955,6 +979,15 @@ impl AppSettings {
         self.post_process_providers
             .iter()
             .find(|provider| provider.id == provider_id)
+    }
+
+    /// Pinned upstream provider slug for `model` on `provider_id`, if any.
+    pub fn upstream_provider_for(&self, provider_id: &str, model: &str) -> Option<&str> {
+        self.post_process_upstream_providers
+            .get(provider_id)?
+            .get(model.trim())
+            .map(|slug| slug.trim())
+            .filter(|slug| !slug.is_empty())
     }
 
     pub fn post_process_provider_mut(

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -1085,6 +1085,55 @@ pub fn change_post_process_model_setting(
     Ok(())
 }
 
+/// Pin (or clear, with an empty slug) the upstream provider `provider_id`
+/// routes `model` to. Only meaningful for providers with `supports_provider_routing`.
+#[tauri::command]
+#[specta::specta]
+pub fn change_post_process_upstream_provider_setting(
+    app: AppHandle,
+    provider_id: String,
+    model: String,
+    provider_slug: String,
+) -> Result<(), String> {
+    let model = model.trim().to_string();
+    if model.is_empty() {
+        return Err("Model must not be empty".to_string());
+    }
+    let mut settings = settings::get_settings(&app);
+    validate_provider_exists(&settings, &provider_id)?;
+    let pins = settings
+        .post_process_upstream_providers
+        .entry(provider_id)
+        .or_default();
+    let slug = provider_slug.trim();
+    if slug.is_empty() {
+        pins.remove(&model);
+    } else {
+        pins.insert(model, slug.to_string());
+    }
+    settings::write_settings(&app, settings);
+    Ok(())
+}
+
+/// List the upstream providers `provider_id` can route `model` to.
+#[tauri::command]
+#[specta::specta]
+pub async fn fetch_post_process_upstream_providers(
+    app: AppHandle,
+    provider_id: String,
+    model: String,
+) -> Result<Vec<crate::llm_client::OpenRouterEndpoint>, String> {
+    let settings = settings::get_settings(&app);
+    let (provider, api_key) = resolve_provider_and_key(&settings, &provider_id)?;
+    if !provider.supports_provider_routing {
+        return Err(format!(
+            "{} does not support upstream provider routing",
+            provider.label
+        ));
+    }
+    crate::llm_client::fetch_openrouter_endpoints(provider, api_key, &model).await
+}
+
 #[tauri::command]
 #[specta::specta]
 pub fn set_post_process_provider(app: AppHandle, provider_id: String) -> Result<(), String> {
@@ -1171,6 +1220,33 @@ pub fn delete_post_process_prompt(app: AppHandle, id: String) -> Result<(), Stri
     Ok(())
 }
 
+/// Look up a post-process provider and its API key. Errors when the key is
+/// missing for providers that need one (everything except Custom and Apple
+/// Intelligence).
+fn resolve_provider_and_key<'a>(
+    settings: &'a settings::AppSettings,
+    provider_id: &str,
+) -> Result<(&'a settings::PostProcessProvider, String), String> {
+    let provider = settings
+        .post_process_provider(provider_id)
+        .ok_or_else(|| format!("Provider '{}' not found", provider_id))?;
+    let api_key = settings
+        .post_process_api_keys
+        .get(provider_id)
+        .cloned()
+        .unwrap_or_default();
+    if api_key.trim().is_empty()
+        && provider.id != "custom"
+        && provider.id != APPLE_INTELLIGENCE_PROVIDER_ID
+    {
+        return Err(format!(
+            "API key is required for {}. Please add an API key to list available models.",
+            provider.label
+        ));
+    }
+    Ok((provider, api_key))
+}
+
 #[tauri::command]
 #[specta::specta]
 pub async fn fetch_post_process_models(
@@ -1179,12 +1255,7 @@ pub async fn fetch_post_process_models(
 ) -> Result<Vec<String>, String> {
     let settings = settings::get_settings(&app);
 
-    // Find the provider
-    let provider = settings
-        .post_process_providers
-        .iter()
-        .find(|p| p.id == provider_id)
-        .ok_or_else(|| format!("Provider '{}' not found", provider_id))?;
+    let (provider, api_key) = resolve_provider_and_key(&settings, &provider_id)?;
 
     if provider.id == APPLE_INTELLIGENCE_PROVIDER_ID {
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
@@ -1196,21 +1267,6 @@ pub async fn fetch_post_process_models(
         {
             return Err("Apple Intelligence is only available on Apple silicon Macs running macOS 15 or later.".to_string());
         }
-    }
-
-    // Get API key
-    let api_key = settings
-        .post_process_api_keys
-        .get(&provider_id)
-        .cloned()
-        .unwrap_or_default();
-
-    // Skip fetching if no API key for providers that typically need one
-    if api_key.trim().is_empty() && provider.id != "custom" {
-        return Err(format!(
-            "API key is required for {}. Please add an API key to list available models.",
-            provider.label
-        ));
     }
 
     crate::llm_client::fetch_models(provider, api_key).await

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -264,6 +264,29 @@ async fetchPostProcessModels(providerId: string) : Promise<Result<string[], stri
     else return { status: "error", error: e  as any };
 }
 },
+/**
+ * Pin (or clear, with an empty slug) the upstream provider `provider_id`
+ * routes `model` to. Only meaningful for providers with `supports_provider_routing`.
+ */
+async changePostProcessUpstreamProviderSetting(providerId: string, model: string, providerSlug: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("change_post_process_upstream_provider_setting", { providerId, model, providerSlug }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * List the upstream providers `provider_id` can route `model` to.
+ */
+async fetchPostProcessUpstreamProviders(providerId: string, model: string) : Promise<Result<OpenRouterEndpoint[], string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("fetch_post_process_upstream_providers", { providerId, model }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async addPostProcessPrompt(name: string, prompt: string) : Promise<Result<LLMPrompt, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("add_post_process_prompt", { name, prompt }) };
@@ -953,19 +976,26 @@ whats_new_last_seen_version?: string; selected_model?: string; onboarding_comple
  * Which input channel to use on the selected microphone device.
  * None means "average all channels" (original behavior).
  */
-selected_channel?: number | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: SecretMap; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; theme?: Theme; experimental_enabled?: boolean; lazy_stream_close?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; paste_delay_after_ms?: number; 
+selected_channel?: number | null; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: SecretMap; post_process_models?: Partial<{ [key in string]: string }>; 
+/**
+ * provider id -> (model id -> pinned upstream provider slug, e.g.
+ * "google-ai-studio") for providers with `supports_provider_routing`.
+ * Missing/empty means the gateway's default routing. Pinning keeps every
+ * request on one upstream so its prompt cache hits.
+ */
+post_process_upstream_providers?: Partial<{ [key in string]: Partial<{ [key in string]: string }> }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; theme?: Theme; experimental_enabled?: boolean; lazy_stream_close?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; paste_delay_after_ms?: number; 
 /**
  * Debug-gated ("beta") receipt-sequenced paste: restore the clipboard only
  * after the target app actually reads the transcript, instead of after a
  * fixed delay. See `paste_tx`. macOS and Windows only.
  */
-reliable_paste?: boolean; typing_tool?: TypingTool; external_script_path?: string | null; filler_word_removal_enabled?: boolean; custom_filler_words?: string[] | null; transcribe_accelerator?: TranscribeAcceleratorSetting; ort_accelerator?: OrtAcceleratorSetting;
+reliable_paste?: boolean; typing_tool?: TypingTool; external_script_path?: string | null; filler_word_removal_enabled?: boolean; custom_filler_words?: string[] | null; transcribe_accelerator?: TranscribeAcceleratorSetting; ort_accelerator?: OrtAcceleratorSetting; 
 /**
  * Stable transcribe.cpp device selector. This is derived from the backend's
  * `device_id` when available (or its name for backends such as Metal),
  * never from the process-local device registry index.
  */
-transcribe_gpu_device?: string | null; extra_recording_buffer_ms?: number; vad_enabled?: boolean;
+transcribe_gpu_device?: string | null; extra_recording_buffer_ms?: number; vad_enabled?: boolean; 
 /**
  * Which recording overlay to show: None / Minimal / Live. Streaming mode is
  * not gated on this — that follows model capability. Migrated from the old
@@ -1031,6 +1061,55 @@ sha256: string | null } } |
  */
 "Local"
 export type ModelUnloadTimeout = "never" | "immediately" | "min_2" | "min_5" | "min_10" | "min_15" | "hour_1" | "sec_15"
+/**
+ * One upstream provider serving a model on OpenRouter.
+ */
+export type OpenRouterEndpoint = { 
+/**
+ * Slug accepted by the `provider.order` routing field (e.g. "google-ai-studio").
+ */
+slug: string; 
+/**
+ * Human readable provider name (e.g. "Google AI Studio").
+ */
+name: string; context_length: number | null; 
+/**
+ * USD per input token, as reported by OpenRouter.
+ */
+prompt_price: number | null; 
+/**
+ * USD per output token.
+ */
+completion_price: number | null; 
+/**
+ * USD per cached input token; present when the upstream supports prompt caching.
+ */
+cache_read_price: number | null; 
+/**
+ * Upstream caches the prompt prefix without explicit `cache_control`.
+ */
+supports_implicit_caching: boolean; 
+/**
+ * Accepts `response_format` (structured outputs); without it Handy falls
+ * back to legacy plain-text mode on every request.
+ */
+supports_structured_output: boolean; 
+/**
+ * Uptime over the last 30 minutes, in percent.
+ */
+uptime_pct: number | null; 
+/**
+ * OpenRouter health status; negative means degraded/deranked.
+ */
+status: number | null; 
+/**
+ * Mean time to first token over the last 30 minutes, in ms (when reported).
+ */
+latency_ms: number | null; 
+/**
+ * Mean generation speed over the last 30 minutes, tokens/s (when reported).
+ */
+throughput_tps: number | null }
 export type OrtAcceleratorSetting = "auto" | "cpu" | "cuda" | "directml" | "rocm"
 export type OverlayPosition = "top" | "bottom"
 /**
@@ -1043,7 +1122,12 @@ export type OverlayStyle = "none" | "minimal" | "live"
 export type PaginatedHistory = { entries: HistoryEntry[]; has_more: boolean }
 export type PasteMethod = "ctrl_v" | "direct" | "none" | "shift_insert" | "ctrl_shift_v" | "external_script"
 export type PermissionAccess = "allowed" | "denied" | "unknown"
-export type PostProcessProvider = { id: string; label: string; base_url: string; allow_base_url_edit?: boolean; models_endpoint?: string | null; supports_structured_output?: boolean }
+export type PostProcessProvider = { id: string; label: string; base_url: string; allow_base_url_edit?: boolean; models_endpoint?: string | null; supports_structured_output?: boolean; 
+/**
+ * Gateway that fronts several upstream providers (OpenRouter): accepts the
+ * `provider` routing object and `cache_control` content-part breakpoints.
+ */
+supports_provider_routing?: boolean }
 export type RecordingRetentionPeriod = "never" | "preserve_limit" | "days_3" | "weeks_2" | "months_3"
 export type SecretMap = Partial<{ [key in string]: string }>
 export type SecureInputStatus = { 

--- a/src/components/settings/PostProcessingSettingsApi/usePostProcessProviderState.ts
+++ b/src/components/settings/PostProcessingSettingsApi/usePostProcessProviderState.ts
@@ -1,6 +1,10 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useSettings } from "../../../hooks/useSettings";
-import { commands, type PostProcessProvider } from "@/bindings";
+import {
+  commands,
+  type OpenRouterEndpoint,
+  type PostProcessProvider,
+} from "@/bindings";
 import type { ModelOption } from "./types";
 import type { DropdownOption } from "../../ui/Dropdown";
 
@@ -26,7 +30,17 @@ type PostProcessProviderState = {
   handleModelSelect: (value: string) => void;
   handleModelCreate: (value: string) => void;
   handleRefreshModels: () => void;
+  // Upstream provider pinning (routing gateways such as OpenRouter)
+  showUpstreamProvider: boolean;
+  upstreamProvider: string;
+  upstreamProviderOptions: OpenRouterEndpoint[];
+  isUpstreamProviderUpdating: boolean;
+  isFetchingUpstreamProviders: boolean;
+  handleUpstreamProviderSelect: (slug: string) => void;
+  handleRefreshUpstreamProviders: () => void;
 };
+
+const NO_ENDPOINTS: OpenRouterEndpoint[] = [];
 
 const APPLE_PROVIDER_ID = "apple_intelligence";
 
@@ -40,6 +54,9 @@ export const usePostProcessProviderState = (): PostProcessProviderState => {
     updatePostProcessModel,
     fetchPostProcessModels,
     postProcessModelOptions,
+    upstreamProviderOptions: upstreamProviderOptionsByKey,
+    fetchUpstreamProviders,
+    updateUpstreamProvider,
   } = useSettings();
 
   // Settings are guaranteed to have providers after migration
@@ -207,7 +224,69 @@ export const usePostProcessProviderState = (): PostProcessProviderState => {
 
   const isCustomProvider = selectedProvider?.id === "custom";
 
-  // No automatic fetching - user must click refresh button
+  // Upstream provider pinning (per provider + model), only for routing gateways
+  const trimmedModel = model.trim();
+  const showUpstreamProvider =
+    (selectedProvider?.supports_provider_routing ?? false) &&
+    trimmedModel !== "";
+  const upstreamKey = `${selectedProviderId}:${trimmedModel}`;
+  const upstreamProvider =
+    settings?.post_process_upstream_providers?.[selectedProviderId]?.[
+      trimmedModel
+    ] ?? "";
+  const upstreamProviderOptions =
+    upstreamProviderOptionsByKey[upstreamKey] ?? NO_ENDPOINTS;
+  const isUpstreamProviderUpdating = isUpdating(
+    `upstream_provider:${upstreamKey}`,
+  );
+  const isFetchingUpstreamProviders = isUpdating(
+    `upstream_providers_fetch:${upstreamKey}`,
+  );
+
+  const handleUpstreamProviderSelect = useCallback(
+    (slug: string) => {
+      if (!showUpstreamProvider) return;
+      void updateUpstreamProvider(
+        selectedProviderId,
+        trimmedModel,
+        slug.trim(),
+      );
+    },
+    [
+      showUpstreamProvider,
+      selectedProviderId,
+      trimmedModel,
+      updateUpstreamProvider,
+    ],
+  );
+
+  const handleRefreshUpstreamProviders = useCallback(() => {
+    if (!showUpstreamProvider) return;
+    void fetchUpstreamProviders(selectedProviderId, trimmedModel);
+  }, [
+    showUpstreamProvider,
+    selectedProviderId,
+    trimmedModel,
+    fetchUpstreamProviders,
+  ]);
+
+  // Auto-load the upstream list once per (provider, model) so the dropdown is
+  // ready without an extra click. Failed fetches are cached as empty, so this
+  // never loops; the refresh button re-fetches explicitly.
+  const upstreamLoaded = upstreamKey in upstreamProviderOptionsByKey;
+  useEffect(() => {
+    if (!showUpstreamProvider || !apiKey.trim()) return;
+    if (upstreamLoaded || isFetchingUpstreamProviders) return;
+    void fetchUpstreamProviders(selectedProviderId, trimmedModel);
+  }, [
+    apiKey,
+    fetchUpstreamProviders,
+    isFetchingUpstreamProviders,
+    selectedProviderId,
+    showUpstreamProvider,
+    trimmedModel,
+    upstreamLoaded,
+  ]);
 
   return {
     providerOptions,
@@ -231,5 +310,12 @@ export const usePostProcessProviderState = (): PostProcessProviderState => {
     handleModelSelect,
     handleModelCreate,
     handleRefreshModels,
+    showUpstreamProvider,
+    upstreamProvider,
+    upstreamProviderOptions,
+    isUpstreamProviderUpdating,
+    isFetchingUpstreamProviders,
+    handleUpstreamProviderSelect,
+    handleRefreshUpstreamProviders,
   };
 };

--- a/src/components/settings/post-processing/PostProcessingSettings.tsx
+++ b/src/components/settings/post-processing/PostProcessingSettings.tsx
@@ -235,26 +235,32 @@ const upstreamDropdownOptions = (
     })),
   ];
   for (const endpoint of endpoints) {
-    const details: string[] = [];
     const free = t(key("free"));
+    const details: string[] = [];
     const prompt = formatPerMillion(endpoint.prompt_price, free);
     const completion = formatPerMillion(endpoint.completion_price, free);
-    if (prompt && completion) details.push(`${prompt} in / ${completion} out`);
+    if (prompt && completion) details.push(`${prompt} / ${completion}`);
     const cached = formatPerMillion(endpoint.cache_read_price, free);
     if (cached) details.push(`${t(key("cached"))} ${cached}`);
     if (endpoint.throughput_tps !== null)
       details.push(`${Math.round(endpoint.throughput_tps)} tok/s`);
     if (endpoint.latency_ms !== null)
       details.push(`${Math.round(endpoint.latency_ms)} ms`);
-    if (endpoint.uptime_pct !== null)
+    // Uptime is only worth the space when it is notably below normal.
+    if (endpoint.uptime_pct !== null && endpoint.uptime_pct < 99.5)
       details.push(`${endpoint.uptime_pct.toFixed(1)}% up`);
     const warnings: string[] = [];
     if ((endpoint.status ?? 0) < 0) warnings.push(t(key("degraded")));
     if (!endpoint.supports_structured_output)
       warnings.push(t(key("noStructuredOutput")));
-    // Names repeat across variants (e.g. "google-ai-studio/flex"), so the
-    // routing slug is always shown.
-    let label = `${endpoint.name} (${endpoint.slug})`;
+    // Slugs are unique and usually self-describing ("google-ai-studio/flex");
+    // prefix the display name only when it adds information.
+    const slugHasName = endpoint.slug
+      .toLowerCase()
+      .includes(endpoint.name.toLowerCase().split(" ")[0]);
+    let label = slugHasName
+      ? endpoint.slug
+      : `${endpoint.name} (${endpoint.slug})`;
     if (details.length) label += ` — ${details.join(", ")}`;
     if (warnings.length) label += ` ⚠ ${warnings.join(", ")}`;
     options.push({ value: endpoint.slug, label });

--- a/src/components/settings/post-processing/PostProcessingSettings.tsx
+++ b/src/components/settings/post-processing/PostProcessingSettings.tsx
@@ -210,8 +210,15 @@ const AUTO_ROUTING = "__auto__";
  */
 const SORT_STRATEGIES = ["throughput", "latency", "price"] as const;
 
-const formatPerMillion = (perToken: number | null): string | null =>
-  perToken === null ? null : `$${(perToken * 1_000_000).toFixed(2)}/M`;
+const formatPerMillion = (
+  perToken: number | null,
+  free: string,
+): string | null => {
+  if (perToken === null) return null;
+  if (perToken === 0) return free;
+  const perMillion = perToken * 1_000_000;
+  return `$${perMillion.toFixed(perMillion < 0.1 ? 3 : 2)}/M`;
+};
 
 const upstreamDropdownOptions = (
   endpoints: OpenRouterEndpoint[],
@@ -229,10 +236,11 @@ const upstreamDropdownOptions = (
   ];
   for (const endpoint of endpoints) {
     const details: string[] = [];
-    const prompt = formatPerMillion(endpoint.prompt_price);
-    const completion = formatPerMillion(endpoint.completion_price);
+    const free = t(key("free"));
+    const prompt = formatPerMillion(endpoint.prompt_price, free);
+    const completion = formatPerMillion(endpoint.completion_price, free);
     if (prompt && completion) details.push(`${prompt} in / ${completion} out`);
-    const cached = formatPerMillion(endpoint.cache_read_price);
+    const cached = formatPerMillion(endpoint.cache_read_price, free);
     if (cached) details.push(`${t(key("cached"))} ${cached}`);
     if (endpoint.throughput_tps !== null)
       details.push(`${Math.round(endpoint.throughput_tps)} tok/s`);

--- a/src/components/settings/post-processing/PostProcessingSettings.tsx
+++ b/src/components/settings/post-processing/PostProcessingSettings.tsx
@@ -1,7 +1,9 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
+import type { TFunction } from "i18next";
 import { RefreshCcw } from "lucide-react";
-import { commands } from "@/bindings";
+import { commands, type OpenRouterEndpoint } from "@/bindings";
+import { Select, type SelectOption } from "../../ui/Select";
 
 import { Alert } from "../../ui/Alert";
 import {
@@ -25,6 +27,15 @@ import { useSettings } from "../../../hooks/useSettings";
 const PostProcessingSettingsApiComponent: React.FC = () => {
   const { t } = useTranslation();
   const state = usePostProcessProviderState();
+  const upstreamOptions = useMemo(
+    () =>
+      upstreamDropdownOptions(
+        state.upstreamProviderOptions,
+        state.upstreamProvider,
+        t,
+      ),
+    [state.upstreamProviderOptions, state.upstreamProvider, t],
+  );
 
   return (
     <>
@@ -126,21 +137,125 @@ const PostProcessingSettingsApiComponent: React.FC = () => {
               onBlur={() => {}}
               className="flex-1 min-w-[380px]"
             />
-            <ResetButton
+            <RefreshButton
               onClick={state.handleRefreshModels}
-              disabled={state.isFetchingModels}
+              busy={state.isFetchingModels}
               ariaLabel={t("settings.postProcessing.api.model.refreshModels")}
-              className="flex h-10 w-10 items-center justify-center"
-            >
-              <RefreshCcw
-                className={`h-4 w-4 ${state.isFetchingModels ? "animate-spin" : ""}`}
-              />
-            </ResetButton>
+            />
+          </div>
+        </SettingContainer>
+      )}
+
+      {state.showUpstreamProvider && (
+        <SettingContainer
+          title={t("settings.postProcessing.api.upstreamProvider.title")}
+          description={t(
+            "settings.postProcessing.api.upstreamProvider.description",
+          )}
+          descriptionMode="tooltip"
+          layout="stacked"
+          grouped={true}
+        >
+          <div className="flex items-center gap-2">
+            <Select
+              className="text-sm flex-1 min-w-[380px]"
+              options={upstreamOptions}
+              value={state.upstreamProvider || AUTO_ROUTING}
+              onChange={(value) =>
+                state.handleUpstreamProviderSelect(
+                  !value || value === AUTO_ROUTING ? "" : value,
+                )
+              }
+              isClearable={false}
+              disabled={state.isUpstreamProviderUpdating}
+              isLoading={state.isFetchingUpstreamProviders}
+            />
+            <RefreshButton
+              onClick={state.handleRefreshUpstreamProviders}
+              busy={state.isFetchingUpstreamProviders}
+              ariaLabel={t(
+                "settings.postProcessing.api.upstreamProvider.refresh",
+              )}
+            />
           </div>
         </SettingContainer>
       )}
     </>
   );
+};
+
+const RefreshButton: React.FC<{
+  onClick: () => void;
+  busy: boolean;
+  ariaLabel: string;
+}> = ({ onClick, busy, ariaLabel }) => (
+  <ResetButton
+    onClick={onClick}
+    disabled={busy}
+    ariaLabel={ariaLabel}
+    className="flex h-10 w-10 items-center justify-center"
+  >
+    <RefreshCcw className={`h-4 w-4 ${busy ? "animate-spin" : ""}`} />
+  </ResetButton>
+);
+
+/** Sentinel dropdown value meaning "let the gateway pick the upstream". */
+const AUTO_ROUTING = "__auto__";
+
+/**
+ * Routing strategies (stored as `sort:<strategy>`, see llm_client.rs): the
+ * gateway sends each request to whichever upstream currently leads on the
+ * chosen metric. Pinning a specific provider below trades that for stability
+ * and guaranteed prompt-cache reuse.
+ */
+const SORT_STRATEGIES = ["throughput", "latency", "price"] as const;
+
+const formatPerMillion = (perToken: number | null): string | null =>
+  perToken === null ? null : `$${(perToken * 1_000_000).toFixed(2)}/M`;
+
+const upstreamDropdownOptions = (
+  endpoints: OpenRouterEndpoint[],
+  current: string,
+  t: TFunction,
+): SelectOption[] => {
+  const key = (name: string) =>
+    `settings.postProcessing.api.upstreamProvider.${name}`;
+  const options: SelectOption[] = [
+    { value: AUTO_ROUTING, label: t(key("auto")) },
+    ...SORT_STRATEGIES.map((strategy) => ({
+      value: `sort:${strategy}`,
+      label: t(key(`sort.${strategy}`)),
+    })),
+  ];
+  for (const endpoint of endpoints) {
+    const details: string[] = [];
+    const prompt = formatPerMillion(endpoint.prompt_price);
+    const completion = formatPerMillion(endpoint.completion_price);
+    if (prompt && completion) details.push(`${prompt} in / ${completion} out`);
+    const cached = formatPerMillion(endpoint.cache_read_price);
+    if (cached) details.push(`${t(key("cached"))} ${cached}`);
+    if (endpoint.throughput_tps !== null)
+      details.push(`${Math.round(endpoint.throughput_tps)} tok/s`);
+    if (endpoint.latency_ms !== null)
+      details.push(`${Math.round(endpoint.latency_ms)} ms`);
+    if (endpoint.uptime_pct !== null)
+      details.push(`${endpoint.uptime_pct.toFixed(1)}% up`);
+    const warnings: string[] = [];
+    if ((endpoint.status ?? 0) < 0) warnings.push(t(key("degraded")));
+    if (!endpoint.supports_structured_output)
+      warnings.push(t(key("noStructuredOutput")));
+    // Names repeat across variants (e.g. "google-ai-studio/flex"), so the
+    // routing slug is always shown.
+    let label = `${endpoint.name} (${endpoint.slug})`;
+    if (details.length) label += ` — ${details.join(", ")}`;
+    if (warnings.length) label += ` ⚠ ${warnings.join(", ")}`;
+    options.push({ value: endpoint.slug, label });
+  }
+  // Keep a pinned value visible even if it is no longer in the fetched list.
+  if (current && !options.some((option) => option.value === current)) {
+    options.push({ value: current, label: current });
+  }
+  return options;
 };
 
 const PostProcessingSettingsPromptsComponent: React.FC = () => {

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,6 +1,10 @@
 import { useEffect } from "react";
 import { useSettingsStore } from "../stores/settingsStore";
-import type { AppSettings as Settings, AudioDevice } from "@/bindings";
+import type {
+  AppSettings as Settings,
+  AudioDevice,
+  OpenRouterEndpoint,
+} from "@/bindings";
 
 interface UseSettingsReturn {
   // State
@@ -41,6 +45,16 @@ interface UseSettingsReturn {
   ) => Promise<void>;
   updatePostProcessModel: (providerId: string, model: string) => Promise<void>;
   fetchPostProcessModels: (providerId: string) => Promise<string[]>;
+  upstreamProviderOptions: Record<string, OpenRouterEndpoint[]>;
+  fetchUpstreamProviders: (
+    providerId: string,
+    model: string,
+  ) => Promise<OpenRouterEndpoint[]>;
+  updateUpstreamProvider: (
+    providerId: string,
+    model: string,
+    providerSlug: string,
+  ) => Promise<void>;
 }
 
 export const useSettings = (): UseSettingsReturn => {
@@ -74,5 +88,8 @@ export const useSettings = (): UseSettingsReturn => {
     updatePostProcessApiKey: store.updatePostProcessApiKey,
     updatePostProcessModel: store.updatePostProcessModel,
     fetchPostProcessModels: store.fetchPostProcessModels,
+    upstreamProviderOptions: store.upstreamProviderOptions,
+    fetchUpstreamProviders: store.fetchUpstreamProviders,
+    updateUpstreamProvider: store.updateUpstreamProvider,
   };
 };

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -412,6 +412,20 @@
           "placeholderWithOptions": "Search or select a model",
           "placeholderNoOptions": "Type a model name",
           "refreshModels": "Refresh models"
+        },
+        "upstreamProvider": {
+          "title": "Upstream Provider",
+          "description": "Choose how OpenRouter routes this model. Automatic balances by price; the speed and price strategies send each request to whichever provider currently leads on that metric. Pinning a specific provider (for example Google AI Studio for Gemini) disables fallbacks so every request reaches the same provider and reuses its prompt cache, which lowers cost.",
+          "auto": "Automatic (OpenRouter balances by price)",
+          "sort": {
+            "throughput": "Fastest generation (highest tokens/s)",
+            "latency": "Lowest latency (fastest first token)",
+            "price": "Cheapest provider"
+          },
+          "cached": "cached",
+          "degraded": "degraded",
+          "noStructuredOutput": "no structured output",
+          "refresh": "Refresh providers"
         }
       },
       "prompts": {

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -423,6 +423,7 @@
             "price": "Cheapest provider"
           },
           "cached": "cached",
+          "free": "free",
           "degraded": "degraded",
           "noStructuredOutput": "no structured output",
           "refresh": "Refresh providers"

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -422,7 +422,7 @@
             "latency": "Lowest latency (fastest first token)",
             "price": "Cheapest provider"
           },
-          "cached": "cached",
+          "cached": "cache",
           "free": "free",
           "degraded": "degraded",
           "noStructuredOutput": "no structured output",

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -4,6 +4,7 @@ import { listen } from "@tauri-apps/api/event";
 import type {
   AppSettings as Settings,
   AudioDevice,
+  OpenRouterEndpoint,
   TranscribeAcceleratorSetting,
   OrtAcceleratorSetting,
 } from "@/bindings";
@@ -53,6 +54,17 @@ interface SettingsStore {
   updatePostProcessModel: (providerId: string, model: string) => Promise<void>;
   fetchPostProcessModels: (providerId: string) => Promise<string[]>;
   setPostProcessModelOptions: (providerId: string, models: string[]) => void;
+  /** Upstream providers keyed by `${providerId}:${model}`, filled by fetchUpstreamProviders */
+  upstreamProviderOptions: Record<string, OpenRouterEndpoint[]>;
+  fetchUpstreamProviders: (
+    providerId: string,
+    model: string,
+  ) => Promise<OpenRouterEndpoint[]>;
+  updateUpstreamProvider: (
+    providerId: string,
+    model: string,
+    providerSlug: string,
+  ) => Promise<void>;
 
   // Internal state setters
   setSettings: (settings: Settings | null) => void;
@@ -71,6 +83,28 @@ const DEFAULT_AUDIO_DEVICE: AudioDevice = {
   index: "default",
   name: "Default",
   is_default: true,
+};
+
+/** Store key for per-(provider, model) upstream provider state. */
+export const upstreamKey = (providerId: string, model: string) =>
+  `${providerId}:${model}`;
+
+/** Run `work` with the `isUpdating(key)` flag set, swallowing thrown errors. */
+const withUpdating = async <T>(
+  get: () => SettingsStore,
+  key: string,
+  work: () => Promise<T>,
+): Promise<T | undefined> => {
+  const { setUpdating } = get();
+  setUpdating(key, true);
+  try {
+    return await work();
+  } catch (error) {
+    console.error(`Failed while updating ${key}:`, error);
+    return undefined;
+  } finally {
+    setUpdating(key, false);
+  }
 };
 
 const settingUpdaters: {
@@ -188,6 +222,7 @@ export const useSettingsStore = create<SettingsStore>()(
     outputDevices: [],
     customSounds: { start: false, stop: false },
     postProcessModelOptions: {},
+    upstreamProviderOptions: {},
 
     // Internal setters
     setSettings: (settings) => set({ settings }),
@@ -569,6 +604,50 @@ export const useSettingsStore = create<SettingsStore>()(
       } finally {
         setUpdating(updateKey, false);
       }
+    },
+
+    fetchUpstreamProviders: async (providerId, model) => {
+      const key = upstreamKey(providerId, model);
+      const data = await withUpdating(
+        get,
+        `upstream_providers_fetch:${key}`,
+        async () => {
+          const result = await commands.fetchPostProcessUpstreamProviders(
+            providerId,
+            model,
+          );
+          if (result.status === "error") {
+            console.error("Failed to fetch upstream providers:", result.error);
+          }
+          // Cache an empty list on failure so the auto-load effect doesn't
+          // retry on every render; the refresh button re-fetches explicitly.
+          const data = result.status === "ok" ? result.data : [];
+          set((state) => ({
+            upstreamProviderOptions: {
+              ...state.upstreamProviderOptions,
+              [key]: data,
+            },
+          }));
+          return data;
+        },
+      );
+      return data ?? [];
+    },
+
+    updateUpstreamProvider: async (providerId, model, providerSlug) => {
+      const key = upstreamKey(providerId, model);
+      await withUpdating(get, `upstream_provider:${key}`, async () => {
+        const result = await commands.changePostProcessUpstreamProviderSetting(
+          providerId,
+          model,
+          providerSlug,
+        );
+        if (result.status === "error") {
+          console.error("Failed to update upstream provider:", result.error);
+          return;
+        }
+        await get().refreshSettings();
+      });
     },
 
     setPostProcessModelOptions: (providerId, models) =>


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

I use OpenRouter for post-processing and noticed that the same model can get routed to different providers each time, so speed and cost are not consistent. I wanted to be able to say "for Gemini, always use Google AI Studio" or just pick the fastest provider, and also keep hitting the same provider so the prompt cache actually gets reused. OpenRouter already supports all of this, Handy just didn't expose it.

### What this adds

An "Upstream Provider" dropdown under Model, only visible for OpenRouter. Options:

- Automatic: same as today
- Fastest generation / lowest latency / cheapest: `provider.sort`, with `require_parameters` so only upstreams that accept our fields are considered
- A specific upstream (including flex/priority tiers): `provider.order` with `allow_fallbacks: false`, so every request hits the same one and reuses its prompt cache

The list comes from `/models/{id}/endpoints` and shows prices and cache read price per upstream, with a warning if one is degraded or lacks structured output.

The system prompt also gets a `cache_control` breakpoint on OpenRouter so Anthropic-style upstreams cache it. Most upstreams need a 1k+ token prefix before caching kicks in, so this mainly helps with long custom prompts.

### Implementation

- `supports_provider_routing` flag on `PostProcessProvider`, same pattern as `supports_structured_output`. No `"openrouter"` checks outside the provider defaults.
- New setting `post_process_upstream_providers` (provider -> model -> slug), defaults to empty. Old settings files load as-is.
- Shared `get_json` and `resolve_provider_and_key` helpers, used by both model fetching and the new endpoint fetch.
- Tests for the routing object, cache breakpoint and endpoint parsing. clippy/lint/format clean.

## Related Issues/Discussions

None

## Community Feedback

None gathered yet. This doesn't add a provider, it exposes routing options of the OpenRouter provider that's already built in, so I'm treating it as completing that integration rather than a new feature. Happy to open a discussion if you'd prefer that first.

## Testing

Manual, macOS Apple Silicon, OpenRouter key:

- gemini flash: ran Automatic, "Fastest generation", and pinned to google-ai-studio and vertex flex. Checked in the OpenRouter activity page that the right upstream served each one.
- Switching models loads the right list, refresh works, missing key doesn't loop.
- Other providers: dropdown hidden, requests unchanged.

## Screenshots/Videos (if applicable)

<img width="950" height="834" alt="Screenshot 2026-08-22 at 18 29 06" src="https://github.com/user-attachments/assets/0b9bf09e-94d5-46f8-b951-3db3eb106e2a" />

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: wrote most of the code, I directed it, reviewed and tested.
