### PR TITLE
docs(linux): document Ubuntu GNOME ydotool setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ If you switch between a MacBook keyboard and an external one, pick a shortcut bu
 **Wayland Support (Linux):**
 
 - Limited support for Wayland display server
-- Requires [`wtype`](https://github.com/atx/wtype) or [`dotool`](https://sr.ht/~geb/dotool/) for text input to work correctly (see [Linux Notes](#linux-notes) below for installation)
+- Requires [`wtype`](https://github.com/atx/wtype), [`dotool`](https://sr.ht/~geb/dotool/), or [`ydotool`](https://github.com/ReimuNotMoe/ydotool) for text input to work correctly (see [Linux Notes](#linux-notes) below)
 
 ### Linux Notes
 
@@ -146,15 +146,35 @@ If you switch between a MacBook keyboard and an external one, pick a shortcut bu
 
 For reliable text input on Linux, install the appropriate tool for your display server:
 
-| Display Server | Recommended Tool | Install Command                                    |
-| -------------- | ---------------- | -------------------------------------------------- |
-| X11            | `xdotool`        | `sudo apt install xdotool`                         |
-| Wayland        | `wtype`          | `sudo apt install wtype`                           |
-| Both           | `dotool`         | `sudo apt install dotool` (requires `input` group) |
+| Display Server            | Recommended Tool | Install Command                                    |
+| ------------------------- | ---------------- | -------------------------------------------------- |
+| X11                       | `xdotool`        | `sudo apt install xdotool`                         |
+| Wayland (where supported) | `wtype`          | `sudo apt install wtype`                           |
+| Both                      | `dotool`         | `sudo apt install dotool` (requires `input` group) |
 
 - **X11**: Install `xdotool` for both direct typing and clipboard paste shortcuts
-- **Ubuntu 26.04**: Has Wayland display server by default. `wtype` does not work, you need to install `ydotool` and configure systemd as described [here](https://github.com/cjpais/Handy/pull/557#issuecomment-3781249267).
-- **Wayland**: Install `wtype` (preferred) or `dotool` for text input to work correctly
+- **Ubuntu 26.04 with GNOME Wayland**: GNOME does not support the protocol required by `wtype`. The following setup was tested with Handy's `.deb` package:
+
+  ```bash
+  sudo apt install ydotool
+  systemctl --user enable --now ydotool.service
+  ```
+
+  Handy releases from 0.6.11 through 0.9.6 can use `ydotool`, but may select an installed `wtype` first. If the debug log shows `Using wtype for key combo`, uninstall `wtype` if you do not need it elsewhere. This selection issue is fixed on `main` by [#1276](https://github.com/cjpais/Handy/pull/1276).
+
+  For this setup, under **Settings > Advanced**, set **Paste Method** to **Clipboard (Ctrl+V)**. Verify the service and device access with:
+
+  ```bash
+  systemctl --user is-active ydotool.service
+  test -w /dev/uinput || echo "ERROR: /dev/uinput is not writable"
+  ```
+
+  If `/dev/uinput` is not writable, run `sudo usermod -aG input "$(id -un)"`, then log out and back in.
+
+  > **Security:** `ydotool` allows processes with access to its socket to inject system-wide input. Membership in the `input` group also grants broad access to input devices. This trades some of Wayland's isolation for reliable automation; [#689](https://github.com/cjpais/Handy/pull/689) explores a portal-based alternative.
+
+  To confirm Handy used `ydotool` for clipboard paste, enable debug mode and look for `Using ydotool for key combo` and any error immediately after it. If pasting still fails, recheck the commands above and see [#1742](https://github.com/cjpais/Handy/issues/1742).
+- **Wayland**: Install `wtype` (preferred where supported) or `dotool` for text input to work correctly
 - **dotool setup**: Requires adding your user to the `input` group: `sudo usermod -aG input $USER` (then log out and back in)
 
 Without these tools, Handy falls back to enigo which may have limited compatibility, especially on Wayland.


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

Not applicable: this is a documentation correction for an existing supported
Linux input path, not a new or previously rejected feature.

## Human Written Description

I've enjoyed using Handy on Windows and Linux after a coworker mentioned it; as a Linux amateur getting paste working on Ubuntu/GNOME took several non-obvious steps — for a while I didn't have `wtype`/`ydotool` so I was relying on GNOME behavior for paste which routed through Remote Desktop — the two most annoying things about this were 1) if I forgot to enable the Remote Desktop toggle and gave a long prompt, I think it got dropped and 2) this annoying orange icon that shows in tray which makes for poor UX since I am using an app working as intended and don't need this glaring reminder for it.

This PR updates documentation with the working tested setup on Ubuntu 26.04 to hopefully make it easier for the next person.

## Related Issues/Discussions

Documents a workaround for [#1742](https://github.com/cjpais/Handy/issues/1742)
and expands the Ubuntu note added in
[#1412](https://github.com/cjpais/Handy/pull/1412).

[#689](https://github.com/cjpais/Handy/pull/689) explores portal-based input,
and [#1568](https://github.com/cjpais/Handy/pull/1568) proposes broader
GNOME/Wayland changes. While that implementation work is still in progress,
this PR only improves the instructions for Handy's current behavior.

## Community Feedback

Issue [#1742](https://github.com/cjpais/Handy/issues/1742) reports the same
Ubuntu 26.04/GNOME auto-paste failure.

## Testing

The instructions were tested on:

- Ubuntu 26.04 with GNOME Wayland
- installed Handy 0.9.3
- Ubuntu `ydotool` 1.0.4-3
- the packaged, active `ydotool.service` user unit
- writable `/dev/uinput` access without joining the `input` group
- successful clipboard pastes logged as `Using ydotool for key combo`

The version-specific `wtype` caveat, command, setting name, fallback order, and
log message were checked against v0.9.6, #1276, and current `main`.
`git diff --check` passes.

## Screenshots/Videos (if applicable)

Not applicable; this is a documentation-only change.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Investigated Handy's Linux paste path, compared the current settings and runtime logs with source defaults, reviewed related issues and pull requests, and drafted the documentation.
