### PR TITLE
fix(history): show copy success only after clipboard write

### DIFF
--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -14,6 +14,7 @@ import { useOsType } from "@/hooks/useOsType";
 import { formatDateTime } from "@/utils/dateFormat";
 import { AudioPlayer, AudioPlayerGroup } from "../../ui/AudioPlayer";
 import { Button } from "../../ui/Button";
+import { copyToClipboard } from "./clipboard";
 
 const IconButton: React.FC<{
   onClick: () => void;
@@ -172,14 +173,6 @@ export const HistorySettings: React.FC = () => {
     }
   };
 
-  const copyToClipboard = async (text: string) => {
-    try {
-      await navigator.clipboard.writeText(text);
-    } catch (error) {
-      console.error("Failed to copy to clipboard:", error);
-    }
-  };
-
   const getAudioUrl = useCallback(
     async (fileName: string) => {
       try {
@@ -297,7 +290,7 @@ export const HistorySettings: React.FC = () => {
 interface HistoryEntryProps {
   entry: HistoryEntry;
   onToggleSaved: () => void;
-  onCopyText: () => void;
+  onCopyText: () => Promise<boolean>;
   getAudioUrl: (fileName: string) => Promise<string | null>;
   deleteAudio: (id: number) => Promise<void>;
   retryTranscription: (id: number) => Promise<void>;
@@ -322,12 +315,16 @@ const HistoryEntryComponent: React.FC<HistoryEntryProps> = ({
     [getAudioUrl, entry.file_name],
   );
 
-  const handleCopyText = () => {
+  const handleCopyText = async () => {
     if (!hasTranscription) {
       return;
     }
 
-    onCopyText();
+    const copied = await onCopyText();
+    if (!copied) {
+      return;
+    }
+
     setShowCopied(true);
     setTimeout(() => setShowCopied(false), 2000);
   };

--- a/src/components/settings/history/clipboard.test.ts
+++ b/src/components/settings/history/clipboard.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { copyToClipboard } from "./clipboard";
+
+const successfulClipboard = {
+  writeText: async () => {},
+};
+
+const failedClipboard = {
+  writeText: async () => {
+    throw new Error("clipboard unavailable");
+  },
+};
+
+assert.equal(await copyToClipboard("copied text", successfulClipboard), true);
+assert.equal(await copyToClipboard("copied text", failedClipboard), false);
+
+console.log("clipboard: all assertions passed");

--- a/src/components/settings/history/clipboard.ts
+++ b/src/components/settings/history/clipboard.ts
@@ -1,0 +1,14 @@
+export type ClipboardWriter = Pick<Clipboard, "writeText">;
+
+export const copyToClipboard = async (
+  text: string,
+  clipboard: ClipboardWriter = navigator.clipboard,
+): Promise<boolean> => {
+  try {
+    await clipboard.writeText(text);
+    return true;
+  } catch (error) {
+    console.error("Failed to copy to clipboard:", error);
+    return false;
+  }
+};


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Human Written Description

When copying a transcription from the History view, Handy showed the “Copied” check icon even when the clipboard write failed. This gave false feedback because the user could believe the transcription was copied when it was not available in the clipboard. The fix makes the success indicator wait for a confirmed clipboard write and adds a regression test for the failure path.

## Related Issues/Discussions

Fixes #2010
Discussion: No separate discussion found. Related clipboard reports were reviewed: #1356, #502, and Discussion #1189.

## Community Feedback

This is a bug fix. Issue #2010 documents the failure mode. No separate community discussion is required.

## Testing

- `bun src/components/settings/history/clipboard.test.ts` — passed the success and failure cases. The failure case emits the expected error log.
- `bun run build` — passed.
- `bun run lint` — passed.
- Prettier and `git diff --check` — passed.

## Screenshots/Videos (if applicable)

Not applicable. This change corrects the copied-state feedback without changing the layout.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: Codex investigated the verified issue, implemented the fix and regression test, and ran the validation checks. The human contributor reviewed the changes and completed the Human Written Description.
