### PR TITLE
fix(history): remove stale recordings from frontend after retention cleanup

### DIFF
--- a/src-tauri/src/managers/history.rs
+++ b/src-tauri/src/managers/history.rs
@@ -338,56 +338,85 @@ impl HistoryManager {
             crate::settings::RecordingRetentionPeriod::PreserveLimit => {
                 // Use the old count-based logic with history_limit
                 let limit = crate::settings::get_history_limit(&self.app_handle);
-                self.cleanup_by_count(limit)
+                self.cleanup_by_count(limit)?;
+                Ok(())
             }
             _ => {
                 // Use time-based logic
-                self.cleanup_by_time(retention_period)
+                self.cleanup_by_time(retention_period)?;
+                Ok(())
             }
         }
     }
 
     fn delete_entries_and_files(&self, entries: &[(i64, String)]) -> Result<usize> {
+        let conn = self.get_connection()?;
+        Self::delete_entries_and_files_with_conn(
+            &conn,
+            &self.recordings_dir,
+            entries,
+            Some(&self.app_handle),
+        )
+    }
+
+    fn delete_entries_and_files_with_conn(
+        conn: &Connection,
+        recordings_dir: &std::path::Path,
+        entries: &[(i64, String)],
+        app_handle: Option<&AppHandle>,
+    ) -> Result<usize> {
         if entries.is_empty() {
             return Ok(0);
         }
 
-        let conn = self.get_connection()?;
         let mut deleted_count = 0;
 
         for (id, file_name) in entries {
             // Delete database entry
-            conn.execute(
+            let deleted = conn.execute(
                 "DELETE FROM transcription_history WHERE id = ?1",
                 params![id],
             )?;
 
-            // Delete WAV file
-            let file_path = self.recordings_dir.join(file_name);
-            if file_path.exists() {
-                if let Err(e) = fs::remove_file(&file_path) {
-                    error!("Failed to delete WAV file {}: {}", file_name, e);
-                } else {
-                    debug!("Deleted old WAV file: {}", file_name);
-                    deleted_count += 1;
-                }
-            }
+            if deleted > 0 {
+                deleted_count += deleted;
 
-            // Emit history updated event
-            if let Err(e) = (HistoryUpdatePayload::Deleted { id: *id }).emit(&self.app_handle) {
-                error!("Failed to emit history-updated event: {}", e);
+                // Delete WAV file
+                let file_path = recordings_dir.join(file_name);
+                if file_path.exists() {
+                    if let Err(e) = fs::remove_file(&file_path) {
+                        error!("Failed to delete WAV file {}: {}", file_name, e);
+                    } else {
+                        debug!("Deleted old WAV file: {}", file_name);
+                    }
+                }
+
+                // Emit history updated event
+                if let Some(app) = app_handle {
+                    if let Err(e) = (HistoryUpdatePayload::Deleted { id: *id }).emit(app) {
+                        error!("Failed to emit history-updated event: {}", e);
+                    }
+                }
             }
         }
 
         Ok(deleted_count)
     }
 
-    fn cleanup_by_count(&self, limit: usize) -> Result<()> {
+    fn cleanup_by_count(&self, limit: usize) -> Result<usize> {
         let conn = self.get_connection()?;
+        Self::cleanup_by_count_with_conn(&conn, &self.recordings_dir, limit, Some(&self.app_handle))
+    }
 
+    fn cleanup_by_count_with_conn(
+        conn: &Connection,
+        recordings_dir: &std::path::Path,
+        limit: usize,
+        app_handle: Option<&AppHandle>,
+    ) -> Result<usize> {
         // Get all entries that are not saved, ordered by timestamp desc
         let mut stmt = conn.prepare(
-            "SELECT id, file_name FROM transcription_history WHERE saved = 0 ORDER BY timestamp DESC"
+            "SELECT id, file_name FROM transcription_history WHERE saved = 0 ORDER BY timestamp DESC",
         )?;
 
         let rows = stmt.query_map([], |row| {
@@ -401,22 +430,41 @@ impl HistoryManager {
 
         if entries.len() > limit {
             let entries_to_delete = &entries[limit..];
-            let deleted_count = self.delete_entries_and_files(entries_to_delete)?;
+            let deleted_count = Self::delete_entries_and_files_with_conn(
+                conn,
+                recordings_dir,
+                entries_to_delete,
+                app_handle,
+            )?;
 
             if deleted_count > 0 {
                 debug!("Cleaned up {} old history entries by count", deleted_count);
             }
+            Ok(deleted_count)
+        } else {
+            Ok(0)
         }
-
-        Ok(())
     }
 
     fn cleanup_by_time(
         &self,
         retention_period: crate::settings::RecordingRetentionPeriod,
-    ) -> Result<()> {
+    ) -> Result<usize> {
         let conn = self.get_connection()?;
+        Self::cleanup_by_time_with_conn(
+            &conn,
+            &self.recordings_dir,
+            retention_period,
+            Some(&self.app_handle),
+        )
+    }
 
+    fn cleanup_by_time_with_conn(
+        conn: &Connection,
+        recordings_dir: &std::path::Path,
+        retention_period: crate::settings::RecordingRetentionPeriod,
+        app_handle: Option<&AppHandle>,
+    ) -> Result<usize> {
         // Calculate cutoff timestamp (current time minus retention period)
         let now = Utc::now().timestamp();
         let cutoff_timestamp = match retention_period {
@@ -440,7 +488,12 @@ impl HistoryManager {
             entries_to_delete.push(row?);
         }
 
-        let deleted_count = self.delete_entries_and_files(&entries_to_delete)?;
+        let deleted_count = Self::delete_entries_and_files_with_conn(
+            conn,
+            recordings_dir,
+            &entries_to_delete,
+            app_handle,
+        )?;
 
         if deleted_count > 0 {
             debug!(
@@ -449,7 +502,7 @@ impl HistoryManager {
             );
         }
 
-        Ok(())
+        Ok(deleted_count)
     }
 
     pub async fn get_history_entries(
@@ -738,5 +791,127 @@ mod tests {
 
         assert_eq!(entry.timestamp, 100);
         assert_eq!(entry.transcription_text, "completed");
+    }
+
+    #[test]
+    fn cleanup_by_count_removes_oldest_db_entries_and_files() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let conn = setup_conn();
+
+        // Create 6 recordings in DB and on disk
+        for ts in [100, 200, 300, 400, 500, 600] {
+            insert_entry(&conn, ts, &format!("recording {}", ts), None);
+            let file_path = temp_dir.path().join(format!("handy-{}.wav", ts));
+            fs::write(&file_path, b"dummy audio content").expect("write dummy audio file");
+            assert!(file_path.exists());
+        }
+
+        // Run count cleanup with limit = 5
+        let deleted = HistoryManager::cleanup_by_count_with_conn(&conn, temp_dir.path(), 5, None)
+            .expect("cleanup by count");
+
+        assert_eq!(deleted, 1);
+
+        // Check remaining database entries
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM transcription_history", [], |r| {
+                r.get(0)
+            })
+            .expect("count rows");
+        assert_eq!(count, 5);
+
+        // Oldest entry (timestamp 100) must be deleted from DB
+        let oldest_in_db: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM transcription_history WHERE timestamp = 100",
+                [],
+                |r| r.get(0),
+            )
+            .expect("check oldest");
+        assert!(!oldest_in_db);
+
+        // Oldest file must be deleted from disk
+        assert!(!temp_dir.path().join("handy-100.wav").exists());
+
+        // Newer 5 files must still exist on disk
+        for ts in [200, 300, 400, 500, 600] {
+            assert!(temp_dir.path().join(format!("handy-{}.wav", ts)).exists());
+        }
+    }
+
+    #[test]
+    fn cleanup_by_count_preserves_saved_entries() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let conn = setup_conn();
+
+        // Insert 6 entries, oldest is saved
+        for ts in [100, 200, 300, 400, 500, 600] {
+            let saved = ts == 100;
+            conn.execute(
+                "INSERT INTO transcription_history (
+                    file_name, timestamp, saved, title, transcription_text,
+                    post_processed_text, post_process_prompt, post_process_requested
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                params![
+                    format!("handy-{}.wav", ts),
+                    ts,
+                    saved,
+                    format!("Recording {}", ts),
+                    "text",
+                    Option::<String>::None,
+                    Option::<String>::None,
+                    false,
+                ],
+            )
+            .expect("insert history entry");
+            let file_path = temp_dir.path().join(format!("handy-{}.wav", ts));
+            fs::write(&file_path, b"audio").expect("write file");
+        }
+
+        // Unsaved entries count = 5 (timestamps 200..600). With limit = 5, none should be deleted.
+        let deleted = HistoryManager::cleanup_by_count_with_conn(&conn, temp_dir.path(), 5, None)
+            .expect("cleanup by count");
+
+        assert_eq!(deleted, 0);
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM transcription_history", [], |r| {
+                r.get(0)
+            })
+            .expect("count rows");
+        assert_eq!(count, 6);
+    }
+
+    #[test]
+    fn delete_entries_and_files_counts_db_deletions_even_when_files_missing() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let conn = setup_conn();
+
+        insert_entry(&conn, 100, "entry 1", None);
+        insert_entry(&conn, 200, "entry 2", None);
+
+        // Files are intentionally NOT created on disk in temp_dir
+
+        let entries = vec![
+            (1i64, "handy-100.wav".to_string()),
+            (2i64, "handy-200.wav".to_string()),
+        ];
+
+        let deleted = HistoryManager::delete_entries_and_files_with_conn(
+            &conn,
+            temp_dir.path(),
+            &entries,
+            None,
+        )
+        .expect("delete entries");
+
+        assert_eq!(deleted, 2);
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM transcription_history", [], |r| {
+                r.get(0)
+            })
+            .expect("count rows");
+        assert_eq!(count, 0);
     }
 }

--- a/src-tauri/src/managers/history.rs
+++ b/src-tauri/src/managers/history.rs
@@ -39,7 +39,7 @@ pub struct PaginatedHistory {
     pub has_more: bool,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Type, tauri_specta::Event)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Type, tauri_specta::Event)]
 #[serde(tag = "action")]
 pub enum HistoryUpdatePayload {
     #[serde(rename = "added")]
@@ -52,7 +52,7 @@ pub enum HistoryUpdatePayload {
     Toggled { id: i64 },
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Type)]
 pub struct HistoryEntry {
     pub id: i64,
     pub file_name: String,
@@ -351,20 +351,22 @@ impl HistoryManager {
 
     fn delete_entries_and_files(&self, entries: &[(i64, String)]) -> Result<usize> {
         let conn = self.get_connection()?;
-        Self::delete_entries_and_files_with_conn(
-            &conn,
-            &self.recordings_dir,
-            entries,
-            Some(&self.app_handle),
-        )
+        Self::delete_entries_and_files_with_conn(&conn, &self.recordings_dir, entries, |payload| {
+            if let Err(e) = payload.emit(&self.app_handle) {
+                error!("Failed to emit history-updated event: {}", e);
+            }
+        })
     }
 
-    fn delete_entries_and_files_with_conn(
+    fn delete_entries_and_files_with_conn<F>(
         conn: &Connection,
         recordings_dir: &std::path::Path,
         entries: &[(i64, String)],
-        app_handle: Option<&AppHandle>,
-    ) -> Result<usize> {
+        mut on_event: F,
+    ) -> Result<usize>
+    where
+        F: FnMut(HistoryUpdatePayload),
+    {
         if entries.is_empty() {
             return Ok(0);
         }
@@ -392,11 +394,7 @@ impl HistoryManager {
                 }
 
                 // Emit history updated event
-                if let Some(app) = app_handle {
-                    if let Err(e) = (HistoryUpdatePayload::Deleted { id: *id }).emit(app) {
-                        error!("Failed to emit history-updated event: {}", e);
-                    }
-                }
+                on_event(HistoryUpdatePayload::Deleted { id: *id });
             }
         }
 
@@ -405,15 +403,22 @@ impl HistoryManager {
 
     fn cleanup_by_count(&self, limit: usize) -> Result<usize> {
         let conn = self.get_connection()?;
-        Self::cleanup_by_count_with_conn(&conn, &self.recordings_dir, limit, Some(&self.app_handle))
+        Self::cleanup_by_count_with_conn(&conn, &self.recordings_dir, limit, |payload| {
+            if let Err(e) = payload.emit(&self.app_handle) {
+                error!("Failed to emit history-updated event: {}", e);
+            }
+        })
     }
 
-    fn cleanup_by_count_with_conn(
+    fn cleanup_by_count_with_conn<F>(
         conn: &Connection,
         recordings_dir: &std::path::Path,
         limit: usize,
-        app_handle: Option<&AppHandle>,
-    ) -> Result<usize> {
+        mut on_event: F,
+    ) -> Result<usize>
+    where
+        F: FnMut(HistoryUpdatePayload),
+    {
         // Get all entries that are not saved, ordered by timestamp desc
         let mut stmt = conn.prepare(
             "SELECT id, file_name FROM transcription_history WHERE saved = 0 ORDER BY timestamp DESC",
@@ -434,7 +439,7 @@ impl HistoryManager {
                 conn,
                 recordings_dir,
                 entries_to_delete,
-                app_handle,
+                &mut on_event,
             )?;
 
             if deleted_count > 0 {
@@ -451,20 +456,22 @@ impl HistoryManager {
         retention_period: crate::settings::RecordingRetentionPeriod,
     ) -> Result<usize> {
         let conn = self.get_connection()?;
-        Self::cleanup_by_time_with_conn(
-            &conn,
-            &self.recordings_dir,
-            retention_period,
-            Some(&self.app_handle),
-        )
+        Self::cleanup_by_time_with_conn(&conn, &self.recordings_dir, retention_period, |payload| {
+            if let Err(e) = payload.emit(&self.app_handle) {
+                error!("Failed to emit history-updated event: {}", e);
+            }
+        })
     }
 
-    fn cleanup_by_time_with_conn(
+    fn cleanup_by_time_with_conn<F>(
         conn: &Connection,
         recordings_dir: &std::path::Path,
         retention_period: crate::settings::RecordingRetentionPeriod,
-        app_handle: Option<&AppHandle>,
-    ) -> Result<usize> {
+        mut on_event: F,
+    ) -> Result<usize>
+    where
+        F: FnMut(HistoryUpdatePayload),
+    {
         // Calculate cutoff timestamp (current time minus retention period)
         let now = Utc::now().timestamp();
         let cutoff_timestamp = match retention_period {
@@ -492,7 +499,7 @@ impl HistoryManager {
             conn,
             recordings_dir,
             &entries_to_delete,
-            app_handle,
+            &mut on_event,
         )?;
 
         if deleted_count > 0 {
@@ -794,11 +801,11 @@ mod tests {
     }
 
     #[test]
-    fn cleanup_by_count_removes_oldest_db_entries_and_files() {
+    fn cleanup_by_count_removes_oldest_db_entries_and_files_and_emits_deleted_event() {
         let temp_dir = tempfile::tempdir().expect("create temp dir");
         let conn = setup_conn();
 
-        // Create 6 recordings in DB and on disk
+        // Create 6 recordings in DB and on disk (timestamps 100..600 -> IDs 1..6)
         for ts in [100, 200, 300, 400, 500, 600] {
             insert_entry(&conn, ts, &format!("recording {}", ts), None);
             let file_path = temp_dir.path().join(format!("handy-{}.wav", ts));
@@ -806,11 +813,20 @@ mod tests {
             assert!(file_path.exists());
         }
 
+        let mut emitted_events = Vec::new();
+
         // Run count cleanup with limit = 5
-        let deleted = HistoryManager::cleanup_by_count_with_conn(&conn, temp_dir.path(), 5, None)
+        let deleted =
+            HistoryManager::cleanup_by_count_with_conn(&conn, temp_dir.path(), 5, |event| {
+                emitted_events.push(event)
+            })
             .expect("cleanup by count");
 
         assert_eq!(deleted, 1);
+
+        // Verify exactly 1 Deleted event was emitted for the oldest entry (ID 1, timestamp 100)
+        assert_eq!(emitted_events.len(), 1);
+        assert_eq!(emitted_events[0], HistoryUpdatePayload::Deleted { id: 1 });
 
         // Check remaining database entries
         let count: i64 = conn
@@ -868,11 +884,17 @@ mod tests {
             fs::write(&file_path, b"audio").expect("write file");
         }
 
+        let mut emitted_events = Vec::new();
+
         // Unsaved entries count = 5 (timestamps 200..600). With limit = 5, none should be deleted.
-        let deleted = HistoryManager::cleanup_by_count_with_conn(&conn, temp_dir.path(), 5, None)
+        let deleted =
+            HistoryManager::cleanup_by_count_with_conn(&conn, temp_dir.path(), 5, |event| {
+                emitted_events.push(event)
+            })
             .expect("cleanup by count");
 
         assert_eq!(deleted, 0);
+        assert!(emitted_events.is_empty());
 
         let count: i64 = conn
             .query_row("SELECT COUNT(*) FROM transcription_history", [], |r| {
@@ -897,15 +919,24 @@ mod tests {
             (2i64, "handy-200.wav".to_string()),
         ];
 
+        let mut emitted_events = Vec::new();
+
         let deleted = HistoryManager::delete_entries_and_files_with_conn(
             &conn,
             temp_dir.path(),
             &entries,
-            None,
+            |event| emitted_events.push(event),
         )
         .expect("delete entries");
 
         assert_eq!(deleted, 2);
+        assert_eq!(
+            emitted_events,
+            vec![
+                HistoryUpdatePayload::Deleted { id: 1 },
+                HistoryUpdatePayload::Deleted { id: 2 },
+            ]
+        );
 
         let count: i64 = conn
             .query_row("SELECT COUNT(*) FROM transcription_history", [], |r| {

--- a/src-tauri/src/managers/history.rs
+++ b/src-tauri/src/managers/history.rs
@@ -372,6 +372,11 @@ impl HistoryManager {
                     deleted_count += 1;
                 }
             }
+
+            // Emit history updated event
+            if let Err(e) = (HistoryUpdatePayload::Deleted { id: *id }).emit(&self.app_handle) {
+                error!("Failed to emit history-updated event: {}", e);
+            }
         }
 
         Ok(deleted_count)

--- a/src-tauri/src/managers/history.rs
+++ b/src-tauri/src/managers/history.rs
@@ -349,15 +349,6 @@ impl HistoryManager {
         }
     }
 
-    fn delete_entries_and_files(&self, entries: &[(i64, String)]) -> Result<usize> {
-        let conn = self.get_connection()?;
-        Self::delete_entries_and_files_with_conn(&conn, &self.recordings_dir, entries, |payload| {
-            if let Err(e) = payload.emit(&self.app_handle) {
-                error!("Failed to emit history-updated event: {}", e);
-            }
-        })
-    }
-
     fn delete_entries_and_files_with_conn<F>(
         conn: &Connection,
         recordings_dir: &std::path::Path,

--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -140,9 +140,11 @@ export const HistorySettings: React.FC = () => {
         setEntries((prev) =>
           prev.map((e) => (e.id === payload.entry.id ? payload.entry : e)),
         );
+      } else if (payload.action === "deleted") {
+        setEntries((prev) => prev.filter((e) => e.id !== payload.id));
       }
-      // "deleted" and "toggled" are handled by optimistic updates only,
-      // so we intentionally ignore them here to avoid double-mutation.
+      // "toggled" is handled by optimistic updates only,
+      // so we intentionally ignore it here to avoid double-mutation.
     });
 
     return () => {


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched existing issues and pull requests (including closed ones) to ensure this isn't a duplicate
- [x] I have read CONTRIBUTING.md

## Human Written Description

When testing Handy's history retention limit, I noticed that recordings were correctly removed from the database and from disk, but could remain visible in the History UI. This could leave a stale history entry pointing to an audio file that no longer existed, so clicking it would fail to play the recording. This PR fixes that by notifying the frontend when retention cleanup removes a recording, and makes the cleanup correctly count database deletions even when the audio file is already missing.

## Related Issues/Discussions

Fixes #
Discussion:

## Community Feedback
.

## Testing

- Added Rust regression tests covering history cleanup and database deletion behavior.
- Added a test verifying that the `Deleted` history event is emitted for recordings removed by retention cleanup.
- Tested the application locally with a history limit of 5 recordings.
- Created recordings beyond the limit and confirmed that the oldest recording is immediately removed from the History UI.
- Confirmed that the remaining recordings can still be played.
- Tested that saved recordings are preserved by the history limit.
- Ran the Rust test suite locally.

## Screenshots/Videos (if applicable)

Not applicable.
## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: ChatGPT
- How extensively: Used for code investigation, debugging, test suggestions, and review of the implementation. The bug was reproduced and the final behavior was manually tested locally.