### PR TITLE
add continuous dictation with VAD segmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,98 +1,176 @@
-
 # Handy
 
 **Handy with continuous dictation using voice activity detection (VAD).**
 
-This fork of [Handy](https://github.com/cjpais/Handy) adds continuous dictation through automatic speech segmentation. Instead of requiring the user to start and stop recording manually for every utterance, Handy continuously listens for speech, detects when a segment begins and ends, and sends completed segments through the existing transcription pipeline.
+This fork of [Handy](https://github.com/cjpais/Handy) adds continuous dictation using Silero VAD. Instead of manually starting and stopping each recording, Handy automatically detects speech, splits it into segments, transcribes each segment, and pastes the result into the active application.
 
-> **Status:** Experimental feature / upstream pull request in progress
+> **Status:** Experimental. This fork contains an implementation currently proposed for upstream Handy in [PR #2026](https://github.com/cjpais/Handy/pull/2026).
 
-## What's Added
+## Continuous Dictation
 
-### Continuous Dictation
+When enabled, Handy continuously monitors microphone input and automatically creates transcription segments based on speech activity.
 
-When enabled, Handy:
+The process is:
 
-1. Continuously captures microphone audio.
-2. Uses Silero VAD to detect speech.
-3. Waits for speech to begin before creating a segment.
-4. Keeps collecting audio while speech continues.
-5. Ends the segment after a period of silence.
-6. Sends the completed segment to Handy's existing transcription system.
-7. Processes and pastes the resulting transcription normally.
+1. Microphone audio is continuously captured.
+2. Silero VAD detects when speech begins.
+3. Audio is collected while speech continues.
+4. Silence marks the end of the segment.
+5. The segment is sent to Handy's existing transcription pipeline.
+6. The resulting text is processed and pasted into the active application.
 
-This allows dictation to feel more like continuous speech input rather than repeated push-to-talk interactions.
+## Enable Continuous Dictation
 
-## Why?
+Continuous Dictation is currently located in Handy's **Debug Settings**.
 
-Handy is already very good at turning speech into text, but traditional push-to-talk dictation requires the user to manually control each recording.
+### 1. Enable Debug Mode
 
-Continuous dictation makes it possible to simply speak naturally while Handy handles the recording boundaries automatically.
+Open Handy's settings and enable **Debug Mode**.
 
-## Implementation
+Once Debug Mode is enabled, the additional Debug settings will appear.
 
-The feature builds on Handy's existing audio and transcription infrastructure rather than introducing a separate transcription system.
+### 2. Enable Continuous Dictation
 
-### Voice Activity Detection
-
-Continuous segmentation uses **Silero VAD** to determine whether incoming audio contains speech.
-
-The segmenter maintains:
-
-* Speech onset detection
-* Silence tracking
-* Audio buffering
-* Segment boundaries
-* Automatic segment callbacks
-
-A small amount of audio from the beginning of speech is retained so the beginning of an utterance is not lost when speech is first detected.
-
-### Transcription
-
-Completed segments are passed through Handy's existing `TranscriptionManager`.
-
-The selected Whisper model is loaded when continuous dictation is enabled, including when the feature is enabled while Handy is already running.
-
-## Configuration
-
-Continuous dictation can be enabled from:
+Go to:
 
 **Settings → Debug → Continuous Dictation**
 
-The setting is persisted with Handy's existing settings system.
+Turn **Continuous Dictation** on.
+
+Handy will then continuously monitor the microphone and automatically split speech into transcription segments.
+
+### 3. Start Speaking
+
+Once enabled, simply speak normally.
+
+You do not need to manually start and stop each recording. Handy will:
+
+* Detect when you start speaking
+* Continue recording while you speak
+* Detect when you stop speaking
+* Transcribe the completed segment
+* Paste the transcription into the active application
+
+> **Note:** Continuous Dictation is currently an experimental feature and is exposed through Debug Settings while it is being tested.
+
+## Installation
+
+### Download a Release
+
+This fork does not currently provide separate release builds.
+
+For the upstream Handy release, see the [official Handy releases](https://github.com/cjpais/Handy/releases).
+
+To use **this fork's continuous dictation implementation**, build Handy from source using the instructions below.
+
+### Build from Source
+
+#### Requirements
+
+You will need:
+
+* [Rust](https://www.rust-lang.org/tools/install) (latest stable)
+* [Bun](https://bun.sh/)
+* Tauri's platform-specific prerequisites
+* A supported operating system:
+
+  * Windows
+  * macOS
+  * Linux
+
+See the upstream [`BUILD.md`](https://github.com/cjpais/Handy/blob/main/BUILD.md) for platform-specific dependencies.
+
+#### 1. Clone this repository
+
+```bash
+git clone https://github.com/siruignaw-sys/Handy-Continuous-Dictation.git
+cd Handy-Continuous-Dictation
+```
+
+#### 2. Install dependencies
+
+```bash
+bun install
+```
+
+#### 3. Start the development build
+
+```bash
+bun tauri dev
+```
+
+This launches Handy with the continuous dictation implementation.
+
+#### 4. Build a production version
+
+```bash
+bun run tauri build
+```
+
+The generated application bundles will be placed under:
+
+```text
+src-tauri/target/release/bundle/
+```
+
+The exact bundle format depends on your operating system.
+
+## How It Works
+
+The continuous dictation feature builds on Handy's existing audio and transcription architecture.
+
+### Voice Activity Detection
+
+Silero VAD is used to identify speech within the continuously captured microphone stream.
+
+The segmenter tracks:
+
+* Speech onset
+* Speech duration
+* Silence duration
+* Audio buffering
+* Segment boundaries
+
+A short onset buffer is retained so the beginning of an utterance is not lost when speech is first detected.
+
+### Transcription
+
+Completed segments are passed to Handy's existing `TranscriptionManager`.
+
+The currently selected transcription model is used, and the resulting text follows Handy's normal processing and paste pipeline.
 
 ## Testing
 
-The feature has been tested locally with:
+The implementation has been tested locally with:
 
 * Normal-volume English speech
 * Continuous speech across multiple segments
 * Automatic VAD segmentation
-* Runtime enabling/disabling of continuous dictation
-* Existing Whisper transcription models
+* Enabling and disabling continuous dictation while Handy is running
+* Whisper transcription models
 * Chinese/English code-switching
-* Automatic insertion of transcribed text into the active application
+* Automatic insertion of transcription into the active application
 
-Transcription quality can vary with very quiet speech and multilingual/code-switched audio because those behaviors depend on the underlying Whisper model.
+Very quiet speech and heavily code-switched audio can produce less reliable transcription depending on the underlying Whisper model.
 
-## Upstream
+## Upstream Contribution
 
-This work is intended as a contribution to the original Handy project:
+This fork was created to develop and test continuous dictation for Handy.
 
-**https://github.com/cjpais/Handy**
+The original feature proposal is documented in [Handy Discussion #1896](https://github.com/cjpais/Handy/discussions/1896).
 
-Related discussion:
-
-**Handy Discussion #1896**
-
-Upstream pull request:
-
-**PR #2026**
+The implementation has been submitted upstream as [PR #2026](https://github.com/cjpais/Handy/pull/2026).
 
 ## Development
 
-This repository follows the development setup and requirements of the upstream Handy project. See the upstream repository and `CONTRIBUTING.md` for build instructions and contribution guidelines.
+For additional development information, platform-specific dependencies, and build details, see the upstream [`BUILD.md`](https://github.com/cjpais/Handy/blob/main/BUILD.md).
+
+## Credits
+
+This project is based on [Handy](https://github.com/cjpais/Handy) by cjpais and contributors.
+
+All original Handy functionality, dependencies, and licensing remain subject to the upstream project.
 
 ## License
 
-See the upstream Handy repository for licensing information.
+See [`LICENSE`](LICENSE) for the license applicable to this repository.

--- a/README.md
+++ b/README.md
@@ -1,525 +1,98 @@
+
 # Handy
 
-[![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?style=for-the-badge&logo=discord&logoColor=white)](https://discord.com/invite/WVBeWsNXK4)
+**Handy with continuous dictation using voice activity detection (VAD).**
 
-**A free, open source, and extensible speech-to-text application that works completely offline.**
+This fork of [Handy](https://github.com/cjpais/Handy) adds continuous dictation through automatic speech segmentation. Instead of requiring the user to start and stop recording manually for every utterance, Handy continuously listens for speech, detects when a segment begins and ends, and sends completed segments through the existing transcription pipeline.
 
-Handy is a cross-platform desktop application that provides simple, privacy-focused speech transcription. Press a shortcut, speak, and have your words appear in any text field. This happens on your own computer without sending any information to the cloud.
+> **Status:** Experimental feature / upstream pull request in progress
 
-## Why Handy?
+## What's Added
 
-Handy was created to fill the gap for a truly open source, extensible speech-to-text tool. As stated on [handy.computer](https://handy.computer):
+### Continuous Dictation
 
-- **Free**: Accessibility tooling belongs in everyone's hands, not behind a paywall
-- **Open Source**: Together we can build further. Extend Handy for yourself and contribute to something bigger
-- **Private**: Your voice stays on your computer. Get transcriptions without sending audio to the cloud
-- **Simple**: One tool, one job. Transcribe what you say and put it into a text box
+When enabled, Handy:
 
-Handy isn't trying to be the best speech-to-text app—it's trying to be the most forkable one.
+1. Continuously captures microphone audio.
+2. Uses Silero VAD to detect speech.
+3. Waits for speech to begin before creating a segment.
+4. Keeps collecting audio while speech continues.
+5. Ends the segment after a period of silence.
+6. Sends the completed segment to Handy's existing transcription system.
+7. Processes and pastes the resulting transcription normally.
 
-## How It Works
+This allows dictation to feel more like continuous speech input rather than repeated push-to-talk interactions.
 
-1. **Press** a configurable keyboard shortcut to start/stop recording (or use push-to-talk mode)
-2. **Speak** your words while the shortcut is active
-3. **Release** and Handy processes your speech using Whisper
-4. **Get** your transcribed text pasted directly into whatever app you're using
+## Why?
 
-The process is entirely local:
+Handy is already very good at turning speech into text, but traditional push-to-talk dictation requires the user to manually control each recording.
 
-- Silence is filtered using VAD (Voice Activity Detection) with Silero
-- Transcription uses your choice of models:
-  - **Whisper models** (Small/Medium/Turbo/Large) with GPU acceleration when available
-  - **Parakeet V3** - CPU-optimized model with excellent performance and automatic language detection
-- Works on Windows, macOS, and Linux
+Continuous dictation makes it possible to simply speak naturally while Handy handles the recording boundaries automatically.
 
-## Quick Start
+## Implementation
 
-### Installation
+The feature builds on Handy's existing audio and transcription infrastructure rather than introducing a separate transcription system.
 
-1. Download the latest release from the [releases page](https://github.com/cjpais/Handy/releases) or the [website](https://handy.computer)
-   - **macOS**: Also available via [Homebrew cask](https://formulae.brew.sh/cask/handy): `brew install --cask handy`
-   - **Windows**: Also available via [winget](https://github.com/microsoft/winget-pkgs): `winget install cjpais.Handy` \
-     **Note:** The Homebrew cask and winget package are not maintained by the Handy developers.
-2. Install the application
-3. Launch Handy and grant necessary system permissions (microphone, accessibility)
-4. Configure your preferred keyboard shortcuts in Settings
-5. Start transcribing!
+### Voice Activity Detection
 
-### Development Setup
+Continuous segmentation uses **Silero VAD** to determine whether incoming audio contains speech.
 
-For detailed build instructions including platform-specific requirements, see [BUILD.md](BUILD.md).
+The segmenter maintains:
 
-## Integrations
+* Speech onset detection
+* Silence tracking
+* Audio buffering
+* Segment boundaries
+* Automatic segment callbacks
 
-<a href="https://www.raycast.com/mattiacolombomc/handy" title="Install Handy Raycast Extension"><img src="https://www.raycast.com/mattiacolombomc/handy/install_button@2x.png?v=1.1" height="64" style="height: 64px;" alt="Install handy Raycast Extension" /></a>
+A small amount of audio from the beginning of speech is retained so the beginning of an utterance is not lost when speech is first detected.
 
-Control Handy from [Raycast](https://www.raycast.com) — start/stop recording, browse transcript history, manage dictionary, switch models and languages.
+### Transcription
 
-[Source](https://github.com/mattiacolombomc/raycast-handy) · by [@mattiacolombomc](https://github.com/mattiacolombomc)
+Completed segments are passed through Handy's existing `TranscriptionManager`.
 
-## Architecture
+The selected Whisper model is loaded when continuous dictation is enabled, including when the feature is enabled while Handy is already running.
 
-Handy is built as a Tauri application combining:
+## Configuration
 
-- **Frontend**: React + TypeScript with Tailwind CSS for the settings UI
-- **Backend**: Rust for system integration, audio processing, and ML inference
-- **Core Libraries**:
-  - `transcribe-cpp`: Local speech recognition with Whisper-family models (GGML/GGUF)
-  - `transcribe-rs`: CPU-optimized speech recognition with Parakeet models
-  - `cpal`: Cross-platform audio I/O
-  - `vad-rs`: Voice Activity Detection
-  - `rdev`: Global keyboard shortcuts and system events
-  - `rubato`: Audio resampling
+Continuous dictation can be enabled from:
 
-### Debug Mode
+**Settings → Debug → Continuous Dictation**
 
-Handy includes an advanced debug mode for development and troubleshooting. Access it by pressing:
+The setting is persisted with Handy's existing settings system.
 
-- **macOS**: `Cmd+Shift+D`
-- **Windows/Linux**: `Ctrl+Shift+D`
+## Testing
 
-### CLI Parameters
+The feature has been tested locally with:
 
-Handy supports command-line flags for controlling a running instance and customizing startup behavior. These work on all platforms (macOS, Windows, Linux).
+* Normal-volume English speech
+* Continuous speech across multiple segments
+* Automatic VAD segmentation
+* Runtime enabling/disabling of continuous dictation
+* Existing Whisper transcription models
+* Chinese/English code-switching
+* Automatic insertion of transcribed text into the active application
 
-**Remote control flags** (sent to an already-running instance via the single-instance plugin):
+Transcription quality can vary with very quiet speech and multilingual/code-switched audio because those behaviors depend on the underlying Whisper model.
 
-```bash
-handy --toggle-transcription    # Toggle recording on/off
-handy --toggle-post-process     # Toggle recording with post-processing on/off
-handy --cancel                  # Cancel the current operation
-```
+## Upstream
 
-**Startup flags:**
+This work is intended as a contribution to the original Handy project:
 
-```bash
-handy --start-hidden            # Start without showing the main window
-handy --no-tray                 # Start without the system tray icon
-handy --debug                   # Enable debug mode with verbose logging
-handy --help                    # Show all available flags
-```
+**https://github.com/cjpais/Handy**
 
-Flags can be combined for autostart scenarios:
+Related discussion:
 
-```bash
-handy --start-hidden --no-tray
-```
+**Handy Discussion #1896**
 
-> **macOS tip:** When Handy is installed as an app bundle, invoke the binary directly:
->
-> ```bash
-> /Applications/Handy.app/Contents/MacOS/Handy --toggle-transcription
-> ```
+Upstream pull request:
 
-## Known Issues & Current Limitations
+**PR #2026**
 
-This project is actively being developed and has some [known issues](https://github.com/cjpais/Handy/issues). We believe in transparency about the current state:
+## Development
 
-### Major Issues (Help Wanted)
-
-**Whisper Model Crashes:**
-
-- Whisper models crash on certain system configurations (Windows and Linux)
-- Does not affect all systems - issue is configuration-dependent
-  - If you experience crashes and are a developer, please help to fix and provide debug logs!
-
-**Wayland Support (Linux):**
-
-- Limited support for Wayland display server
-- Requires [`wtype`](https://github.com/atx/wtype) or [`dotool`](https://sr.ht/~geb/dotool/) for text input to work correctly (see [Linux Notes](#linux-notes) below for installation)
-
-### Linux Notes
-
-**Text Input Tools:**
-
-For reliable text input on Linux, install the appropriate tool for your display server:
-
-| Display Server | Recommended Tool | Install Command                                    |
-| -------------- | ---------------- | -------------------------------------------------- |
-| X11            | `xdotool`        | `sudo apt install xdotool`                         |
-| Wayland        | `wtype`          | `sudo apt install wtype`                           |
-| Both           | `dotool`         | `sudo apt install dotool` (requires `input` group) |
-
-- **X11**: Install `xdotool` for both direct typing and clipboard paste shortcuts
-- **Ubuntu 26.04**: Has Wayland display server by default. `wtype` does not work, you need to install `ydotool` and configure systemd as described [here](https://github.com/cjpais/Handy/pull/557#issuecomment-3781249267).
-- **Wayland**: Install `wtype` (preferred) or `dotool` for text input to work correctly
-- **dotool setup**: Requires adding your user to the `input` group: `sudo usermod -aG input $USER` (then log out and back in)
-
-Without these tools, Handy falls back to enigo which may have limited compatibility, especially on Wayland.
-
-**Other Notes:**
-
-- **Runtime library dependency (`libgtk-layer-shell.so.0`)**:
-  - Handy links `gtk-layer-shell` on Linux. If startup fails with `error while loading shared libraries: libgtk-layer-shell.so.0`, install the runtime package for your distro:
-
-    | Distro        | Package to install    | Example command                        |
-    | ------------- | --------------------- | -------------------------------------- |
-    | Ubuntu/Debian | `libgtk-layer-shell0` | `sudo apt install libgtk-layer-shell0` |
-    | Fedora/RHEL   | `gtk-layer-shell`     | `sudo dnf install gtk-layer-shell`     |
-    | Arch Linux    | `gtk-layer-shell`     | `sudo pacman -S gtk-layer-shell`       |
-
-  - For building from source on Ubuntu/Debian, you may also need `libgtk-layer-shell-dev`.
-
-- The recording overlay is disabled by default on Linux (`Overlay Position: None`) because certain compositors treat it as the active window. When the overlay is visible it can steal focus, which prevents Handy from pasting back into the application that triggered transcription. If you enable the overlay anyway, be aware that clipboard-based pasting might fail or end up in the wrong window.
-- If you are having trouble with the app, running with the environment variable `WEBKIT_DISABLE_DMABUF_RENDERER=1` may help
-- If Handy fails to start reliably on Linux, see [Troubleshooting → Linux Startup Crashes or Instability](#linux-startup-crashes-or-instability).
-- **Global keyboard shortcuts (Wayland):** On Wayland, system-level shortcuts must be configured through your desktop environment or window manager. Use the [CLI flags](#cli-parameters) as the command for your custom shortcut.
-
-  **GNOME:**
-  1. Open **Settings > Keyboard > Keyboard Shortcuts > Custom Shortcuts**
-  2. Click the **+** button to add a new shortcut
-  3. Set the **Name** to `Toggle Handy Transcription`
-  4. Set the **Command** to `handy --toggle-transcription`
-  5. Click **Set Shortcut** and press your desired key combination (e.g., `Super+O`)
-
-  **KDE Plasma:**
-  1. Open **System Settings > Shortcuts > Custom Shortcuts**
-  2. Click **Edit > New > Global Shortcut > Command/URL**
-  3. Name it `Toggle Handy Transcription`
-  4. In the **Trigger** tab, set your desired key combination
-  5. In the **Action** tab, set the command to `handy --toggle-transcription`
-
-  **Sway / i3:**
-
-  Add to your config file (`~/.config/sway/config` or `~/.config/i3/config`):
-
-  ```ini
-  bindsym $mod+o exec handy --toggle-transcription
-  ```
-
-  **Hyprland:**
-
-  Add to your config file (`~/.config/hypr/hyprland.conf`):
-
-  ```ini
-  bind = $mainMod, O, exec, handy --toggle-transcription
-  ```
-
-- You can also trigger Handy externally via Unix signals or the CLI flags, which lets Wayland window managers or other hotkey daemons keep ownership of keybindings:
-
-  | Action                                    | Trigger                                                  |
-  | ----------------------------------------- | -------------------------------------------------------- |
-  | Toggle transcription                      | `pkill -USR2 -n handy` or `handy --toggle-transcription` |
-  | Toggle transcription with post-processing | `handy --toggle-post-process`                            |
-
-  Example Sway config:
-
-  ```ini
-  bindsym $mod+o exec pkill -USR2 -n handy
-  bindsym $mod+p exec handy --toggle-post-process
-  ```
-
-  `pkill` here simply delivers the signal—it does not terminate the process.
-
-  > **Behavior change:** older releases also accepted `SIGUSR1` for toggling transcription with post-processing. WebKitGTK — the webview engine embedded in Handy on Linux — uses SIGUSR1 internally to coordinate JavaScript garbage collection, so listening for it caused phantom recordings and interrupted dictations every few minutes ([#1660](https://github.com/cjpais/Handy/issues/1660)). Handy no longer listens for SIGUSR1 on Linux; the post-processing toggle is still available via `handy --toggle-post-process`. **Remove any `pkill -USR1` bindings**: the signal is now delivered straight to WebKit's internal handler and can crash the app.
-
-**Overlay & Pasting Issues (Linux):**
-
-- The recording overlay window can interfere with pasting transcribed text into target applications on Linux (X11)
-- **Solution:** Open **Settings > Advanced** and set **"Overlay Position"** to **"None"** to disable the overlay
-- Enable **"Audio Feedback"** (also in Advanced) if you still want audible confirmation of recording state
-- Users who upgrade from older versions or import settings from other platforms may need to manually apply this change
-
-### Platform Support
-
-- **macOS (both Intel and Apple Silicon)**
-- **x64 Windows**
-- **x64 Linux**
-
-### System Requirements/Recommendations
-
-The following are recommendations for running Handy on your own machine. If you don't meet the system requirements, the performance of the application may be degraded. We are working on improving the performance across all kinds of computers and hardware.
-
-**For Whisper Models:**
-
-- **macOS**: M series Mac, Intel Mac
-- **Windows**: Intel, AMD, or NVIDIA GPU
-- **Linux**: Intel, AMD, or NVIDIA GPU
-  - Ubuntu 22.04, 24.04
-
-**For Parakeet V3 Model:**
-
-- **CPU-only operation** - runs on a wide variety of hardware
-- **Minimum**: Intel Skylake (6th gen) or equivalent AMD processors
-- **Performance**: ~5x real-time speed on mid-range hardware (tested on i5)
-- **Automatic language detection** - no manual language selection required
-
-## Roadmap & Active Development
-
-We're actively working on several features and improvements. Contributions and feedback are welcome!
-
-### In Progress
-
-**Debug Logging:**
-
-- Adding debug logging to a file to help diagnose issues
-
-**macOS Keyboard Improvements:**
-
-- Support for Globe key as transcription trigger
-- A rewrite of global shortcut handling for MacOS, and potentially other OS's too.
-
-**Opt-in Analytics:**
-
-- Collect anonymous usage data to help improve Handy
-- Privacy-first approach with clear opt-in
-
-**Settings Refactoring:**
-
-- Cleanup and refactor settings system which is becoming bloated and messy
-- Implement better abstractions for settings management
-
-**Tauri Commands Cleanup:**
-
-- Abstract and organize Tauri command patterns
-- Investigate tauri-specta for improved type safety and organization
-
-## Verify Release Signatures
-
-Handy release artifacts are signed with Tauri's updater signature format. The public key is stored in [`src-tauri/tauri.conf.json`](src-tauri/tauri.conf.json) under `plugins.updater.pubkey`.
-
-To verify a release manually, set `ARTIFACT` to the filename you downloaded, save the `pubkey` value from `src-tauri/tauri.conf.json` to `handy.pub.b64`, then decode the public key and matching `.sig` file from base64 and verify the artifact with `minisign`:
-
-```bash
-# Replace with the file you downloaded
-ARTIFACT="Handy_0.8.1_amd64.AppImage"
-
-python3 - "$ARTIFACT" <<'PY'
-import base64, pathlib, sys
-
-artifact = sys.argv[1]
-
-pub = pathlib.Path("handy.pub.b64").read_text().strip()
-pathlib.Path("handy.pub").write_bytes(base64.b64decode(pub))
-
-sig = pathlib.Path(f"{artifact}.sig").read_text().strip()
-pathlib.Path(f"{artifact}.minisig").write_bytes(base64.b64decode(sig))
-PY
-
-minisign -Vm "$ARTIFACT" \
-  -p handy.pub \
-  -x "$ARTIFACT.minisig"
-```
-
-On success, `minisign` prints:
-
-```text
-Signature and comment signature verified
-```
-
-Do not use `gpg` for these `.sig` files.
-
-## Troubleshooting
-
-### Manual Model Installation (For Proxy Users or Network Restrictions)
-
-If you're behind a proxy, firewall, or in a restricted network environment where Handy cannot download models automatically, you can manually download and install them. The URLs are publicly accessible from any browser.
-
-#### Step 1: Find Your App Data Directory
-
-1. Open Handy settings
-2. Navigate to the **About** section
-3. Copy the "App Data Directory" path shown there, or use the shortcuts:
-   - **macOS**: `Cmd+Shift+D` to open debug menu
-   - **Windows/Linux**: `Ctrl+Shift+D` to open debug menu
-
-The typical paths are:
-
-- **macOS**: `~/Library/Application Support/com.pais.handy/`
-- **Windows**: `C:\Users\{username}\AppData\Roaming\com.pais.handy\`
-- **Linux**: `~/.config/com.pais.handy/`
-
-#### Step 2: Create Models Directory
-
-Inside your app data directory, create a `models` folder if it doesn't already exist:
-
-```bash
-# macOS/Linux
-mkdir -p ~/Library/Application\ Support/com.pais.handy/models
-
-# Windows (PowerShell)
-New-Item -ItemType Directory -Force -Path "$env:APPDATA\com.pais.handy\models"
-```
-
-#### Step 3: Download Model Files
-
-Download the models you want from below
-
-**Whisper Models (single .bin files):**
-
-- Small (487 MB): `https://blob.handy.computer/ggml-small.bin`
-- Medium (492 MB): `https://blob.handy.computer/whisper-medium-q4_1.bin`
-- Turbo (1600 MB): `https://blob.handy.computer/ggml-large-v3-turbo.bin`
-- Large (1100 MB): `https://blob.handy.computer/ggml-large-v3-q5_0.bin`
-
-**Parakeet Unified EN 0.6B (single `.gguf` file, recommended):**
-
-- Q8_0 (731 MB): `https://huggingface.co/handy-computer/parakeet-unified-en-0.6b-gguf/resolve/main/parakeet-unified-en-0.6b-Q8_0.gguf`
-
-**Parakeet Models (compressed archives):**
-
-- V2 (473 MB): `https://blob.handy.computer/parakeet-v2-int8.tar.gz`
-- V3 (478 MB): `https://blob.handy.computer/parakeet-v3-int8.tar.gz`
-
-#### Step 4: Install Models
-
-**For Whisper Models (.bin files):**
-
-Simply place the `.bin` file directly into the `models` directory:
-
-```
-{app_data_dir}/models/
-├── ggml-small.bin
-├── whisper-medium-q4_1.bin
-├── ggml-large-v3-turbo.bin
-└── ggml-large-v3-q5_0.bin
-```
-
-**For GGUF Models (.gguf files):**
-
-Place the `.gguf` file directly into the `models` directory, exactly like the Whisper `.bin` files above. Handy also picks up models already present in the shared Hugging Face cache (`~/.cache/huggingface/hub`), so a copy downloaded by another tool works without being moved.
-
-**For Parakeet Models (.tar.gz archives):**
-
-1. Extract the `.tar.gz` file
-2. Place the **extracted directory** into the `models` folder
-3. The directory must be named exactly as follows:
-   - **Parakeet V2**: `parakeet-tdt-0.6b-v2-int8`
-   - **Parakeet V3**: `parakeet-tdt-0.6b-v3-int8`
-
-Final structure should look like:
-
-```
-{app_data_dir}/models/
-├── parakeet-tdt-0.6b-v2-int8/     (directory with model files inside)
-│   ├── (model files)
-│   └── (config files)
-└── parakeet-tdt-0.6b-v3-int8/     (directory with model files inside)
-    ├── (model files)
-    └── (config files)
-```
-
-**Important Notes:**
-
-- For Parakeet models, the extracted directory name **must** match exactly as shown above
-- Do not rename the `.bin` or `.gguf` files—use the exact filenames from the download URLs
-- After placing the files, restart Handy to detect the new models
-
-#### Step 5: Verify Installation
-
-1. Restart Handy
-2. Open Settings → Models
-3. Your manually installed models should now appear as "Downloaded"
-4. Select the model you want to use and test transcription
-
-### Custom Whisper Models
-
-Handy can auto-discover custom Whisper GGML models placed in the `models` directory. This is useful for users who want to use fine-tuned or community models not included in the default model list.
-
-**How to use:**
-
-1. Obtain a Whisper model in GGML `.bin` format (e.g., from [Hugging Face](https://huggingface.co/models?search=whisper%20ggml))
-2. Place the `.bin` file in your `models` directory (see paths above)
-3. Restart Handy to discover the new model
-4. The model will appear in the "Custom Models" section of the Models settings page
-
-**Important:**
-
-- Community models are user-provided and may not receive troubleshooting assistance
-- The model must be a valid Whisper GGML format (`.bin` file)
-- Model name is derived from the filename (e.g., `my-custom-model.bin` → "My Custom Model")
-
-### Linux Startup Crashes or Instability
-
-If Handy fails to start reliably on Linux — for example, it crashes shortly after launch, never shows its window, or reports a Wayland protocol error — try the steps below in order.
-
-**1. Install (or reinstall) `gtk-layer-shell`**
-
-Handy uses `gtk-layer-shell` for its recording overlay and links against it at runtime. A missing or broken installation is the most common cause of startup failures and can manifest as a crash or a hang well before any window is shown. Make sure the runtime package is installed for your distro:
-
-| Distro        | Package to install    | Example command                        |
-| ------------- | --------------------- | -------------------------------------- |
-| Ubuntu/Debian | `libgtk-layer-shell0` | `sudo apt install libgtk-layer-shell0` |
-| Fedora/RHEL   | `gtk-layer-shell`     | `sudo dnf install gtk-layer-shell`     |
-| Arch Linux    | `gtk-layer-shell`     | `sudo pacman -S gtk-layer-shell`       |
-
-If it is already installed and you still see startup problems, try reinstalling it (e.g. `sudo pacman -S gtk-layer-shell` again) in case the library files were corrupted by a partial upgrade.
-
-**2. Disable the GTK layer shell overlay (`HANDY_NO_GTK_LAYER_SHELL`)**
-
-If installing the library does not help, you can skip `gtk-layer-shell` initialization entirely as a workaround. On some compositors (notably KDE Plasma under Wayland) it has been reported to interact poorly with the recording overlay. With this variable set, the overlay falls back to a regular always-on-top window:
-
-```bash
-HANDY_NO_GTK_LAYER_SHELL=1 handy
-```
-
-**3. Disable WebKit DMA-BUF renderer (`WEBKIT_DISABLE_DMABUF_RENDERER`)**
-
-On some GPU/driver combinations the WebKitGTK DMA-BUF renderer can cause the window to fail to render or to crash. Try:
-
-```bash
-WEBKIT_DISABLE_DMABUF_RENDERER=1 handy
-```
-
-**Making a workaround permanent**
-
-Once you've found a flag that helps, export it from your shell profile (`~/.bashrc`, `~/.zshenv`, …) or from the desktop autostart entry that launches Handy. If you launch Handy from a `.desktop` file, you can prefix the `Exec=` line, e.g.:
-
-```ini
-Exec=env HANDY_NO_GTK_LAYER_SHELL=1 handy
-```
-
-If a workaround helps you, please [open an issue](https://github.com/cjpais/Handy/issues) describing your distro, desktop environment, and session type — that information helps us narrow down the underlying bug.
-
-### Handy Starts or Stops Recording on Its Own (Linux)
-
-Handy 0.9.4 and earlier listened for `SIGUSR1` as a remote-control trigger. WebKitGTK — the webview engine embedded in Handy on Linux — uses that same signal internally to coordinate JavaScript garbage collection, so GC cycles were misread as hotkey presses: recordings started on their own, or real dictations were cut off mid-sentence (typically ~2 minutes in). See [#1660](https://github.com/cjpais/Handy/issues/1660).
-
-Update to a newer release, and replace any `pkill -USR1 -n handy` keybindings with `handy --toggle-post-process`.
-
-### How to Contribute
-
-1. **Check existing issues** at [github.com/cjpais/Handy/issues](https://github.com/cjpais/Handy/issues)
-2. **Fork the repository** and create a feature branch
-3. **Test thoroughly** on your target platform
-4. **Submit a pull request** with clear description of changes
-5. **Join the discussion** - reach out at [contact@handy.computer](mailto:contact@handy.computer)
-
-The goal is to create both a useful tool and a foundation for others to build upon—a well-patterned, simple codebase that serves the community.
-
-## Sponsors
-
-<div align="center">
-  We're grateful for the support of our sponsors who help make Handy possible:
-  <br><br>
-  <a href="https://wordcab.com">
-    <img src="sponsor-images/wordcab.png" alt="Wordcab" width="120" height="120">
-  </a>
-  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-  <a href="https://github.com/epicenter-so/epicenter">
-    <img src="sponsor-images/epicenter.png" alt="Epicenter" width="120" height="120">
-  </a>
-  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-  <a href="https://boltai.com?utm_source=handy">
-    <img src="sponsor-images/boltai.jpg" alt="Bolt AI" width="120" height="120">
-  </a>
-</div>
-
-## Related Projects
-
-- **[Handy CLI](https://github.com/cjpais/handy-cli)** - The original Python command-line version
-- **[handy.computer](https://handy.computer)** - Project website with demos and documentation
+This repository follows the development setup and requirements of the upstream Handy project. See the upstream repository and `CONTRIBUTING.md` for build instructions and contribution guidelines.
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) file for details.
-
-Handy is open-source software, but the Handy name, logo, icon, and brand assets are not open-source. Unofficial forks, rewrites, and redistributions must use their own branding and must not imply endorsement or affiliation.
-
-## Acknowledgments
-
-- **Whisper** by OpenAI for the speech recognition model
-- **ggml and transcribe.cpp** for amazing cross-platform speech-to-text inference/acceleration
-- **Silero** for great lightweight VAD
-- **Tauri** team for the excellent Rust-based app framework
-- **Community contributors** helping make Handy better
+See the upstream Handy repository for licensing information.

--- a/src-tauri/src/audio_toolkit/audio/recorder.rs
+++ b/src-tauri/src/audio_toolkit/audio/recorder.rs
@@ -19,6 +19,8 @@ use crate::audio_toolkit::{
     VoiceActivityDetector,
 };
 
+const VAD_SEGMENT_SILENCE_FRAMES: usize = 25;
+
 enum Cmd {
     /// Begin capturing. Carries the send timestamp so the consumer can log how
     /// long the command sat in the channel (and how much audio was dropped
@@ -26,6 +28,8 @@ enum Cmd {
     Start(VadPolicy, Instant),
     Stop(mpsc::Sender<Vec<f32>>),
     Shutdown,
+    EnableAutoMode,
+    DisableAutoMode,
 }
 
 enum AudioChunk {
@@ -69,6 +73,7 @@ impl VadConfig {
 /// Callback invoked with each 16 kHz mono frame that passes the active capture
 /// policy while recording. Used to feed a live streaming transcription as audio arrives.
 pub type AudioFrameCallback = Arc<dyn Fn(&[f32]) + Send + Sync + 'static>;
+pub type SegmentCompleteCallback = Arc<dyn Fn(Vec<f32>) + Send + Sync + 'static>;
 
 pub struct AudioRecorder {
     device: Option<Device>,
@@ -77,6 +82,8 @@ pub struct AudioRecorder {
     vad: Option<VadConfig>,
     level_cb: Option<Arc<dyn Fn(Vec<f32>) + Send + Sync + 'static>>,
     audio_cb: Option<AudioFrameCallback>,
+    audio_seg_cb: Option<SegmentCompleteCallback>,
+    auto_mode_enabled: bool,
     /// Which input channel to use. None = average all (original behavior).
     selected_channel: Option<usize>,
     /// Preferred stream config cached per device name. The two HAL property
@@ -97,6 +104,8 @@ impl AudioRecorder {
             vad: None,
             level_cb: None,
             audio_cb: None,
+            audio_seg_cb: None,
+            auto_mode_enabled: false,
             selected_channel: None,
             config_cache: Arc::new(Mutex::new(None)),
         })
@@ -139,6 +148,14 @@ impl AudioRecorder {
         self
     }
 
+    pub fn with_segment_callback<F>(mut self, cb: F) -> Self
+    where
+        F: Fn(Vec<f32>) + Send + Sync + 'static,
+    {
+        self.audio_seg_cb = Some(Arc::new(cb));
+        self
+    }
+
     pub fn with_selected_channel(mut self, channel: Option<u16>) -> Self {
         self.set_selected_channel(channel);
         self
@@ -178,6 +195,8 @@ impl AudioRecorder {
         let level_cb = self.level_cb.clone();
         // Move the optional real-time audio frame callback into the worker thread
         let audio_cb = self.audio_cb.clone();
+        let audio_seg_cb = self.audio_seg_cb.clone();
+        let auto_mode_enabled = self.auto_mode_enabled;
         let selected_channel = self.selected_channel;
         let config_cache = Arc::clone(&self.config_cache);
 
@@ -314,6 +333,8 @@ impl AudioRecorder {
                         cmd_rx,
                         level_cb,
                         audio_cb,
+                        audio_seg_cb,
+                        auto_mode_enabled,
                         stop_flag,
                         stream_running_at,
                     );
@@ -368,6 +389,24 @@ impl AudioRecorder {
             tx.send(Cmd::Stop(resp_tx))?;
         }
         Ok(resp_rx.recv()?) // wait for the samples
+    }
+
+    pub fn enable_auto_mode(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        self.auto_mode_enabled = true;
+
+        if let Some(tx) = &self.cmd_tx {
+            tx.send(Cmd::EnableAutoMode)?;
+        }
+        Ok(())
+    }
+
+    pub fn disable_auto_mode(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        self.auto_mode_enabled = false;
+
+        if let Some(tx) = &self.cmd_tx {
+            tx.send(Cmd::DisableAutoMode)?;
+        }
+        Ok(())
     }
 
     /// True once the capture worker has exited without anyone calling `close`.
@@ -604,6 +643,8 @@ fn run_consumer(
     cmd_rx: mpsc::Receiver<Cmd>,
     level_cb: Option<Arc<dyn Fn(Vec<f32>) + Send + Sync + 'static>>,
     audio_cb: Option<AudioFrameCallback>,
+    audio_seg_cb: Option<SegmentCompleteCallback>,
+    initial_auto_mode_enabled: bool,
     stop_flag: Arc<AtomicBool>,
     stream_running_at: Instant,
 ) {
@@ -613,7 +654,12 @@ fn run_consumer(
         Duration::from_millis(30),
     );
 
+    let mut auto_mode_enabled = initial_auto_mode_enabled;
+
     let mut processed_samples = Vec::<f32>::new();
+    let mut silent_frame_count: usize = 0;
+    let mut speech_onset_count: usize = 0;
+    let mut onset_buffer = Vec::<f32>::new();
     let mut recording = false;
     let mut vad_policy = VadPolicy::Offline;
 
@@ -651,10 +697,15 @@ fn run_consumer(
         vad_policy: VadPolicy,
         vad: &Option<VadConfig>,
         audio_cb: &Option<AudioFrameCallback>,
+        audio_seg_cb: &Option<SegmentCompleteCallback>,
         out_buf: &mut Vec<f32>,
-    ) {
-        if !recording {
-            return;
+        silent_frame_count: &mut usize,
+        speech_onset_count: &mut usize,
+        onset_buffer: &mut Vec<f32>,
+        auto_mode_enabled: bool,
+    ) -> Option<bool> {
+        if !recording && !auto_mode_enabled {
+            return Some(false);
         }
 
         let mut emit = |buf: &[f32]| {
@@ -666,17 +717,65 @@ fn run_consumer(
 
         if vad_policy == VadPolicy::Disabled {
             emit(samples);
-            return;
+            return None;
         }
+        if !recording {
+            if let Some(cfg) = vad {
+                let mut det = cfg.detector.lock().unwrap();
+                match det.push_frame(samples).unwrap_or(VadFrame::Speech(samples)) {
+                    VadFrame::Speech(buf) => {
+                        onset_buffer.extend_from_slice(buf);
+                        *speech_onset_count += 1;
+                        log::debug!("onset watch: speech frame, count={}", *speech_onset_count);
+                        if *speech_onset_count >= 3 {
+                            log::debug!("Onset detected, starting auto recording");
 
+                            emit(&onset_buffer);
+                            onset_buffer.clear();
+
+                            *speech_onset_count = 0;
+                            return Some(true);
+                        }
+                        return None;
+                    }
+                    VadFrame::Noise => {
+                        *speech_onset_count = 0;
+                        onset_buffer.clear();
+                        return None;
+                    }
+                    _ => {
+                        return None;
+                    }
+                }
+            }
+            return None;
+        }
         if let Some(cfg) = vad {
             let mut det = cfg.detector.lock().unwrap();
             match det.push_frame(samples).unwrap_or(VadFrame::Speech(samples)) {
-                VadFrame::Speech(buf) => emit(buf),
-                VadFrame::Noise => {}
+                VadFrame::Speech(buf) => {
+                    *silent_frame_count = 0;
+                    emit(buf);
+                    return None;
+                }
+                VadFrame::Noise => {
+                    *silent_frame_count += 1;
+                    if *silent_frame_count > VAD_SEGMENT_SILENCE_FRAMES {
+                        if let Some(cb) = audio_seg_cb {
+                            let out_buffer = std::mem::take(out_buf);
+                            cb(out_buffer);
+                        }
+
+                        *silent_frame_count = 0;
+                        *speech_onset_count = 0;
+                        return Some(false);
+                    }
+                    return None;
+                }
             }
         } else {
             emit(samples);
+            return None;
         }
     }
 
@@ -698,6 +797,9 @@ fn run_consumer(
                     stop_flag.store(false, Ordering::Relaxed);
                     vad_policy = policy;
                     processed_samples.clear();
+                    onset_buffer.clear();
+                    speech_onset_count = 0;
+                    silent_frame_count = 0;
                     recording = true;
                     visualizer.reset();
                     frame_resampler.reset();
@@ -719,18 +821,24 @@ fn run_consumer(
                     // The chunk in hand arrived before the stop; it belongs to
                     // the recording, so feed it ahead of the drain below.
                     if let Some(AudioChunk::Samples(raw)) = pending.take() {
-                        frame_resampler.push(&raw, &mut |frame: &[f32]| {
-                            handle_frame(
-                                frame,
-                                true,
-                                vad_policy,
-                                &vad,
-                                &audio_cb,
-                                &mut processed_samples,
-                            )
+                        frame_resampler.push(&raw, &mut |frame: &[f32]| match handle_frame(
+                            frame,
+                            true,
+                            vad_policy,
+                            &vad,
+                            &audio_cb,
+                            &audio_seg_cb,
+                            &mut processed_samples,
+                            &mut silent_frame_count,
+                            &mut speech_onset_count,
+                            &mut onset_buffer,
+                            auto_mode_enabled,
+                        ) {
+                            Some(true) => recording = true,
+                            Some(false) => recording = false,
+                            None => {}
                         });
                     }
-
                     // Drain all remaining audio until the producer confirms end-of-stream.
                     // The cpal callback sees the stop flag, sends EndOfStream, and goes
                     // silent — guaranteeing every captured sample is in the channel
@@ -739,14 +847,23 @@ fn run_consumer(
                         match sample_rx.recv_timeout(Duration::from_secs(2)) {
                             Ok(AudioChunk::Samples(remaining)) => {
                                 frame_resampler.push(&remaining, &mut |frame: &[f32]| {
-                                    handle_frame(
+                                    match handle_frame(
                                         frame,
                                         true,
                                         vad_policy,
                                         &vad,
                                         &audio_cb,
+                                        &audio_seg_cb,
                                         &mut processed_samples,
-                                    )
+                                        &mut silent_frame_count,
+                                        &mut speech_onset_count,
+                                        &mut onset_buffer,
+                                        auto_mode_enabled,
+                                    ) {
+                                        Some(true) => recording = true,
+                                        Some(false) => recording = false,
+                                        None => {}
+                                    }
                                 });
                             }
                             Ok(AudioChunk::EndOfStream) => break,
@@ -757,15 +874,22 @@ fn run_consumer(
                         }
                     }
 
-                    frame_resampler.finish(&mut |frame: &[f32]| {
-                        handle_frame(
-                            frame,
-                            true,
-                            vad_policy,
-                            &vad,
-                            &audio_cb,
-                            &mut processed_samples,
-                        )
+                    frame_resampler.finish(&mut |frame: &[f32]| match handle_frame(
+                        frame,
+                        true,
+                        vad_policy,
+                        &vad,
+                        &audio_cb,
+                        &audio_seg_cb,
+                        &mut processed_samples,
+                        &mut silent_frame_count,
+                        &mut speech_onset_count,
+                        &mut onset_buffer,
+                        auto_mode_enabled,
+                    ) {
+                        Some(true) => recording = true,
+                        Some(false) => recording = false,
+                        None => {}
                     });
 
                     let _ = reply_tx.send(std::mem::take(&mut processed_samples));
@@ -777,6 +901,20 @@ fn run_consumer(
                 Cmd::Shutdown => {
                     stop_flag.store(true, Ordering::Relaxed);
                     return;
+                }
+                Cmd::EnableAutoMode => {
+                    auto_mode_enabled = true;
+                    speech_onset_count = 0;
+                    silent_frame_count = 0;
+                    onset_buffer.clear();
+                    log::debug!("Auto mode enabled");
+                }
+                Cmd::DisableAutoMode => {
+                    auto_mode_enabled = false;
+                    speech_onset_count = 0;
+                    silent_frame_count = 0;
+                    onset_buffer.clear();
+                    log::debug!("Auto mode disabled");
                 }
             }
         }
@@ -806,22 +944,29 @@ fn run_consumer(
         // idle to avoid doing unnecessary work whose output is thrown away. Both
         // are reset on Cmd::Start (visualizer.reset() / frame_resampler.reset()),
         // so they resume cleanly the moment recording begins.
-        if recording {
+        if recording || auto_mode_enabled {
             if let Some(buckets) = visualizer.feed(&raw) {
                 if let Some(cb) = &level_cb {
                     cb(buckets);
                 }
             }
 
-            frame_resampler.push(&raw, &mut |frame: &[f32]| {
-                handle_frame(
-                    frame,
-                    recording,
-                    vad_policy,
-                    &vad,
-                    &audio_cb,
-                    &mut processed_samples,
-                )
+            frame_resampler.push(&raw, &mut |frame: &[f32]| match handle_frame(
+                frame,
+                recording,
+                vad_policy,
+                &vad,
+                &audio_cb,
+                &audio_seg_cb,
+                &mut processed_samples,
+                &mut silent_frame_count,
+                &mut speech_onset_count,
+                &mut onset_buffer,
+                auto_mode_enabled,
+            ) {
+                Some(true) => recording = true,
+                Some(false) => recording = false,
+                None => {}
             });
         }
 

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -178,12 +178,39 @@ pub async fn update_microphone_mode(app: AppHandle, always_on: bool) -> Result<(
         .map_err(|e| format!("audio task join failed: {}", e))?
         .map_err(|e| format!("Failed to update microphone mode: {}", e))
 }
+#[tauri::command]
+#[specta::specta]
+pub async fn update_continuous_dictation(
+    app: AppHandle,
+    continuous_dictation_enabled: bool,
+) -> Result<(), String> {
+    let mut settings = get_settings(&app);
+    settings.continuous_dictation_enabled = continuous_dictation_enabled;
+    write_settings(&app, settings);
 
+    let rm = app.state::<Arc<AudioRecordingManager>>().inner().clone();
+
+    if continuous_dictation_enabled {
+        rm.initiate_transcription_model_load();
+    }
+
+    tokio::task::spawn_blocking(move || rm.set_auto_mode(continuous_dictation_enabled))
+        .await
+        .map_err(|e| format!("audio task join failed: {}", e))?
+        .map_err(|e| format!("Failed to update continuous dictation mode: {}", e))
+}
 #[tauri::command]
 #[specta::specta]
 pub fn get_microphone_mode(app: AppHandle) -> Result<bool, String> {
     let settings = get_settings(&app);
     Ok(settings.always_on_microphone)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn get_continuous_dictation(app: AppHandle) -> Result<bool, String> {
+    let settings = get_settings(&app);
+    Ok(settings.continuous_dictation_enabled)
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -162,8 +162,12 @@ fn initialize_core_logic(app_handle: &AppHandle) {
             .expect("Failed to initialize transcription manager"),
     );
     let recording_manager = Arc::new(
-        AudioRecordingManager::new(app_handle, transcription_manager.stream_router())
-            .expect("Failed to initialize recording manager"),
+        AudioRecordingManager::new(
+            app_handle,
+            transcription_manager.stream_router(),
+            transcription_manager.clone(),
+        )
+        .expect("Failed to initialize recording manager"),
     );
     let history_manager =
         Arc::new(HistoryManager::new(app_handle).expect("Failed to initialize history manager"));
@@ -689,6 +693,8 @@ pub fn run(cli_args: CliArgs) {
             commands::models::rescan_local_models,
             commands::audio::update_microphone_mode,
             commands::audio::get_microphone_mode,
+            commands::audio::update_continuous_dictation,
+            commands::audio::get_continuous_dictation,
             commands::audio::get_windows_microphone_permission_status,
             commands::audio::open_microphone_privacy_settings,
             commands::audio::get_available_microphones,

--- a/src-tauri/src/managers/audio.rs
+++ b/src-tauri/src/managers/audio.rs
@@ -1,3 +1,4 @@
+use crate::actions::process_transcription_output;
 use crate::audio_toolkit::{
     list_input_devices,
     vad::{
@@ -8,6 +9,7 @@ use crate::audio_toolkit::{
 };
 use crate::helpers::clamshell;
 use crate::managers::transcription::StreamRouter;
+use crate::managers::transcription::TranscriptionManager;
 use crate::settings::{get_settings, AppSettings};
 use crate::utils;
 use log::{debug, error, info, trace, warn};
@@ -264,6 +266,7 @@ fn create_audio_recorder(
     app_handle: &tauri::AppHandle,
     selected_channel: Option<u16>,
     stream_router: Arc<StreamRouter>,
+    transcription_manager: Arc<TranscriptionManager>,
 ) -> Result<AudioRecorder, anyhow::Error> {
     // A single Silero engine covers both the offline and streaming policies (never
     // active at once within a recording), so the recorder reconfigures its
@@ -299,6 +302,42 @@ fn create_audio_recorder(
             move |frame| {
                 router.feed(frame);
             }
+        })
+        .with_segment_callback({
+            let app_handle = app_handle.clone();
+            let tm = transcription_manager.clone();
+            move |segment: Vec<f32>| {
+                let app_handle = app_handle.clone();
+                let tm = tm.clone();
+                tauri::async_runtime::spawn(async move {
+                    match tm.transcribe(segment) {
+                        Ok(text) => {
+                            let processed =
+                                process_transcription_output(&app_handle, &text, false).await;
+                            if processed.final_text.is_empty() {
+                            } else {
+                                let app_handle_for_paste = app_handle.clone();
+                                app_handle
+                                    .run_on_main_thread(move || {
+                                        match utils::paste(
+                                            processed.final_text,
+                                            app_handle_for_paste,
+                                        ) {
+                                            Ok(()) => {}
+                                            Err(e) => {
+                                                log::error!("Auto-segement paste failed: {}", e);
+                                            }
+                                        }
+                                    })
+                                    .unwrap_or_else(|e| error!("run on main thread failed: {}", e));
+                            }
+                        }
+                        Err(e) => {
+                            log::error!("Auto-segment transcription failed: {}", e);
+                        }
+                    }
+                });
+            }
         });
 
     Ok(recorder)
@@ -321,6 +360,7 @@ pub struct AudioRecordingManager {
     close_generation: Arc<AtomicU64>,
     cancel_generation: Arc<AtomicU64>,
     stream_router: Arc<StreamRouter>,
+    transcription_manager: Arc<TranscriptionManager>,
     /// Lock-free mirror of "is the state in {Recording, Stopping}",
     /// maintained by `set_state()`. The hot-path `is_recording()` reads THIS
     /// instead of the std `state` mutex, so a UI poll can no longer deadlock
@@ -342,6 +382,7 @@ impl AudioRecordingManager {
     pub fn new(
         app: &tauri::AppHandle,
         stream_router: Arc<StreamRouter>,
+        transcription_manager: Arc<TranscriptionManager>,
     ) -> Result<Self, anyhow::Error> {
         let settings = get_settings(app);
         let mode = if settings.always_on_microphone {
@@ -362,6 +403,7 @@ impl AudioRecordingManager {
             close_generation: Arc::new(AtomicU64::new(0)),
             cancel_generation: Arc::new(AtomicU64::new(0)),
             stream_router,
+            transcription_manager,
             recording_active: Arc::new(AtomicBool::new(false)),
             cached_device: Arc::new(Mutex::new(None)),
         };
@@ -506,6 +548,10 @@ impl AudioRecordingManager {
         }
     }
 
+    pub fn initiate_transcription_model_load(&self) {
+        self.transcription_manager.initiate_model_load();
+    }
+
     pub fn preload_vad(&self) -> Result<(), anyhow::Error> {
         let mut recorder_opt = self.recorder.lock().unwrap();
         if recorder_opt.is_none() {
@@ -518,12 +564,21 @@ impl AudioRecordingManager {
                 )
                 .map_err(|e| anyhow::anyhow!("Failed to resolve VAD path: {}", e))?;
             let settings = get_settings(&self.app_handle);
-            *recorder_opt = Some(create_audio_recorder(
+            let mut recorder = create_audio_recorder(
                 &vad_path,
                 &self.app_handle,
                 settings.selected_channel,
                 Arc::clone(&self.stream_router),
-            )?);
+                Arc::clone(&self.transcription_manager),
+            )?;
+
+            if settings.continuous_dictation_enabled {
+                recorder
+                    .enable_auto_mode()
+                    .map_err(|e| anyhow::anyhow!("Failed to enable continuous dictation: {}", e))?;
+            }
+
+            *recorder_opt = Some(recorder);
         }
         Ok(())
     }
@@ -601,6 +656,11 @@ impl AudioRecordingManager {
         let vad_started = Instant::now();
         self.preload_vad()?;
         let vad_elapsed = vad_started.elapsed();
+
+        if settings.continuous_dictation_enabled {
+            log::info!("Continuous dictation enabled, initiating transcription model load");
+            self.transcription_manager.initiate_model_load();
+        }
 
         let open_started = Instant::now();
         let mut recorder_opt = self.recorder.lock().unwrap();
@@ -683,6 +743,19 @@ impl AudioRecordingManager {
         }
 
         *self.mode.lock().unwrap() = new_mode;
+        Ok(())
+    }
+
+    pub fn set_auto_mode(&self, enabled: bool) -> Result<(), anyhow::Error> {
+        if let Some(rec) = self.recorder.lock().unwrap().as_mut() {
+            if enabled {
+                rec.enable_auto_mode()
+                    .map_err(|e| anyhow::anyhow!("Error enabling: {}", e))?;
+            } else {
+                rec.disable_auto_mode()
+                    .map_err(|e| anyhow::anyhow!("Error disabling: {}", e))?;
+            }
+        }
         Ok(())
     }
 

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -737,6 +737,11 @@ impl TranscriptionManager {
             let settings = get_settings(&self_clone.app_handle);
             if let Err(e) = self_clone.load_model(&settings.selected_model) {
                 error!("Failed to load model: {}", e);
+            } else {
+                log::info!(
+                    "transcription model loaded successfully: {}",
+                    settings.selected_model
+                );
             }
             let mut is_loading = self_clone.is_loading.lock().unwrap();
             *is_loading = false;

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -376,6 +376,8 @@ pub struct AppSettings {
     #[serde(default = "default_always_on_microphone")]
     pub always_on_microphone: bool,
     #[serde(default)]
+    pub continuous_dictation_enabled: bool,
+    #[serde(default)]
     pub selected_microphone: Option<String>,
     /// Which input channel to use on the selected microphone device.
     /// None means "average all channels" (original behavior).
@@ -866,6 +868,7 @@ pub fn get_default_settings() -> AppSettings {
         selected_model: "".to_string(),
         onboarding_completed: false,
         always_on_microphone: false,
+        continuous_dictation_enabled: false,
         selected_microphone: None,
         selected_channel: None,
         clamshell_microphone: None,

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -713,6 +713,22 @@ async getMicrophoneMode() : Promise<Result<boolean, string>> {
     else return { status: "error", error: e  as any };
 }
 },
+async updateContinuousDictation(continuousDictationEnabled: boolean) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("update_continuous_dictation", { continuousDictationEnabled }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async getContinuousDictation() : Promise<Result<boolean, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_continuous_dictation") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async getWindowsMicrophonePermissionStatus() : Promise<WindowsMicrophonePermissionStatus> {
     return await TAURI_INVOKE("get_windows_microphone_permission_status");
 },
@@ -889,10 +905,8 @@ async updateRecordingRetentionPeriod(period: string) : Promise<Result<null, stri
 }
 },
 /**
- * Checks if the Mac is a laptop by detecting battery presence
- * 
- * This uses pmset to check for battery information.
- * Returns true if a battery is detected (laptop), false otherwise (desktop)
+ * Stub implementation for non-macOS platforms
+ * Always returns false since laptop detection is macOS-specific
  */
 async isLaptop() : Promise<Result<boolean, string>> {
     try {
@@ -948,7 +962,7 @@ bindings?: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk?: boolean
  * upgrading from before this key existed are blanked by the migration so they
  * see the current release's notes — see `apply_settings_migrations`.
  */
-whats_new_last_seen_version?: string; selected_model?: string; onboarding_completed?: boolean; always_on_microphone?: boolean; selected_microphone?: string | null; 
+whats_new_last_seen_version?: string; selected_model?: string; onboarding_completed?: boolean; always_on_microphone?: boolean; continuous_dictation_enabled?: boolean; selected_microphone?: string | null; 
 /**
  * Which input channel to use on the selected microphone device.
  * None means "average all channels" (original behavior).

--- a/src/components/settings/ContinuousDictation.tsx
+++ b/src/components/settings/ContinuousDictation.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { ToggleSwitch } from "../ui/ToggleSwitch";
+import { useSettings } from "../../hooks/useSettings";
+
+interface ContinuousDictationProps {
+  descriptionMode?: "inline" | "tooltip";
+  grouped?: boolean;
+}
+
+export const ContinuousDictation: React.FC<ContinuousDictationProps> = React.memo(
+  ({ descriptionMode = "tooltip", grouped = false }) => {
+    const { t } = useTranslation();
+    const { getSetting, updateSetting, isUpdating } = useSettings();
+
+    const continuousDictationEnabled = getSetting("continuous_dictation_enabled") || false;
+
+    return (
+      <ToggleSwitch
+        checked={continuousDictationEnabled}
+        onChange={(enabled) => updateSetting("continuous_dictation_enabled", enabled)}
+        isUpdating={isUpdating("continuous_dictation_enabled")}
+        label={t("settings.debug.continuousDictation.label")}
+        description={t("settings.debug.continuousDictation.description")}
+        descriptionMode={descriptionMode}
+        grouped={grouped}
+      />
+    );
+  },
+);

--- a/src/components/settings/debug/DebugSettings.tsx
+++ b/src/components/settings/debug/DebugSettings.tsx
@@ -13,6 +13,7 @@ import { ClamshellMicrophoneSelector } from "../ClamshellMicrophoneSelector";
 import { UpdateChecksToggle } from "../UpdateChecksToggle";
 import { WhatsNewPreview } from "./WhatsNewPreview";
 import { KeyboardDiagnostic } from "./KeyboardDiagnostic";
+import { ContinuousDictation } from "../ContinuousDictation";
 
 export const DebugSettings: React.FC = () => {
   const { t } = useTranslation();
@@ -39,6 +40,7 @@ export const DebugSettings: React.FC = () => {
         <ReliablePasteToggle descriptionMode="tooltip" grouped={true} />
         <RecordingBuffer descriptionMode="tooltip" grouped={true} />
         <AlwaysOnMicrophone descriptionMode="tooltip" grouped={true} />
+        <ContinuousDictation descriptionMode="tooltip" grouped={true} />
         <ClamshellMicrophoneSelector descriptionMode="tooltip" grouped={true} />
         <KeyboardDiagnostic />
         <LiveLogViewer descriptionMode="tooltip" grouped={true} />

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -14,6 +14,7 @@ export { ClamshellMicrophoneSelector } from "./ClamshellMicrophoneSelector";
 export { OutputDeviceSelector } from "./OutputDeviceSelector";
 export { AlwaysOnMicrophone } from "./AlwaysOnMicrophone";
 export { PushToTalk } from "./PushToTalk";
+export { ContinuousDictation } from "./ContinuousDictation";
 export { AudioFeedback } from "./AudioFeedback";
 export { ShowOverlay } from "./ShowOverlay";
 export { GlobalShortcutInput } from "./GlobalShortcutInput";

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -510,6 +510,10 @@
         "label": "Always-On Microphone",
         "description": "Keep microphone active for faster response"
       },
+      "continuousDictation": {
+        "label": "Continuous Dictation",
+        "description": "Automatically start and stop recording based on when you're speaking"
+      },
       "clamshellMicrophone": {
         "title": "Clamshell Microphone",
         "description": "Microphone to use when laptop lid is closed"

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -78,6 +78,8 @@ const settingUpdaters: {
 } = {
   always_on_microphone: (value) =>
     commands.updateMicrophoneMode(value as boolean),
+  continuous_dictation_enabled: (value) => 
+    commands.updateContinuousDictation(value as boolean),
   audio_feedback: (value) =>
     commands.changeAudioFeedbackSetting(value as boolean),
   audio_feedback_volume: (value) =>


### PR DESCRIPTION
## Before Submitting This PR

<!--
HANDY IS UNDERGOING A FEATURE FREEZE. IF YOU ARE SUBMITTING A PR WHICH IS A NEW FEATURE THAT THE COMMUNITY HAS NOT ASKED FOR: PREPARE TO BE REJECTED. IF THE COMMUNITY HAS ASKED FOR IT, OR YOU HAVE EXPLICITLY GATHERED SUPPORT IT MAY STILL BE CONSIDERED.

BUG FIXES ARE THE TOP PRIORITY. THERE ARE 60+ ISSUES TO FIX.
-->

**Please submit only one fix or feature per pull request. Pull requests containing multiple fixes or features will likely be closed.**

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

<!-- Describe your changes clearly and concisely


Please write 2-3 sentences in your own words explaining:
- What problem you noticed or idea you had
- Why you think this change matters

This section should be YOUR thinking, not AI-generated text. Even if AI helped write the code, we want to hear from you directly. Your perspective as a human is what makes contributions meaningful. Your PR may be rejected if you do not
include a human-written description.
-->
Handy currently uses a push-to-talk design, forcing users to press the push-to-talk button when finished in order for their speech to be transcribed. I added a continuous dictation mode for larger models, allowing for long speech sessions to be able to be visualized while the user is speaking, rather than printing after hitting ending the recording. My implementation adds continuous VAD-based segmentation and sends completed segments through the existing transcription pipeline.

## Related Issues/Discussions

<!-- Link to related issues, discussions, or previous PRs -->
<!-- If reopening something previously closed, explain why this should be reconsidered -->

Fixes #
Discussion: #1896

## Community Feedback

<!--
PRs with community support are much more likely to be merged.

For features: Link to a discussion where community members have expressed interest.
For bug fixes: Link to the issue where others have confirmed the bug.

If you haven't gathered feedback yet, consider starting a discussion first:
https://github.com/cjpais/Handy/discussions

It is not explicitly required to gather feedback, but it certainly helps your PR get merged.
-->

## Testing

Tested continuous dictation with the app running locally.
Confirmed VAD detects speech and produces segments.
Confirmed segments are passed to the existing Whisper transcription pipeline.
Tested normal-volume English speech.
Tested Chinese/English code-switching.
Confirmed the transcription model loads when continuous dictation is enabled at runtime.
Confirmed transcribed output is pasted into the active application.
## Screenshots/Videos (if applicable)

<!-- Add screenshots or videos demonstrating the change -->

## AI Assistance

<!-- AI-assisted PRs are welcome! Just let us know so we can review appropriately. -->

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude
- How extensively: Used for debugging terminal errors and reviewing the implementation.
