### PR TITLE
Quit on window close when --no-tray is set instead of hiding the window

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1020,24 +1020,33 @@ pub fn run(cli_args: CliArgs) {
         })
         .on_window_event(|window, event| match event {
             tauri::WindowEvent::CloseRequested { api, .. } => {
-                api.prevent_close();
-                let _res = window.hide();
+                let no_tray = window.app_handle().state::<CliArgs>().no_tray;
 
-                #[cfg(target_os = "macos")]
-                {
-                    let settings = get_settings(window.app_handle());
-                    let tray_visible =
-                        settings.show_tray_icon && !window.app_handle().state::<CliArgs>().no_tray;
-                    if tray_visible {
-                        // Tray is available: hide the dock icon, app lives in the tray
-                        let res = window
-                            .app_handle()
-                            .set_activation_policy(tauri::ActivationPolicy::Accessory);
-                        if let Err(e) = res {
-                            log::error!("Failed to set activation policy: {}", e);
+                if no_tray {
+                    // --no-tray: closing the window quits the app, matching the
+                    // documented behavior. Without this, the window is hidden
+                    // with no tray affordance to bring it back — on tiling WMs
+                    // the only recovery is relaunching.
+                    window.app_handle().exit(0);
+                } else {
+                    api.prevent_close();
+                    let _res = window.hide();
+
+                    #[cfg(target_os = "macos")]
+                    {
+                        let settings = get_settings(window.app_handle());
+                        let tray_visible = settings.show_tray_icon;
+                        if tray_visible {
+                            // Tray is available: hide the dock icon, app lives in the tray
+                            let res = window
+                                .app_handle()
+                                .set_activation_policy(tauri::ActivationPolicy::Accessory);
+                            if let Err(e) = res {
+                                log::error!("Failed to set activation policy: {}", e);
+                            }
                         }
+                        // No tray: keep the dock icon visible so the user can reopen
                     }
-                    // No tray: keep the dock icon visible so the user can reopen
                 }
             }
             tauri::WindowEvent::ThemeChanged(theme) => {


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Human Written Description

<!-- TODO: Brad, please write 2-3 sentences in your own words about why you noticed this and why the fix matters -->

## Related Issues/Discussions

Fixes #1932

## Community Feedback

The issue was filed by another contributor who noted the mismatch between the documented `--no-tray` behavior ("closing window quits the app") and the actual behavior (window hides with no recovery path on tiling WMs). The maintainer asked for a PR but none was submitted. This PR implements option 1 from the issue (honor the doc).

## Testing

- Verified the `CloseRequested` handler in `src-tauri/src/lib.rs` now branches on `no_tray`.
- When `--no-tray` is passed: `api.prevent_close()` is NOT called, and `app_handle().exit(0)` quits the app — matching the AGENTS.md documentation.
- When a tray is available: the existing `prevent_close()` + `window.hide()` behavior is preserved, including the macOS activation policy switch.
- On macOS without `--no-tray`: the `tray_visible` check no longer needs to test `no_tray` because we are already in the `else` branch (tray path).

**Not yet tested:** Full `bun run tauri dev` build and runtime verification (no Rust toolchain on the contributing machine). The logic change is small and straightforward, but maintainer verification on a real build is recommended, especially on a tiling WM (i3/sway) with `--no-tray`.

## Screenshots/Videos (if applicable)

N/A — behavioral change with no visible UI difference.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude (Anthropic)
- How extensively: AI assisted with codebase analysis to trace the close path and verify the fix. The logic was reviewed by the human contributor.
