### PR TITLE
Docker environment for Linux builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,21 @@ mkdir -p src-tauri/resources/models
 curl -o src-tauri/resources/models/silero_vad_v4.onnx https://blob.handy.computer/silero_vad_v4.onnx
 ```
 
+**Linux container build:**
+
+`docker-build-env/` carries the whole build stack, so the host needs only docker:
+
+```bash
+docker-build-env/shell tauri build --no-sign   # deb + rpm + AppImage, into src-tauri/target/release/bundle/
+docker-build-env/shell bun install
+docker-build-env/shell                         # a bash in there, for anything else
+```
+
+`--no-sign` skips the updater signature, which needs the release key. The repo is
+mounted at its host path so container and host share one `target/`. Don't build
+the repo from two different paths: build scripts cache absolute `OUT_DIR` paths
+that only `cargo clean` clears.
+
 For detailed platform-specific build setup, see [BUILD.md](BUILD.md).
 
 ## Architecture Overview
@@ -84,7 +99,9 @@ Handy is a cross-platform desktop speech-to-text application built with Tauri 2.
   - `shared/`, `ui/`, `icons/`, `footer/` - Shared components
 - `hooks/useSettings.ts` - Settings state management hook
 - `stores/settingsStore.ts` - Zustand store for settings
-- `bindings.ts` - Auto-generated Tauri type bindings (via tauri-specta)
+- `bindings.ts` - Auto-generated Tauri type bindings (via tauri-specta). Regenerated
+  on every backend build, so a Linux build rewrites the doc comments that the
+  committed macOS-generated version carries (e.g. `isLaptop`). Don't commit that churn
 - `overlay/` - Recording overlay window entry point
 - `lib/types.ts` - Shared TypeScript type definitions
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -116,6 +116,8 @@ bun run tauri build
 
 This compiles a release binary and generates platform-specific bundles (deb, rpm, AppImage on Linux; dmg on macOS; msi on Windows).
 
+On Linux, `docker-build-env/shell tauri build --no-sign` does the same in a container (see [docker-build-env/](docker-build-env/)), needing nothing on the host but docker.
+
 ## Linux Install (from source)
 
 The raw binary (`src-tauri/target/release/handy`) cannot run standalone — it needs Tauri resource files (tray icons, sounds, VAD model) to be co-located at the expected path.
@@ -197,7 +199,9 @@ cd src-tauri/target/release/bundle/appimage
   --appdir Handy.AppDir --plugin gtk --output appimage
 ```
 
-**Workaround:** The binary, deb, and rpm bundles all build fine — only the AppImage step fails. To skip it:
+**Workaround:** Build in the container (`docker-build-env/shell tauri build --no-sign`),
+which ships a linuxdeploy new enough for current toolchains. Or skip the AppImage, since
+the binary, deb, and rpm bundles all build fine:
 
 ```bash
 bun run tauri build -- --bundles deb

--- a/docker-build-env/Dockerfile
+++ b/docker-build-env/Dockerfile
@@ -1,0 +1,66 @@
+# Build environment for Handy's Linux bundles: the toolchain only, never the
+# app. Driven by ./shell.
+#
+# Ubuntu 24.04, the release CI builder for Handy's AppImage and rpm: nothing
+# bundles glibc, so building against an older one than the host's is what keeps
+# the bundles runnable on more than just this machine.
+FROM ubuntu:24.04
+ENV DEBIAN_FRONTEND=noninteractive
+
+# build.yml's "install dependencies (ubuntu 24.04 x64)" list, plus the toolchains
+# crates shell out to and what the bundlers need: tauri copies xdg-open into the
+# AppDir, linuxdeploy's plugins shell out to patchelf and file, appimagetool
+# validates the .desktop entry, and WebKit's media playback rides on the
+# GStreamer plugins that `bundleMediaFramework` pulls in.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf \
+      libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev \
+      libgtk-layer-shell-dev libevdev-dev libssl-dev \
+      build-essential clang libclang-dev cmake pkg-config \
+      ca-certificates curl git unzip xdg-utils desktop-file-utils file \
+      gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad \
+    && rm -rf /var/lib/apt/lists/*
+
+# ggml's Vulkan backend needs the loader, headers and glslc. LunarG's repo is
+# where CI gets them.
+RUN curl -fsSL -o /etc/apt/trusted.gpg.d/lunarg.asc https://packages.lunarg.com/lunarg-signing-key-pub.asc \
+ && curl -fsSL -o /etc/apt/sources.list.d/lunarg-vulkan.list https://packages.lunarg.com/vulkan/1.3.290/lunarg-vulkan-1.3.290-noble.list \
+ && apt-get update && apt-get install -y --no-install-recommends vulkan-sdk \
+ && rm -rf /var/lib/apt/lists/*
+
+# The distro's apt rust is far too old for tauri 2. shell repoints CARGO_HOME at the
+# build tree so the crate cache survives between runs. The node_modules/.bin shims
+# ask for `node`; bun answers to that name.
+ENV RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo PATH=/usr/local/cargo/bin:$PATH
+RUN curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --no-modify-path \
+ && curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash \
+ && ln -s bun /usr/local/bin/node
+
+# With no /dev/fuse in a container, the linuxdeploy AppImages have to unpack
+# themselves rather than mount.
+ENV APPIMAGE_EXTRACT_AND_RUN=1
+
+# The Vulkan loader and the Wayland client library have to come from the host's
+# own graphics stack. A bundled copy shadows it and can stop the host's Mesa or
+# Vulkan ICD from loading.
+ENV LINUXDEPLOY_EXCLUDED_LIBRARIES='libvulkan.so*;libwayland-client.so*'
+
+# Build as the invoking user, so what lands in the bind-mounted repo stays owned
+# by them.
+# noble ships its own uid-1000 user, which would collide.
+ARG USER_ID=1000
+RUN userdel -r ubuntu 2>/dev/null; useradd -u $USER_ID -m build
+USER build
+ENV HOME=/home/build
+
+# Fill Tauri's AppImage tool cache, which it otherwise re-downloads on every
+# build. linuxdeploy comes from upstream rather than Tauri's 2024 mirror, which
+# predates the LINUXDEPLOY_EXCLUDED_LIBRARIES above.
+RUN arch=$(uname -m) \
+ && mkdir -p $HOME/.cache/tauri && cd $HOME/.cache/tauri \
+ && curl -fsSLO "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-$arch.AppImage" \
+ && curl -fsSL -o linuxdeploy-plugin-appimage.AppImage "https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-$arch.AppImage" \
+ && curl -fsSLO "https://github.com/tauri-apps/binary-releases/releases/download/apprun-old/AppRun-$arch" \
+ && curl -fsSLO https://raw.githubusercontent.com/tauri-apps/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh \
+ && curl -fsSLO https://raw.githubusercontent.com/tauri-apps/linuxdeploy-plugin-gstreamer/master/linuxdeploy-plugin-gstreamer.sh \
+ && chmod +x ./*

--- a/docker-build-env/shell
+++ b/docker-build-env/shell
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Run a command inside Handy's Linux build environment (see ./Dockerfile), so the
+# host needs no toolchain of its own, just docker:
+#
+#   docker-build-env/shell tauri build --no-sign   # deb + rpm + AppImage
+#   docker-build-env/shell bun install
+#   docker-build-env/shell                         # bash
+set -euo pipefail
+
+repo=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+docker build -t handy-build-env --build-arg "USER_ID=$(id -u)" - <"$repo/docker-build-env/Dockerfile"
+
+tty=(-i)
+[ -t 0 ] && tty+=(-t)
+
+# The repo is mounted at its host path so container and host agree on every path:
+# build scripts bake absolute OUT_DIR paths into target/, and those dangle if the
+# same tree is ever built from two different locations.
+#
+# libtranscribe.so exists only inside the cargo build tree, from where build.rs
+# stages it into transcribe-libs/. linuxdeploy resolves the app's NEEDED
+# libraries with ldd and hard-fails on any it cannot find, so point it there.
+#
+# node_modules/.bin goes on PATH so the repo's own tools (tauri, vite, ...) run
+# by name.
+exec docker run --rm "${tty[@]}" \
+  -v "$repo:$repo" -w "$repo" \
+  -e "CARGO_HOME=$repo/src-tauri/target/cargo-home" \
+  -e "LD_LIBRARY_PATH=$repo/src-tauri/transcribe-libs" \
+  handy-build-env bash -c 'PATH=$PWD/node_modules/.bin:$PATH exec "${@:-bash}"' -- "$@"


### PR DESCRIPTION
Building Handy on Linux is rather challenging. This PR provides a simple shells script that uses Docker to provide a working development environment. So with only Docker being installed you can:

```sh
docker-build-env/shell tauri build
```

## Testing

"Works on my machine!" TM

But the point of this is that Docker will hopefully make it work on your machine too.

## AI Assistance

<!-- AI-assisted PRs are welcome! Just let us know so we can review appropriately. -->

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

Claude Fable 5.1 did most of the typing.