### PR TITLE
fix(macos): restore original app focus before pasting (#1995)

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -470,6 +470,15 @@ impl ShortcutAction for TranscribeAction {
         let start_time = Instant::now();
         debug!("TranscribeAction::start called for binding: {}", binding_id);
 
+        // Remember whichever application is frontmost right now, so the
+        // eventual paste can return to it even if the user clicks elsewhere
+        // (Handy's own window, another app, ...) while still dictating
+        // (#1995). Dispatched to the main thread since querying the
+        // frontmost application is an AppKit call.
+        if let Err(e) = app.run_on_main_thread(crate::focus_restore::capture) {
+            debug!("focus_restore: failed to dispatch capture to main thread: {e:?}");
+        }
+
         // Load model in the background
         let tm = app.state::<Arc<TranscriptionManager>>();
         let rm = app.state::<Arc<AudioRecordingManager>>();

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -1,3 +1,4 @@
+use crate::focus_restore;
 use crate::input::{self, EnigoState};
 #[cfg(target_os = "linux")]
 use crate::settings::TypingTool;
@@ -788,6 +789,15 @@ pub fn paste(text: String, app_handle: AppHandle) -> Result<(), String> {
         "Using paste method: {:?}, delay before: {}ms, delay after: {}ms",
         paste_method, paste_delay_ms, paste_delay_after_ms
     );
+
+    // Return focus to whichever application was frontmost when this
+    // recording started, if it isn't anymore (#1995). Skipped for
+    // PasteMethod::None: nothing is about to be typed, so there is nothing
+    // to redirect and stealing focus back would be a pure, unwanted
+    // side effect for users who deliberately disabled auto-paste.
+    if paste_method != PasteMethod::None {
+        focus_restore::restore();
+    }
 
     // Perform the paste operation
     match paste_method {

--- a/src-tauri/src/focus_restore.rs
+++ b/src-tauri/src/focus_restore.rs
@@ -1,0 +1,161 @@
+//! Restores focus to the application that was frontmost when a dictation
+//! recording started, so the transcript lands in the field the user was
+//! actually dictating into — not wherever focus happens to be when the
+//! hotkey is released (#1995).
+//!
+//! Recording is driven by a global keyboard shortcut and keeps capturing
+//! audio no matter which window has focus, so nothing about the audio
+//! itself is lost when the user clicks around mid-dictation (into Handy's
+//! own window, another app, the taskbar, ...). But the eventual paste is
+//! just a simulated keystroke (or direct-typed text) sent to whichever
+//! application happens to be frontmost at that moment — there was
+//! previously no notion of a "target" application at all. Any focus change
+//! mid-dictation therefore silently redirects the transcript, which reads
+//! to the user as if the whole dictation buffer was discarded.
+//!
+//! [`capture`] records the frontmost application right when a recording
+//! starts; [`restore`] reactivates it immediately before the paste is
+//! injected, if focus has since moved elsewhere. Both are no-ops when
+//! nothing was captured or focus never left the original application, so
+//! this only ever changes behavior in exactly the broken case described in
+//! #1995.
+//!
+//! macOS only for now — reactivating an application windowed elsewhere
+//! needs platform-specific APIs (`NSWorkspace`/`NSRunningApplication`
+//! here). Windows/Linux keep the pre-existing behavior (paste goes to
+//! whatever has focus at release time) rather than ship unverified platform
+//! code; see `paste_tx` for the same per-platform-module precedent this
+//! follows.
+
+/// Pure decision: given the pid captured at recording start and whichever
+/// pid is frontmost right now, does the captured application need to be
+/// reactivated? Kept outside the `cfg(target_os = "macos")` module (like
+/// `paste_tx::evaluate`) so this logic is unit-tested on every platform,
+/// independent of whether the AppKit-calling implementation below is wired
+/// up for that platform yet.
+fn needs_reactivation(original_pid: i32, current_pid: Option<i32>) -> bool {
+    current_pid != Some(original_pid)
+}
+
+#[cfg(target_os = "macos")]
+mod imp {
+    use super::needs_reactivation;
+    use log::debug;
+    use objc2_app_kit::{NSApplicationActivationOptions, NSRunningApplication, NSWorkspace};
+    use std::sync::Mutex;
+
+    /// The frontmost application's pid at the moment the current recording
+    /// started. `None` means either no recording has started yet or there
+    /// was no frontmost application to capture.
+    ///
+    /// A single slot is enough: only one recording is ever active at a
+    /// time, and every `capture()` overwrites whatever a previous
+    /// recording left behind before it could matter again.
+    static ORIGINAL_FRONTMOST_PID: Mutex<Option<i32>> = Mutex::new(None);
+
+    fn frontmost_pid() -> Option<i32> {
+        NSWorkspace::sharedWorkspace()
+            .frontmostApplication()
+            .map(|app| app.processIdentifier())
+    }
+
+    /// Records the currently frontmost application so [`restore`] can
+    /// reactivate it later. Call once, as close to recording start as
+    /// possible. Must run on the main thread (AppKit requirement).
+    pub fn capture() {
+        let pid = frontmost_pid();
+        match pid {
+            Some(pid) => debug!("focus_restore: captured frontmost application (pid {pid})"),
+            None => debug!("focus_restore: no frontmost application to capture"),
+        }
+        *ORIGINAL_FRONTMOST_PID.lock().unwrap() = pid;
+    }
+
+    /// Reactivates the application captured by [`capture`], if it is no
+    /// longer frontmost. Must run on the main thread (AppKit requirement) —
+    /// call this immediately before the paste keystroke is injected.
+    ///
+    /// Best-effort by design: any failure (the app already quit, activation
+    /// was refused, ...) just leaves the paste going wherever focus
+    /// currently is, which is the same behavior as before this module
+    /// existed. Restoring focus must never block or fail the paste itself.
+    pub fn restore() {
+        let Some(original_pid) = *ORIGINAL_FRONTMOST_PID.lock().unwrap() else {
+            return;
+        };
+
+        if !needs_reactivation(original_pid, frontmost_pid()) {
+            // Focus never left (or has already returned to) the original
+            // application — nothing to do.
+            return;
+        }
+
+        let Some(app) = NSRunningApplication::runningApplicationWithProcessIdentifier(original_pid)
+        else {
+            debug!(
+                "focus_restore: originally frontmost application (pid {original_pid}) is no longer running"
+            );
+            return;
+        };
+
+        // No options: macOS 14+ made plain activation always take over from
+        // whatever else is frontmost (the same effect `ActivateIgnoringOtherApps`
+        // used to provide explicitly — that flag is now deprecated and a no-op).
+        if app.activateWithOptions(NSApplicationActivationOptions::empty()) {
+            debug!(
+                "focus_restore: reactivated originally frontmost application (pid {original_pid})"
+            );
+            // activateWithOptions only requests activation — AppKit doesn't
+            // guarantee (or even necessarily complete) the switch by the time
+            // it returns. A short settle delay gives the window server a
+            // chance to actually hand focus over before the paste keystroke
+            // is injected right after this call returns.
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        } else {
+            debug!(
+                "focus_restore: failed to reactivate originally frontmost application (pid {original_pid})"
+            );
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+mod imp {
+    // Not implemented on Windows/Linux yet — recording and pasting behave
+    // exactly as they did before this module existed. See the module docs
+    // above for why this is scoped to macOS for now.
+    pub fn capture() {}
+    pub fn restore() {}
+}
+
+/// Records the currently frontmost application so it can be restored before
+/// the transcript is pasted. Call once, at the start of a recording.
+pub fn capture() {
+    imp::capture();
+}
+
+/// Reactivates the application captured by [`capture`], if focus has since
+/// moved elsewhere. Call immediately before injecting the paste.
+pub fn restore() {
+    imp::restore();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::needs_reactivation;
+
+    #[test]
+    fn no_reactivation_needed_when_still_frontmost() {
+        assert!(!needs_reactivation(123, Some(123)));
+    }
+
+    #[test]
+    fn reactivation_needed_when_a_different_app_is_frontmost() {
+        assert!(needs_reactivation(123, Some(456)));
+    }
+
+    #[test]
+    fn reactivation_needed_when_nothing_is_currently_frontmost() {
+        assert!(needs_reactivation(123, None));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod catalog;
 pub mod cli;
 mod clipboard;
 mod commands;
+mod focus_restore;
 mod helpers;
 mod input;
 mod llm_client;


### PR DESCRIPTION
## Before Submitting This PR

**Please submit only one fix or feature per pull request. Pull requests containing multiple fixes or features will likely be closed.**

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

<!-- TODO(victor): please replace this placeholder with 2-3 sentences in your own words. Claude Code left this as a placeholder per AGENTS.md's instruction not to invent a human contributor's voice for this section. -->

## Related Issues/Discussions

Fixes #1995

While researching, I found closed PR #1736 included a `focus.rs` module (`save_frontmost_app`/`restore_frontmost_app`) tackling the same underlying problem with the same `NSWorkspace`/`NSRunningApplication` approach, bundled inside a much larger, unrelated multi-feature PR that was closed for scope reasons rather than because that specific mechanism didn't work. This PR extracts and ships just that piece, scoped to #1995.

## Community Feedback

None gathered yet beyond the original bug report. This is filed as a bug fix (not a new feature) restoring correct paste-target behavior, so per CONTRIBUTING.md this doesn't require a Discussion, but I'm glad to open one if the maintainer would prefer it reviewed that way.

## Testing

- `cargo fmt --check`, `cargo check`, and `cargo clippy` all clean on macOS (aarch64) — no warnings from the new code.
- `cargo test --lib` — all 242 tests pass (239 pre-existing + 3 new unit tests for the pure reactivation-decision logic in `focus_restore.rs`).
- Verified the core AppKit mechanism against the real, live desktop session with a small standalone harness using the same `objc2-app-kit` calls (`NSWorkspace::sharedWorkspace().frontmostApplication()`, `NSRunningApplication::runningApplicationWithProcessIdentifier(pid).activateWithOptions(...)`): confirmed it reads the real frontmost application (not sandboxed away from AppKit) and that `activateWithOptions` returns `true` without crashing.
- I was not able to drive a full end-to-end live dictation test (start recording → click away → release hotkey → verify paste lands in the original app) in this environment, since that needs a downloaded Whisper model plus real spoken microphone input that I can't provide programmatically. The change is scoped and low-risk (see below), but a manual click-away repro on a real machine would be a valuable final check before merging.
- Behavior when nothing changes: `capture()`/`restore()` are no-ops whenever focus never left the original application (the overwhelmingly common case), so existing dictation flows are unaffected. `restore()` is also skipped entirely when `PasteMethod::None` is selected, so users who disabled auto-paste never have their focus changed by this.
- Windows/Linux are intentionally left as no-op stubs for now rather than shipping unverified platform-specific code I have no way to build or test here — see the module doc in `focus_restore.rs`.

## Screenshots/Videos (if applicable)

N/A — this is a background focus-tracking fix with no UI surface.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Anthropic)
- How extensively: Claude Code investigated the root cause, designed and implemented the fix (`src-tauri/src/focus_restore.rs` plus the three call-site wiring changes), wrote and ran the unit tests, verified the AppKit mechanism against the live session, and wrote this PR description, under my direction.
