### PR TITLE
fix(shortcut): reject unknown reset binding IDs

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1220,12 +1220,12 @@ pub fn get_bindings(app: &AppHandle) -> HashMap<String, ShortcutBinding> {
     settings.bindings
 }
 
-pub fn get_stored_binding(app: &AppHandle, id: &str) -> ShortcutBinding {
-    let bindings = get_bindings(app);
-
-    let binding = bindings.get(id).unwrap().clone();
-
-    binding
+pub fn get_stored_binding(settings: &AppSettings, id: &str) -> Result<ShortcutBinding, String> {
+    settings
+        .bindings
+        .get(id)
+        .cloned()
+        .ok_or_else(|| format!("Binding with id '{}' not found", id))
 }
 
 pub fn get_history_limit(app: &AppHandle) -> usize {
@@ -1241,6 +1241,24 @@ pub fn get_recording_retention_period(app: &AppHandle) -> RecordingRetentionPeri
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn stored_binding_returns_the_requested_binding() {
+        let settings = get_default_settings();
+
+        let result = get_stored_binding(&settings, "transcribe");
+
+        assert_eq!(result.unwrap().id, "transcribe");
+    }
+
+    #[test]
+    fn unknown_stored_binding_returns_an_error() {
+        let settings = get_default_settings();
+
+        let result = get_stored_binding(&settings, "unknown");
+
+        assert_eq!(result.unwrap_err(), "Binding with id 'unknown' not found");
+    }
 
     fn default_settings_json() -> serde_json::Value {
         serde_json::to_value(get_default_settings()).unwrap()

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -224,7 +224,7 @@ fn restore_registration(app: &AppHandle, binding: &ShortcutBinding) {
 #[tauri::command]
 #[specta::specta]
 pub fn reset_binding(app: AppHandle, id: String) -> Result<BindingResponse, String> {
-    let binding = settings::get_stored_binding(&app, &id);
+    let binding = settings::get_stored_binding(&settings::get_settings(&app), &id)?;
     change_binding(app, id, binding.default_binding)
 }
 


### PR DESCRIPTION
## Before Submitting This PR

  - [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
  - [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

  ## Human Written Description

  When Handy receives an unknown shortcut ID while resetting a shortcut, the backend used an unchecked map lookup and could panic. This could make invalid or stale command input crash the application. The fix
  returns a clear command error instead and adds regression tests for both known and unknown shortcut IDs.

  ## Related Issues/Discussions

  No exact GitHub issue or discussion was found for this failure mode. This fixes verified issue P3-17 from the project issue audit.

  Related shortcut reports were reviewed, including [#96](https://github.com/cjpais/Handy/issues/96), [#855](https://github.com/cjpais/Handy/issues/855), [#92](https://github.com/cjpais/Handy/issues/92), and
  [Discussion #211](https://github.com/cjpais/Handy/discussions/211). Those reports concern shortcut registration and compatibility issues, not invalid shortcut IDs.

  ## Community Feedback

  This is a bug fix. No separate community discussion is required.

  ## Testing

  - `cargo test --manifest-path src-tauri/Cargo.toml --lib settings::tests::stored_binding_returns_the_requested_binding -- --exact` — passed.
  - `cargo test --manifest-path src-tauri/Cargo.toml --lib settings::tests::unknown_stored_binding_returns_an_error -- --exact` — passed.
  - `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 264 passed.
  - `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` — passed.
  - `git diff --check` — passed.

  The regression test fails with the original unchecked lookup and passes after the error-handling fix.

  ## Screenshots/Videos (if applicable)

  Not applicable. This change affects backend error handling and does not change the UI.

  ## AI Assistance

  - [ ] No AI was used in this PR
  - [x] AI was used (please describe below)

  **If AI was used:**

  - Tools used: Codex
  - How extensively: Codex investigated the verified issue, implemented the fix and regression tests, reviewed the changes, and ran the validation checks. The human contributor reviewed the changes.