### PR TITLE
Restrict asset protocol scope to recordings directory

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,7 @@
       "assetProtocol": {
         "enable": true,
         "scope": {
-          "allow": ["**"],
+          "allow": ["$APPDATA/recordings/**"],
           "requireLiteralLeadingDot": false
         }
       }


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Human Written Description

<!-- TODO: Brad, please write 2-3 sentences in your own words about why this security fix matters to you -->

## Related Issues/Discussions

Fixes #1384

## Community Feedback

This is a security hardening fix, not a new feature. The issue was filed as a security report and has no competing PRs.

## Testing

- Verified `tauri.conf.json` remains valid JSON after the change.
- Confirmed the only usage of `convertFileSrc()` is in `src/components/settings/history/HistorySettings.tsx` to serve WAV files from `$APPDATA/recordings/`.
- On Linux, history audio already uses `readFile` (fs plugin) instead of `convertFileSrc`, so this change does not affect Linux playback.
- The `fs:scope` in `capabilities/default.json` already restricts filesystem access to `$APPDATA/**`, so this brings the asset protocol in line with the existing fs scope.

**Not yet tested:** Full `bun run tauri dev` build and runtime playback on macOS/Windows (no Rust toolchain on the contributing machine). The change is a single-line config scope restriction, so the risk of behavioral breakage is low, but maintainer verification on a real build is recommended.

## Screenshots/Videos (if applicable)

N/A — configuration change with no visible UI difference.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude (Anthropic)
- How extensively: AI assisted with codebase analysis to confirm `convertFileSrc` usage scope and verify the fix. The one-line change was reviewed by the human contributor.
