### PR TITLE
feat: show dictation usage stats on the History page

### DIFF
--- a/src-tauri/src/commands/history.rs
+++ b/src-tauri/src/commands/history.rs
@@ -1,10 +1,23 @@
 use crate::actions::process_transcription_output;
 use crate::managers::{
-    history::{HistoryManager, PaginatedHistory},
+    history::{HistoryManager, HistoryStats, PaginatedHistory},
     transcription::TranscriptionManager,
 };
 use std::sync::Arc;
 use tauri::{AppHandle, State};
+
+#[tauri::command]
+#[specta::specta]
+pub async fn get_history_stats(
+    _app: AppHandle,
+    history_manager: State<'_, Arc<HistoryManager>>,
+) -> Result<HistoryStats, String> {
+    let history_manager = history_manager.inner().clone();
+    tokio::task::spawn_blocking(move || history_manager.get_history_stats())
+        .await
+        .map_err(|e| format!("history stats task panicked: {e}"))?
+        .map_err(|e| e.to_string())
+}
 
 #[tauri::command]
 #[specta::specta]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -721,6 +721,7 @@ pub fn run(cli_args: CliArgs) {
             commands::transcription::get_model_load_status,
             commands::transcription::unload_model_manually,
             commands::history::get_history_entries,
+            commands::history::get_history_stats,
             commands::history::toggle_history_entry_saved,
             commands::history::get_audio_file_path,
             commands::history::delete_history_entry,

--- a/src-tauri/src/managers/history.rs
+++ b/src-tauri/src/managers/history.rs
@@ -65,6 +65,111 @@ pub struct HistoryEntry {
     pub post_process_requested: bool,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+pub struct HistoryStats {
+    pub total_dictations: i64,
+    pub total_words: i64,
+    pub this_week: i64,
+    pub this_month: i64,
+    pub daily_average: f64,
+    pub current_streak_days: i64,
+    pub longest_streak_days: i64,
+    pub post_processed: i64,
+    pub post_process_rate: i64,
+    pub time_saved_minutes: f64,
+    pub avg_wpm: Option<f64>,
+}
+
+/// Typing speed baseline and speaking rate used for the "time saved" estimate,
+/// matching the convention used by Willow Voice (words * (1/40 - 1/150) minutes).
+const TYPING_WPM: f64 = 40.0;
+const SPEAKING_WPM: f64 = 150.0;
+
+/// Days since epoch (UTC-midnight bucket) from a "YYYY-MM-DD" local date string.
+fn day_string_to_epoch_days(day: &str) -> Option<i64> {
+    use chrono::TimeZone;
+    chrono::NaiveDate::parse_from_str(day, "%Y-%m-%d")
+        .ok()
+        .and_then(|d| d.and_hms_opt(0, 0, 0))
+        .map(|ndt| chrono::Utc.from_utc_datetime(&ndt).timestamp() / 86_400)
+}
+
+/// Unix timestamp for local midnight on `date`.
+/// Ambiguous DST folds pick the earlier mapping. A DST spring gap falls back
+/// to 01:00 local so week/month bounds never collapse to the epoch.
+fn local_midnight_timestamp(date: chrono::NaiveDate) -> i64 {
+    use chrono::{LocalResult, TimeZone};
+    let midnight = date
+        .and_hms_opt(0, 0, 0)
+        .expect("midnight is a valid naive time");
+    match Local.from_local_datetime(&midnight) {
+        LocalResult::Single(dt) | LocalResult::Ambiguous(dt, _) => dt.timestamp(),
+        LocalResult::None => {
+            let shifted = date
+                .and_hms_opt(1, 0, 0)
+                .expect("01:00 is a valid naive time");
+            match Local.from_local_datetime(&shifted) {
+                LocalResult::Single(dt) | LocalResult::Ambiguous(dt, _) => dt.timestamp(),
+                LocalResult::None => Local::now().timestamp(),
+            }
+        }
+    }
+}
+
+/// Current and longest streak of consecutive days with at least one dictation.
+/// The current streak stays alive if the last active day is today or yesterday.
+fn compute_streaks(days: &[i64], today: i64) -> (i64, i64) {
+    let mut current = 0i64;
+    let start = if days.contains(&today) {
+        Some(today)
+    } else if days.contains(&(today - 1)) {
+        Some(today - 1)
+    } else {
+        None
+    };
+    if let Some(mut d) = start {
+        while days.contains(&d) {
+            current += 1;
+            d -= 1;
+        }
+    }
+
+    let mut longest = 0i64;
+    let mut run = 0i64;
+    let mut prev: Option<i64> = None;
+    for &d in days {
+        run = if prev == Some(d - 1) { run + 1 } else { 1 };
+        longest = longest.max(run);
+        prev = Some(d);
+    }
+
+    (current, longest)
+}
+
+/// Whitespace-separated word count. Consecutive spaces and newlines do not
+/// create extra words.
+fn count_words(text: &str) -> i64 {
+    text.split_whitespace().count() as i64
+}
+
+/// Final text for an entry: post-processed when present and non-empty, else raw.
+fn final_text<'a>(transcription: &'a str, post_processed: Option<&'a str>) -> &'a str {
+    match post_processed {
+        Some(processed) if !processed.trim().is_empty() => processed,
+        _ => transcription,
+    }
+}
+
+/// Audio duration in seconds, read from the WAV header only.
+fn wav_duration_seconds(path: &std::path::Path) -> Result<f64> {
+    let reader = hound::WavReader::open(path)?;
+    let sample_rate = reader.spec().sample_rate;
+    if sample_rate == 0 {
+        anyhow::bail!("WAV file has zero sample rate: {:?}", path);
+    }
+    Ok(reader.duration() as f64 / sample_rate as f64)
+}
+
 pub struct HistoryManager {
     app_handle: AppHandle,
     recordings_dir: PathBuf,
@@ -504,6 +609,145 @@ impl HistoryManager {
         Ok(PaginatedHistory { entries, has_more })
     }
 
+    /// Compute aggregate usage stats over completed history entries.
+    pub fn get_history_stats(&self) -> Result<HistoryStats> {
+        let conn = self.get_connection()?;
+        Self::get_history_stats_with_conn(&conn, &self.recordings_dir)
+    }
+
+    fn get_history_stats_with_conn(
+        conn: &Connection,
+        recordings_dir: &std::path::Path,
+    ) -> Result<HistoryStats> {
+        use chrono::{Datelike, Duration};
+
+        let tx = conn.unchecked_transaction()?;
+        let now_local = Local::now();
+        let now = now_local.timestamp();
+
+        // Start of the local week (Monday 00:00) and month (1st 00:00)
+        let monday = now_local.date_naive()
+            - Duration::days(now_local.weekday().num_days_from_monday() as i64);
+        let week_start = local_midnight_timestamp(monday);
+        let first_of_month = now_local
+            .date_naive()
+            .with_day(1)
+            .unwrap_or_else(|| now_local.date_naive());
+        let month_start = local_midnight_timestamp(first_of_month);
+
+        let (total, this_week, this_month, post_processed) = tx.query_row(
+            "SELECT
+                    COUNT(*),
+                    COALESCE(SUM(CASE WHEN timestamp >= ?1 THEN 1 ELSE 0 END), 0),
+                    COALESCE(SUM(CASE WHEN timestamp >= ?2 THEN 1 ELSE 0 END), 0),
+                    COALESCE(SUM(CASE WHEN NULLIF(TRIM(post_processed_text), '') IS NOT NULL THEN 1 ELSE 0 END), 0)
+                FROM transcription_history
+                WHERE transcription_text != ''",
+            params![week_start, month_start],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, i64>(3)?,
+                ))
+            },
+        )?;
+
+        // Distinct local days with at least one dictation, for streaks and daily average
+        let days: Vec<i64> = {
+            let mut stmt = tx.prepare(
+                "SELECT DISTINCT strftime('%Y-%m-%d', timestamp, 'unixepoch', 'localtime') AS day
+             FROM transcription_history
+             WHERE transcription_text != ''
+             ORDER BY day",
+            )?;
+            let day_strings = stmt
+                .query_map([], |row| row.get::<_, String>("day"))?
+                .collect::<rusqlite::Result<Vec<String>>>()?;
+            day_strings
+                .into_iter()
+                .filter_map(|day| day_string_to_epoch_days(&day))
+                .collect()
+        };
+
+        // Today's bucket derived the same way as the DB rows (local date string)
+        // so streak comparisons are consistent in every timezone.
+        let today_string = now_local.format("%Y-%m-%d").to_string();
+        let today_bucket = day_string_to_epoch_days(&today_string).unwrap_or_else(|| now / 86_400);
+
+        let (current_streak_days, longest_streak_days) = compute_streaks(&days, today_bucket);
+
+        let span_days = if days.is_empty() {
+            1
+        } else {
+            (days[days.len() - 1] - days[0] + 1).max(1)
+        };
+        let daily_average = ((total as f64 / span_days as f64) * 10.0).round() / 10.0;
+
+        let post_process_rate = if total > 0 {
+            post_processed * 100 / total
+        } else {
+            0
+        };
+
+        // Average dictation speed from real audio durations (WAV headers only).
+        // Entries whose recording was removed by retention are skipped.
+        let rows: Vec<(String, String, Option<String>)> = {
+            let mut stmt = tx.prepare(
+                "SELECT file_name, transcription_text, post_processed_text
+             FROM transcription_history
+             WHERE transcription_text != ''",
+            )?;
+            let mapped = stmt.query_map([], |row| {
+                Ok((
+                    row.get::<_, String>("file_name")?,
+                    row.get::<_, String>("transcription_text")?,
+                    row.get::<_, Option<String>>("post_processed_text")?,
+                ))
+            })?;
+            let rows = mapped.collect::<rusqlite::Result<Vec<_>>>()?;
+            rows
+        };
+
+        let mut total_words = 0i64;
+        let mut words_with_audio = 0i64;
+        let mut audio_seconds = 0f64;
+        for (file_name, transcription, post_processed_text) in &rows {
+            let words = count_words(final_text(transcription, post_processed_text.as_deref()));
+            total_words += words;
+            let path = recordings_dir.join(file_name);
+            if let Ok(secs) = wav_duration_seconds(&path) {
+                if secs > 0.0 {
+                    words_with_audio += words;
+                    audio_seconds += secs;
+                }
+            }
+        }
+        let time_saved_minutes = total_words as f64 * (1.0 / TYPING_WPM - 1.0 / SPEAKING_WPM);
+        let avg_wpm = if audio_seconds > 0.0 {
+            Some((words_with_audio as f64 / (audio_seconds / 60.0)).round())
+        } else {
+            None
+        };
+
+        let stats = HistoryStats {
+            total_dictations: total,
+            total_words,
+            this_week,
+            this_month,
+            daily_average,
+            current_streak_days,
+            longest_streak_days,
+            post_processed,
+            post_process_rate,
+            time_saved_minutes,
+            avg_wpm,
+        };
+        tx.commit()?;
+        Ok(stats)
+    }
+
     #[cfg(test)]
     fn get_latest_entry_with_conn(conn: &Connection) -> Result<Option<HistoryEntry>> {
         let mut stmt = conn.prepare(
@@ -733,5 +977,156 @@ mod tests {
 
         assert_eq!(entry.timestamp, 100);
         assert_eq!(entry.transcription_text, "completed");
+    }
+
+    #[test]
+    fn compute_streaks_handles_gaps_and_yesterday() {
+        // No activity
+        assert_eq!(compute_streaks(&[], 100), (0, 0));
+
+        // Consecutive days ending yesterday: streak still current
+        assert_eq!(compute_streaks(&[97, 98, 99], 100), (3, 3));
+
+        // Consecutive days ending today
+        assert_eq!(compute_streaks(&[98, 99, 100], 100), (3, 3));
+
+        // Gap: current run (2) is shorter than nothing else; longest is 2
+        assert_eq!(compute_streaks(&[97, 99, 100], 100), (2, 2));
+
+        // Longest run in the past beats the current streak
+        assert_eq!(compute_streaks(&[90, 91, 92, 93, 97, 99, 100], 100), (2, 4));
+
+        // Activity stopped two days ago: no current streak
+        assert_eq!(compute_streaks(&[97, 98], 100), (0, 2));
+    }
+
+    #[test]
+    fn stats_count_words_and_exclude_failed_entries() {
+        let conn = setup_conn();
+        insert_entry(&conn, 100, "hello world  foo\nbar", None);
+        insert_entry(&conn, 200, "", None); // failed transcription, excluded
+        insert_entry(&conn, 300, "raw text ignored", Some("one two")); // final text wins
+
+        let stats = HistoryManager::get_history_stats_with_conn(
+            &conn,
+            std::path::Path::new("/nonexistent"),
+        )
+        .expect("compute stats");
+
+        assert_eq!(stats.total_dictations, 2);
+        assert_eq!(stats.total_words, 6); // 4 + 2
+        assert_eq!(stats.post_processed, 1);
+        assert_eq!(stats.post_process_rate, 50);
+        assert_eq!(stats.avg_wpm, None);
+        let expected_saved = 6.0 * (1.0 / TYPING_WPM - 1.0 / SPEAKING_WPM);
+        assert!((stats.time_saved_minutes - expected_saved).abs() < 1e-9);
+    }
+
+    #[test]
+    fn count_words_collapses_whitespace() {
+        assert_eq!(count_words("hello world  foo\nbar"), 4);
+        assert_eq!(count_words(""), 0);
+        assert_eq!(count_words("  \n\t"), 0);
+        assert_eq!(count_words("one two"), 2);
+    }
+
+    #[test]
+    fn stats_streaks_from_consecutive_days() {
+        use chrono::{Duration, TimeZone};
+
+        let conn = setup_conn();
+        let today = Local::now().date_naive();
+        let noon_ts = |days_ago: i64| {
+            let date = today - Duration::days(days_ago);
+            let noon = date
+                .and_hms_opt(12, 0, 0)
+                .expect("noon is a valid naive time");
+            match Local.from_local_datetime(&noon) {
+                chrono::LocalResult::Single(dt) | chrono::LocalResult::Ambiguous(dt, _) => {
+                    dt.timestamp()
+                }
+                chrono::LocalResult::None => date
+                    .and_hms_opt(13, 0, 0)
+                    .and_then(|shifted| Local.from_local_datetime(&shifted).single())
+                    .map(|dt| dt.timestamp())
+                    .expect("local noon mapping"),
+            }
+        };
+        insert_entry(&conn, noon_ts(0), "today", None);
+        insert_entry(&conn, noon_ts(1), "yesterday", None);
+        insert_entry(&conn, noon_ts(2), "two days ago", None);
+        insert_entry(&conn, noon_ts(4), "gap before", None);
+
+        let stats = HistoryManager::get_history_stats_with_conn(
+            &conn,
+            std::path::Path::new("/nonexistent"),
+        )
+        .expect("compute stats");
+
+        assert_eq!(stats.current_streak_days, 3);
+        assert_eq!(stats.longest_streak_days, 3);
+        assert_eq!(stats.total_dictations, 4);
+    }
+
+    #[test]
+    fn empty_post_processed_text_does_not_count_as_processed() {
+        let conn = setup_conn();
+        insert_entry(&conn, 100, "hello", Some(""));
+
+        let stats = HistoryManager::get_history_stats_with_conn(
+            &conn,
+            std::path::Path::new("/nonexistent"),
+        )
+        .expect("compute stats");
+
+        assert_eq!(stats.total_dictations, 1);
+        assert_eq!(stats.total_words, 1);
+        assert_eq!(stats.post_processed, 0);
+        assert_eq!(stats.post_process_rate, 0);
+    }
+
+    #[test]
+    fn stats_avg_wpm_from_wav_durations() {
+        let conn = setup_conn();
+        let dir = std::env::temp_dir().join(format!(
+            "handy-stats-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+
+        let wav_path = dir.join("handy-wpm.wav");
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 16_000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = hound::WavWriter::create(&wav_path, spec).expect("create wav");
+        for _ in 0..16_000 {
+            writer.write_sample(0i16).expect("write sample");
+        }
+        writer.finalize().expect("finalize wav");
+
+        // 5 words over 1 second of audio = 300 WPM
+        conn.execute(
+            "INSERT INTO transcription_history (
+                file_name, timestamp, saved, title, transcription_text
+            ) VALUES ('handy-wpm.wav', 100, false, 't', 'one two three four five')",
+            [],
+        )
+        .expect("insert entry");
+
+        let stats =
+            HistoryManager::get_history_stats_with_conn(&conn, &dir).expect("compute stats");
+
+        assert_eq!(stats.avg_wpm, Some(300.0));
+        assert_eq!(stats.total_words, 5);
+
+        std::fs::remove_file(&wav_path).ok();
+        std::fs::remove_dir(&dir).ok();
     }
 }

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -840,6 +840,14 @@ async getHistoryEntries(cursor: number | null, limit: number | null) : Promise<R
     else return { status: "error", error: e  as any };
 }
 },
+async getHistoryStats() : Promise<Result<HistoryStats, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_history_stats") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async toggleHistoryEntrySaved(id: number) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("toggle_history_entry_saved", { id }) };
@@ -987,6 +995,7 @@ export type EngineType =
 "TranscribeCpp" | "Parakeet" | "Moonshine" | "MoonshineStreaming" | "SenseVoice" | "GigaAM" | "Canary" | "Cohere"
 export type GpuDeviceOption = { id: string; name: string; total_vram_mb: number }
 export type HistoryEntry = { id: number; file_name: string; timestamp: number; saved: boolean; title: string; transcription_text: string; post_processed_text: string | null; post_process_prompt: string | null; post_process_requested: boolean }
+export type HistoryStats = { total_dictations: number; total_words: number; this_week: number; this_month: number; daily_average: number; current_streak_days: number; longest_streak_days: number; post_processed: number; post_process_rate: number; time_saved_minutes: number; avg_wpm: number | null }
 export type HistoryUpdatePayload = { action: "added"; entry: HistoryEntry } | { action: "updated"; entry: HistoryEntry } | { action: "deleted"; id: number } | { action: "toggled"; id: number }
 /**
  * Result of changing keyboard implementation

--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -8,12 +8,14 @@ import {
   commands,
   events,
   type HistoryEntry,
+  type HistoryStats,
   type HistoryUpdatePayload,
 } from "@/bindings";
 import { useOsType } from "@/hooks/useOsType";
 import { formatDateTime } from "@/utils/dateFormat";
 import { AudioPlayer, AudioPlayerGroup } from "../../ui/AudioPlayer";
 import { Button } from "../../ui/Button";
+import { SettingsGroup } from "../../ui/SettingsGroup";
 
 const IconButton: React.FC<{
   onClick: () => void;
@@ -59,15 +61,45 @@ const OpenRecordingsButton: React.FC<OpenRecordingsButtonProps> = ({
   </Button>
 );
 
+const formatTimeSaved = (
+  minutes: number,
+  t: (key: string, options?: Record<string, string | number>) => string,
+): string => {
+  const total = Math.max(0, Math.round(minutes));
+  const hours = Math.floor(total / 60);
+  const remaining = total % 60;
+  if (hours > 0) {
+    return t("settings.history.stats.timeSavedHoursMinutes", {
+      hours,
+      minutes: remaining,
+    });
+  }
+  return t("settings.history.stats.timeSavedMinutesOnly", {
+    minutes: remaining,
+  });
+};
+
+const StatsRow: React.FC<{ title: string; value: string }> = ({
+  title,
+  value,
+}) => (
+  <div className="flex items-center justify-between min-h-12 px-4 p-2">
+    <h3 className="text-sm font-medium">{title}</h3>
+    <p className="text-sm tabular-nums">{value}</p>
+  </div>
+);
+
 export const HistorySettings: React.FC = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const osType = useOsType();
   const [entries, setEntries] = useState<HistoryEntry[]>([]);
+  const [stats, setStats] = useState<HistoryStats | null>(null);
   const [loading, setLoading] = useState(true);
   const [hasMore, setHasMore] = useState(true);
   const sentinelRef = useRef<HTMLDivElement>(null);
   const entriesRef = useRef<HistoryEntry[]>([]);
   const loadingRef = useRef(false);
+  const statsRequestRef = useRef(0);
 
   // Keep ref in sync for use in IntersectionObserver callback
   useEffect(() => {
@@ -101,10 +133,27 @@ export const HistorySettings: React.FC = () => {
     }
   }, []);
 
+  const loadStats = useCallback(async () => {
+    const requestId = statsRequestRef.current + 1;
+    statsRequestRef.current = requestId;
+    try {
+      const result = await commands.getHistoryStats();
+      if (requestId !== statsRequestRef.current) {
+        return;
+      }
+      if (result.status === "ok") {
+        setStats(result.data);
+      }
+    } catch (error) {
+      console.error("Failed to load history stats:", error);
+    }
+  }, []);
+
   // Initial load
   useEffect(() => {
     loadPage();
-  }, [loadPage]);
+    loadStats();
+  }, [loadPage, loadStats]);
 
   // Infinite scroll via IntersectionObserver
   useEffect(() => {
@@ -136,19 +185,22 @@ export const HistorySettings: React.FC = () => {
       const payload: HistoryUpdatePayload = event.payload;
       if (payload.action === "added") {
         setEntries((prev) => [payload.entry, ...prev]);
+        loadStats();
       } else if (payload.action === "updated") {
         setEntries((prev) =>
           prev.map((e) => (e.id === payload.entry.id ? payload.entry : e)),
         );
+        loadStats();
+      } else if (payload.action === "deleted") {
+        loadStats();
       }
-      // "deleted" and "toggled" are handled by optimistic updates only,
-      // so we intentionally ignore them here to avoid double-mutation.
+      // "toggled" is handled by optimistic updates only.
     });
 
     return () => {
       unlisten.then((fn) => fn());
     };
-  }, []);
+  }, [loadStats]);
 
   const toggleSaved = async (id: number) => {
     // Optimistic update
@@ -272,8 +324,71 @@ export const HistorySettings: React.FC = () => {
     );
   }
 
+  const numberFormat = new Intl.NumberFormat(i18n.language);
+  const statsCard = stats ? (
+    <SettingsGroup title={t("settings.history.stats.title")}>
+      <dl className="grid grid-cols-3 gap-2 px-4 py-4">
+        <div className="text-center flex flex-col-reverse">
+          <dt className="text-xs font-medium text-mid-gray uppercase tracking-wide">
+            {t("settings.history.stats.words")}
+          </dt>
+          <dd className="text-2xl font-medium tabular-nums">
+            {numberFormat.format(stats.total_words)}
+          </dd>
+        </div>
+        <div className="text-center flex flex-col-reverse">
+          <dt className="text-xs font-medium text-mid-gray uppercase tracking-wide">
+            {t("settings.history.stats.timeSaved")}
+          </dt>
+          <dd className="text-2xl font-medium tabular-nums">
+            {formatTimeSaved(stats.time_saved_minutes, t)}
+          </dd>
+        </div>
+        <div className="text-center flex flex-col-reverse">
+          <dt className="text-xs font-medium text-mid-gray uppercase tracking-wide">
+            {t("settings.history.stats.avgSpeed")}
+          </dt>
+          <dd className="text-2xl font-medium tabular-nums">
+            {stats.avg_wpm === null
+              ? t("settings.history.stats.unavailable")
+              : t("settings.history.stats.wpm", {
+                  value: numberFormat.format(stats.avg_wpm),
+                })}
+          </dd>
+        </div>
+      </dl>
+      <StatsRow
+        title={t("settings.history.stats.total")}
+        value={numberFormat.format(stats.total_dictations)}
+      />
+      <StatsRow
+        title={t("settings.history.stats.thisWeekMonth")}
+        value={`${numberFormat.format(stats.this_week)} / ${numberFormat.format(stats.this_month)}`}
+      />
+      <StatsRow
+        title={t("settings.history.stats.dailyAverage")}
+        value={numberFormat.format(stats.daily_average)}
+      />
+      <StatsRow
+        title={t("settings.history.stats.streak")}
+        value={t("settings.history.stats.streakValue", {
+          current: stats.current_streak_days,
+          best: stats.longest_streak_days,
+        })}
+      />
+      <StatsRow
+        title={t("settings.history.stats.postProcessed")}
+        value={t("settings.history.stats.postProcessedValue", {
+          count: stats.post_processed,
+          percent: stats.post_process_rate,
+        })}
+      />
+    </SettingsGroup>
+  ) : null;
+
   return (
     <div className="max-w-3xl w-full mx-auto space-y-6">
+      {statsCard}
       <div className="space-y-2">
         <div className="px-4 flex items-center justify-between">
           <div>

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -426,7 +426,24 @@
       "retranscribe": "إعادة النسخ",
       "retranscribeError": "فشلت إعادة النسخ. يرجى المحاولة مرة أخرى.",
       "transcribing": "جارٍ النسخ...",
-      "transcriptionFailed": "فشل النسخ. يمكنك إعادة النسخ باستخدام أيقونة إعادة المحاولة."
+      "transcriptionFailed": "فشل النسخ. يمكنك إعادة النسخ باستخدام أيقونة إعادة المحاولة.",
+      "stats": {
+        "title": "Usage",
+        "words": "Words dictated",
+        "timeSaved": "Time saved",
+        "avgSpeed": "Avg speed",
+        "unavailable": "—",
+        "wpm": "{{value}} WPM",
+        "total": "Total dictations",
+        "thisWeekMonth": "This week / this month",
+        "dailyAverage": "Daily average",
+        "streak": "Streak",
+        "streakValue": "{{current}}-day current, {{best}}-day best",
+        "postProcessed": "Post-processed",
+        "postProcessedValue": "{{count}} ({{percent}}%)",
+        "timeSavedHoursMinutes": "{{hours}}h {{minutes}}m",
+        "timeSavedMinutesOnly": "{{minutes}}m"
+      }
     },
     "debug": {
       "title": "تصحيح الأخطاء",

--- a/src/i18n/locales/bg/translation.json
+++ b/src/i18n/locales/bg/translation.json
@@ -449,7 +449,24 @@
       "retranscribe": "Повторна транскрипция",
       "retranscribeError": "Повторната транскрипция не бе успешна. Опитайте отново.",
       "transcribing": "Транскрибиране...",
-      "transcriptionFailed": "Транскрипцията не бе успешна. Можете да опитате отново с иконата за повторен опит."
+      "transcriptionFailed": "Транскрипцията не бе успешна. Можете да опитате отново с иконата за повторен опит.",
+      "stats": {
+        "title": "Usage",
+        "words": "Words dictated",
+        "timeSaved": "Time saved",
+        "avgSpeed": "Avg speed",
+        "unavailable": "—",
+        "wpm": "{{value}} WPM",
+        "total": "Total dictations",
+        "thisWeekMonth": "This week / this month",
+        "dailyAverage": "Daily average",
+        "streak": "Streak",
+        "streakValue": "{{current}}-day current, {{best}}-day best",
+        "postProcessed": "Post-processed",
+        "postProcessedValue": "{{count}} ({{percent}}%)",
+        "timeSavedHoursMinutes": "{{hours}}h {{minutes}}m",
+        "timeSavedMinutesOnly": "{{minutes}}m"
+      }
     },
     "debug": {
       "title": "Отстраняване",

--- a/src/i18n/locales/cs/translation.json
+++ b/src/i18n/locales/cs/translation.json
@@ -449,7 +449,24 @@
       "retranscribe": "Přepsat znovu",
       "retranscribeError": "Opětovný přepis se nezdařil. Zkuste to prosím znovu.",
       "transcribing": "Přepisuji...",
-      "transcriptionFailed": "Přepis selhal. Můžete zkusit přepis znovu pomocí ikony opakování."
+      "transcriptionFailed": "Přepis selhal. Můžete zkusit přepis znovu pomocí ikony opakování.",
+      "stats": {
+        "title": "Usage",
+        "words": "Words dictated",
+        "timeSaved": "Time saved",
+        "avgSpeed": "Avg speed",
+        "unavailable": "—",
+        "wpm": "{{value}} WPM",
+        "total": "Total dictations",
+        "thisWeekMonth": "This week / this month",
+        "dailyAverage": "Daily average",
+        "streak": "Streak",
+        "streakValue": "{{current}}-day current, {{best}}-day best",
+        "postProcessed": "Post-processed",
+        "postProcessedValue": "{{count}} ({{percent}}%)",
+        "timeSavedHoursMinutes": "{{hours}}h {{minutes}}m",
+        "timeSavedMinutesOnly": "{{minutes}}m"
+      }
     },
     "debug": {
       "title": "Ladění",

--- a/src/i18n/locales/da/translation.json
+++ b/src/i18n/locales/da/translation.json
@@ -449,7 +449,24 @@
       "retranscribe": "Transskribér igen",
       "retranscribeError": "Kunne ikke transskribere igen. Prøv igen.",
       "transcribing": "Transskriberer...",
-      "transcriptionFailed": "Transskription mislykkedes. Du kan transskribere igen ved hjælp af genforsøgsikonet."
+      "transcriptionFailed": "Transskription mislykkedes. Du kan transskribere igen ved hjælp af genforsøgsikonet.",
+      "stats": {
+        "title": "Usage",
+        "words": "Words dictated",
+        "timeSaved": "Time saved",
+        "avgSpeed": "Avg speed",
+        "unavailable": "—",
+        "wpm": "{{value}} WPM",
+        "total": "Total dictations",
+        "thisWeekMonth": "This week / this month",
+        "dailyAverage": "Daily average",
+        "streak": "Streak",
+        "streakValue": "{{current}}-day current, {{best}}-day best",
+        "postProcessed": "Post-processed",
+        "postProcessedValue": "{{count}} ({{percent}}%)",
+        "timeSavedHoursMinutes": "{{hours}}h {{minutes}}m",
+        "timeSavedMinutesOnly": "{{minutes}}m"
+      }
     },
     "debug": {
       "title": "Fejlfinding",

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -449,7 +449,24 @@
       "retranscribe": "Erneut transkribieren",
       "retranscribeError": "Erneute Transkription fehlgeschlagen. Bitte versuche es erneut.",
       "transcribing": "Transkribiere...",
-      "transcriptionFailed": "Transkription fehlgeschlagen. Du kannst über das Wiederholen-Symbol erneut transkribieren."
+      "transcriptionFailed": "Transkription fehlgeschlagen. Du kannst über das Wiederholen-Symbol erneut transkribieren.",
+      "stats": {
+        "title": "Usage",
+        "words": "Words dictated",
+        "timeSaved": "Time saved",
+        "avgSpeed": "Avg speed",
+        "unavailable": "—",
+        "wpm": "{{value}} WPM",
+        "total": "Total dictations",
+        "thisWeekMonth": "This week / this month",
+        "dailyAverage": "Daily average",
+        "streak": "Streak",
+        "streakValue": "{{current}}-day current, {{best}}-day best",
+        "postProcessed": "Post-processed",
+        "postProcessedValue": "{{count}} ({{percent}}%)",
+        "timeSavedHoursMinutes": "{{hours}}h {{minutes}}m",
+        "timeSavedMinutesOnly": "{{minutes}}m"
+      }
     },
     "debug": {
       "title": "Debug",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -449,7 +449,24 @@
       "retranscribe": "Re-transcribe",
       "retranscribeError": "Failed to re-transcribe. Please try again.",
       "transcribing": "Transcribing...",
-      "transcriptionFailed": "Transcription failed. You can re-transcribe using the retry icon."
+      "transcriptionFailed": "Transcription failed. You can re-transcribe using the retry icon.",
+      "stats": {
+        "title": "Usage",
+        "words": "Words dictated",
+        "timeSaved": "Time saved",
+        "avgSpeed": "Avg speed",
+        "unavailable": "—",
+        "wpm": "{{value}} WPM",
+        "total": "Total dictations",
+        "thisWeekMonth": "This week / this month",
+        "dailyAverage": "Daily average",
+        "streak": "Streak",
+        "streakValue": "{{current}}-day current, {{best}}-day best",
+        "postProcessed": "Post-processed",
+        "postProcessedValue": "{{count}} ({{percent}}%)",
+        "timeSavedHoursMinutes": "{{hours}}h {{minutes}}m",
+        "timeSavedMinutesOnly": "{{minutes}}m"
+      }
     },
     "debug": {
       "title": "Debug",

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -449,7 +449,24 @@
       "retranscribe": "Re-transcribir",
       "retranscribeError": "No se pudo re-transcribir. Por favor, inténtalo de nuevo.",
       "transcribing": "Transcribiendo...",
-      "transcriptionFailed": "La transcripción falló. Puedes re-transcribir usando el icono de reintentar."
+      "transcriptionFailed": "La transcripción falló. Puedes re-transcribir usando el icono de reintentar.",
+      "stats": {
+        "title": "Usage",
+        "words": "Words dictated",
+        "timeSaved": "Time saved",
+        "avgSpeed": "Avg speed",
+        "unavailable": "—",
+        "wpm": "{{value}} WPM",
+        "total": "Total dictations",
+        "thisWeekMonth": "This week / this month",
+        "dailyAverage": "Daily average",
+        "streak": "Streak",
+        "streakValue": "{{current}}-day current, {{best}}-day best",
+        "postProcessed": "Post-processed",
+        "postProcessedValue": "{{count}} ({{percent}}%)",
+        "timeSavedHoursMinutes": "{{hours}}h {{minutes}}m",
+        "timeSavedMinutesOnly": "{{minutes}}m"
+      }
     },
     "debug": {
       "title": "Depuración",

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -449,7 +449,24 @@
       "retranscribe": "Re-transcrire",
       "retranscribeError": "Impossible de re-transcrire. Veuillez réessayer.",
       "transcribing": "Transcription en cours...",
-      "transcriptionFailed": "La transcription a échoué. Vous pouvez re-transcrire en utilisant l'icône de réessai."
+      "transcriptionFailed": "La transcription a échoué. Vous pouvez re-transcrire en utilisant l'icône de réessai.",
+      "stats": {
+        "title": "Usage",
+        "words": "Words dictated",
+        "timeSaved": "Time saved",
+        "avgSpeed": "Avg speed",
+        "unavailable": "—",
+        "wpm": "{{value}} WPM",
+        "total": "Total dictations",
+        "thisWeekMonth": "This week / this month",
+        "dailyAverage": "Daily average",
+        "streak": "Streak",
+        "streakValue": "{{current}}-day current, {{best}}-day best",
+        "postProcessed": "Post-processed",
+        "postProcessedValue": "{{count}} ({{percent}}%)",
+        "timeSavedHoursMinutes": "{{hours}}h {{minutes}}m",
+        "timeSavedMinutesOnly": "{{minutes}}m"
+      }
     },
     "debug": {
       "title": "Débogage",

--- a/src/i18n/locales/he/translation.json
+++ b/src/i18n/locales/he/translation.json
@@ -449,7 +449,24 @@
       "retranscribe": "תמלל מחדש",
       "retranscribeError": "תמלול מחדש נכשל. נסה שוב.",
       "transcribing": "מתמלל...",
-      "transcriptionFailed": "התמלול נכשל. אפשר לתמלל מחדש באמצעות אייקון הניסיון החוזר."
+      "transcriptionFailed": "התמלול נכשל. אפשר לתמלל מחדש באמצעות אייקון הניסיון החוזר.",
+      "stats": {
+        "title": "Usage",
+        "words": "Words dictated",
+        "timeSaved": "Time saved",
+        "avgSpeed": "Avg speed",
+        "unavailable": "—",
+        "wpm": "{{value}} WPM",
+        "total": "Total dictations",
+        "thisWeekMonth": "This week / this month",
+        "dailyAverage": "Daily average",
+        "streak": "Streak",
+        "streakValue": "{{current}}-day current, {{best}}-day best",
+        "postProcessed": "Post-processed",
+        "postProcessedValue": "{{count}} ({{percent}}%)",
+        "timeSavedHoursMinutes": "{{hours}}h {{minutes}}m",
+        "timeSavedMinutesOnly": "{{minutes}}m"
+      }
     },
     "debug": {
       "title": "ניפוי שגיאות",

--- a/src/i18n/locales/hi/translation.json
+++ b/src/i18n/locales/hi/translation.json
@@ -449,7 +449,24 @@
       "retranscribe": "फिर से ट्रांसक्राइब करें",
       "retranscribeError": "फिर से ट्रांसक्राइब नहीं किया जा सका. कृपया फिर से कोशिश करें.",
       "transcribing": "ट्रांसक्राइब हो रहा है...",
-      "transcriptionFailed": "ट्रांसक्रिप्शन नहीं हो सका. आप रीट्राई आइकन से फिर से ट्रांसक्राइब कर सकते हैं."
+      "transcriptionFailed": "ट्रांसक्रिप्शन नहीं हो सका. आप रीट्राई आइकन से फिर से ट्रांसक्राइब कर सकते हैं.",
+      "stats": {
+        "title": "Usage",
+        "words": "Words dictated",
+        "timeSaved": "Time saved",
+        "avgSpeed": "Avg speed",
+        "unavailable": "—",
+        "wpm": "{{value}} WPM",
+        "total": "Total dictations",
+        "thisWeekMonth": "This week / this month",
+        "dailyAverage": "Daily average",
+        "streak": "Streak",
+        "streakValue": "{{current}}-day current, {{best}}-day best",
+        "postProcessed": "Post-processed",
+        "postProcessedValue": "{{count}} ({{percent}}%)",
+        "timeSavedHoursMinutes": "{{hours}}h {{minutes}}m",
+        "timeSavedMinutesOnly": "{{minutes}}m"
+      }
     },
     "debug": {
       "title": "डिबग",

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -449,7 +449,24 @@
       "retranscribe": "Ri-trascrivere",
       "retranscribeError": "Impossibile ri-trascrivere. Riprova.",
       "transcribing": "Trascrizione in corso...",
-      "transcriptionFailed": "Trascrizione fallita. Puoi ri-trascrivere usando l'icona di ripetizione."
+      "transcriptionFailed": "Trascrizione fallita. Puoi ri-trascrivere usando l'icona di ripetizione.",
+      "stats": {
+        "title": "Usage",
+        "words": "Words dictated",
+        "timeSaved": "Time saved",
+        "avgSpeed": "Avg speed",
+        "unavailable": "—",
+        "wpm": "{{value}} WPM",
+        "total": "Total dictations",
+        "thisWeekMonth": "This week / this month",
+        "dailyAverage": "Daily average",
+        "streak": "Streak",
+        "streakValue": "{{current}}-day current, {{best}}-day best",
+        "postProcessed": "Post-processed",
+        "postProcessedValue": "{{count}} ({{percent}}%)",
+        "timeSavedHoursMinutes": "{{hours}}h {{minutes}}m",
+        "timeSavedMinutesOnly": "{{minutes}}m"
+      }
     },
     "debug": {
       "title": "Debug",

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -449,7 +449,24 @@
       "retranscribe": "再文字起こし",
       "retranscribeError": "再文字起こしに失敗しました。もう一度お試しください。",
       "transcribing": "文字起こし中…",
-      "transcriptionFailed": "文字起こしに失敗しました。リトライアイコンを使用して再文字起こしできます。"
+      "transcriptionFailed": "文字起こしに失敗しました。リトライアイコンを使用して再文字起こしできます。",
+      "stats": {
+        "title": "Usage",
+        "words": "Words dictated",
+        "timeSaved": "Time saved",
+        "avgSpeed": "Avg speed",
+        "unavailable": "—",
+        "wpm": "{{value}} WPM",
+        "total": "Total dictations",
+        "thisWeekMonth": "This week / this month",
+        "dailyAverage": "Daily average",
+        "streak": "Streak",
+        "streakValue": "{{current}}-day current, {{best}}-day best",
+        "postProcessed": "Post-processed",
+        "postProcessedValue": "{{count}} ({{percent}}%)",
+        "timeSavedHoursMinutes": "{{hours}}h {{minutes}}m",
+        "timeSavedMinutesOnly": "{{minutes}}m"
+      }
     },
     "debug": {
       "title": "デバッグ",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -449,7 +449,24 @@
       "retranscribe": "다시 전사",
       "retranscribeError": "다시 전사에 실패했습니다. 다시 시도해주세요.",
       "transcribing": "전사 중...",
-      "transcriptionFailed": "전사에 실패했습니다. 재시도 아이콘을 사용하여 다시 전사할 수 있습니다."
+      "transcriptionFailed": "전사에 실패했습니다. 재시도 아이콘을 사용하여 다시 전사할 수 있습니다.",
+      "stats": {
+        "title": "Usage",
+        "words": "Words dictated",
+        "timeSaved": "Time saved",
+        "avgSpeed": "Avg speed",
+        "unavailable": "—",
+        "wpm": "{{value}} WPM",
+        "total": "Total dictations",
+        "thisWeekMonth": "This week / this month",
+        "dailyAverage": "Daily average",
+        "streak": "Streak",
+        "streakValue": "{{current}}-day current, {{best}}-day best",
+        "postProcessed": "Post-processed",
+        "postProcessedValue": "{{count}} ({{percent}}%)",
+        "timeSavedHoursMinutes": "{{hours}}h {{minutes}}m",
+        "timeSavedMinutesOnly": "{{minutes}}m"
+      }
     },
     "debug": {
       "title": "디버그",

--- a/src/i18n/locales/ne/translation.json
+++ b/src/i18n/locales/ne/translation.json
@@ -449,7 +449,24 @@
       "retranscribe": "फेरि ट्रान्सक्राइब गर्नुहोस्",
       "retranscribeError": "फेरि ट्रान्सक्राइब गर्न सकिएन। कृपया फेरि प्रयास गर्नुहोस्।",
       "transcribing": "ट्रान्सक्राइब गरिँदैछ...",
-      "transcriptionFailed": "ट्रान्सक्रिप्सन गर्न सकिएन। रिट्राई आइकन प्रयोग गरेर फेरि ट्रान्सक्राइब गर्न सक्नुहुन्छ।"
+      "transcriptionFailed": "ट्रान्सक्रिप्सन गर्न सकिएन। रिट्राई आइकन प्रयोग गरेर फेरि ट्रान्सक्राइब गर्न सक्नुहुन्छ।",
+      "stats": {
+        "title": "Usage",
+        "words": "Words dictated",
+        "timeSaved": "Time saved",
+        "avgSpeed": "Avg speed",
+        "unavailable": "—",
+        "wpm": "{{value}} WPM",
+        "total": "Total dictations",
+        "thisWeekMonth": "This week / this month",
+        "dailyAverage": "Daily average",
+        "streak": "Streak",
+        "streakValue": "{{current}}-day current, {{best}}-day best",
+        "postProcessed": "Post-processed",
+        "postProcessedValue": "{{count}} ({{percent}}%)",
+        "timeSavedHoursMinutes": "{{hours}}h {{minutes}}m",
+        "timeSavedMinutesOnly": "{{minutes}}m"
+      }
     },
     "debug": {
       "title": "डिबग",

--- a/src/i18n/locales/nl/translation.json
+++ b/src/i18n/locales/nl/translation.json
@@ -449,7 +449,24 @@
       "retranscribe": "Opnieuw transcriberen",
       "retranscribeError": "Opnieuw transcriberen mislukt. Probeer het opnieuw.",
       "transcribing": "Transcriberen...",
-      "transcriptionFailed": "Transcriptie mislukt. Je kunt het opnieuw proberen via het herlaad-pictogram."
+      "transcriptionFailed": "Transcriptie mislukt. Je kunt het opnieuw proberen via het herlaad-pictogram.",
+      "stats": {
+        "title": "Usage",
+        "words": "Words dictated",
+        "timeSaved": "Time saved",
+        "avgSpeed": "Avg speed",
+        "unavailable": "—",
+        "wpm": "{{value}} WPM",
+        "total": "Total dictations",
+        "thisWeekMonth": "This week / this month",
+        "dailyAverage": "Daily average",
+        "streak": "Streak",
+        "streakValue": "{{current}}-day current, {{best}}-day best",
+        "postProcessed": "Post-processed",
+        "postProcessedValue": "{{count}} ({{percent}}%)",
+        "timeSavedHoursMinutes": "{{hours}}h {{minutes}}m",
+        "timeSavedMinutesOnly": "{{minutes}}m"
+      }
     },
     "debug": {
       "title": "Probleemoplossing",

--- a/src/i18n/locales/pl/translation.json
+++ b/src/i18n/locales/pl/translation.json
@@ -449,7 +449,24 @@
       "retranscribe": "Transkrybuj ponownie",
       "retranscribeError": "Nie udało się ponownie transkrybować. Spróbuj ponownie.",
       "transcribing": "Transkrybuję...",
-      "transcriptionFailed": "Transkrypcja nie powiodła się. Możesz transkrybować ponownie za pomocą ikony ponowienia."
+      "transcriptionFailed": "Transkrypcja nie powiodła się. Możesz transkrybować ponownie za pomocą ikony ponowienia.",
+      "stats": {
+        "title": "Usage",
+        "words": "Words dictated",
+        "timeSaved": "Time saved",
+        "avgSpeed": "Avg speed",
+        "unavailable": "—",
+        "wpm": "{{value}} WPM",
+        "total": "Total dictations",
+        "thisWeekMonth": "This week / this month",
+        "dailyAverage": "Daily average",
+        "streak": "Streak",
+        "streakValue": "{{current}}-day current, {{best}}-day best",
+        "postProcessed": "Post-processed",
+        "postProcessedValue": "{{count}} ({{percent}}%)",
+        "timeSavedHoursMinutes": "{{hours}}h {{minutes}}m",
+        "timeSavedMinutesOnly": "{{minutes}}m"
+      }
     },
     "debug": {
       "title": "Debugowanie",

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -449,7 +449,24 @@
       "retranscribe": "Re-transcrever",
       "retranscribeError": "Falha ao re-transcrever. Por favor, tente novamente.",
       "transcribing": "Transcrevendo...",
-      "transcriptionFailed": "A transcrição falhou. Você pode re-transcrever usando o ícone de tentar novamente."
+      "transcriptionFailed": "A transcrição falhou. Você pode re-transcrever usando o ícone de tentar novamente.",
+      "stats": {
+        "title": "Usage",
+        "words": "Words dictated",
+        "timeSaved": "Time saved",
+        "avgSpeed": "Avg speed",
+        "unavailable": "—",
+        "wpm": "{{value}} WPM",
+        "total": "Total dictations",
+        "thisWeekMonth": "This week / this month",
+        "dailyAverage": "Daily average",
+        "streak": "Streak",
+        "streakValue": "{{current}}-day current, {{best}}-day best",
+        "postProcessed": "Post-processed",
+        "postProcessedValue": "{{count}} ({{percent}}%)",
+        "timeSavedHoursMinutes": "{{hours}}h {{minutes}}m",
+        "timeSavedMinutesOnly": "{{minutes}}m"
+      }
     },
     "debug": {
       "title": "Depuração",

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -449,7 +449,24 @@
       "retranscribe": "Перетранскрибировать",
       "retranscribeError": "Не удалось перетранскрибировать. Пожалуйста, попробуйте снова.",
       "transcribing": "Транскрибирование...",
-      "transcriptionFailed": "Транскрипция не удалась. Вы можете перетранскрибировать, используя значок повтора."
+      "transcriptionFailed": "Транскрипция не удалась. Вы можете перетранскрибировать, используя значок повтора.",
+      "stats": {
+        "title": "Usage",
+        "words": "Words dictated",
+        "timeSaved": "Time saved",
+        "avgSpeed": "Avg speed",
+        "unavailable": "—",
+        "wpm": "{{value}} WPM",
+        "total": "Total dictations",
+        "thisWeekMonth": "This week / this month",
+        "dailyAverage": "Daily average",
+        "streak": "Streak",
+        "streakValue": "{{current}}-day current, {{best}}-day best",
+        "postProcessed": "Post-processed",
+        "postProcessedValue": "{{count}} ({{percent}}%)",
+        "timeSavedHoursMinutes": "{{hours}}h {{minutes}}m",
+        "timeSavedMinutesOnly": "{{minutes}}m"
+      }
     },
     "debug": {
       "title": "Отлаживать",

--- a/src/i18n/locales/sv/translation.json
+++ b/src/i18n/locales/sv/translation.json
@@ -449,7 +449,24 @@
       "retranscribe": "Transkribera igen",
       "retranscribeError": "Misslyckades med att transkribera igen. Försök igen.",
       "transcribing": "Transkriberar...",
-      "transcriptionFailed": "Transkribering misslyckades. Du kan transkribera igen med hjälp av ikonen för nytt försök."
+      "transcriptionFailed": "Transkribering misslyckades. Du kan transkribera igen med hjälp av ikonen för nytt försök.",
+      "stats": {
+        "title": "Usage",
+        "words": "Words dictated",
+        "timeSaved": "Time saved",
+        "avgSpeed": "Avg speed",
+        "unavailable": "—",
+        "wpm": "{{value}} WPM",
+        "total": "Total dictations",
+        "thisWeekMonth": "This week / this month",
+        "dailyAverage": "Daily average",
+        "streak": "Streak",
+        "streakValue": "{{current}}-day current, {{best}}-day best",
+        "postProcessed": "Post-processed",
+        "postProcessedValue": "{{count}} ({{percent}}%)",
+        "timeSavedHoursMinutes": "{{hours}}h {{minutes}}m",
+        "timeSavedMinutesOnly": "{{minutes}}m"
+      }
     },
     "debug": {
       "title": "Felsökning",

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -449,7 +449,24 @@
       "retranscribe": "Yeniden transkribe et",
       "retranscribeError": "Yeniden transkripsiyon başarısız oldu. Lütfen tekrar deneyin.",
       "transcribing": "Transkribe ediliyor...",
-      "transcriptionFailed": "Transkripsiyon başarısız oldu. Yeniden deneme simgesini kullanarak tekrar transkribe edebilirsiniz."
+      "transcriptionFailed": "Transkripsiyon başarısız oldu. Yeniden deneme simgesini kullanarak tekrar transkribe edebilirsiniz.",
+      "stats": {
+        "title": "Usage",
+        "words": "Words dictated",
+        "timeSaved": "Time saved",
+        "avgSpeed": "Avg speed",
+        "unavailable": "—",
+        "wpm": "{{value}} WPM",
+        "total": "Total dictations",
+        "thisWeekMonth": "This week / this month",
+        "dailyAverage": "Daily average",
+        "streak": "Streak",
+        "streakValue": "{{current}}-day current, {{best}}-day best",
+        "postProcessed": "Post-processed",
+        "postProcessedValue": "{{count}} ({{percent}}%)",
+        "timeSavedHoursMinutes": "{{hours}}h {{minutes}}m",
+        "timeSavedMinutesOnly": "{{minutes}}m"
+      }
     },
     "debug": {
       "title": "Hata Ayıklama",

--- a/src/i18n/locales/uk/translation.json
+++ b/src/i18n/locales/uk/translation.json
@@ -449,7 +449,24 @@
       "retranscribe": "Перетранскрибувати",
       "retranscribeError": "Не вдалося перетранскрибувати. Будь ласка, спробуйте ще раз.",
       "transcribing": "Транскрибування...",
-      "transcriptionFailed": "Транскрипція не вдалася. Ви можете перетранскрибувати за допомогою іконки повтору."
+      "transcriptionFailed": "Транскрипція не вдалася. Ви можете перетранскрибувати за допомогою іконки повтору.",
+      "stats": {
+        "title": "Usage",
+        "words": "Words dictated",
+        "timeSaved": "Time saved",
+        "avgSpeed": "Avg speed",
+        "unavailable": "—",
+        "wpm": "{{value}} WPM",
+        "total": "Total dictations",
+        "thisWeekMonth": "This week / this month",
+        "dailyAverage": "Daily average",
+        "streak": "Streak",
+        "streakValue": "{{current}}-day current, {{best}}-day best",
+        "postProcessed": "Post-processed",
+        "postProcessedValue": "{{count}} ({{percent}}%)",
+        "timeSavedHoursMinutes": "{{hours}}h {{minutes}}m",
+        "timeSavedMinutesOnly": "{{minutes}}m"
+      }
     },
     "debug": {
       "title": "Дебаг",

--- a/src/i18n/locales/vi/translation.json
+++ b/src/i18n/locales/vi/translation.json
@@ -449,7 +449,24 @@
       "retranscribe": "Phiên âm lại",
       "retranscribeError": "Không thể phiên âm lại. Vui lòng thử lại.",
       "transcribing": "Đang phiên âm...",
-      "transcriptionFailed": "Phiên âm thất bại. Bạn có thể phiên âm lại bằng biểu tượng thử lại."
+      "transcriptionFailed": "Phiên âm thất bại. Bạn có thể phiên âm lại bằng biểu tượng thử lại.",
+      "stats": {
+        "title": "Usage",
+        "words": "Words dictated",
+        "timeSaved": "Time saved",
+        "avgSpeed": "Avg speed",
+        "unavailable": "—",
+        "wpm": "{{value}} WPM",
+        "total": "Total dictations",
+        "thisWeekMonth": "This week / this month",
+        "dailyAverage": "Daily average",
+        "streak": "Streak",
+        "streakValue": "{{current}}-day current, {{best}}-day best",
+        "postProcessed": "Post-processed",
+        "postProcessedValue": "{{count}} ({{percent}}%)",
+        "timeSavedHoursMinutes": "{{hours}}h {{minutes}}m",
+        "timeSavedMinutesOnly": "{{minutes}}m"
+      }
     },
     "debug": {
       "title": "Gỡ lỗi",

--- a/src/i18n/locales/zh-TW/translation.json
+++ b/src/i18n/locales/zh-TW/translation.json
@@ -449,7 +449,24 @@
       "retranscribe": "重新轉錄",
       "retranscribeError": "重新轉錄失敗，請重試。",
       "transcribing": "轉錄中...",
-      "transcriptionFailed": "轉錄失敗。您可以使用重試圖示重新轉錄。"
+      "transcriptionFailed": "轉錄失敗。您可以使用重試圖示重新轉錄。",
+      "stats": {
+        "title": "Usage",
+        "words": "Words dictated",
+        "timeSaved": "Time saved",
+        "avgSpeed": "Avg speed",
+        "unavailable": "—",
+        "wpm": "{{value}} WPM",
+        "total": "Total dictations",
+        "thisWeekMonth": "This week / this month",
+        "dailyAverage": "Daily average",
+        "streak": "Streak",
+        "streakValue": "{{current}}-day current, {{best}}-day best",
+        "postProcessed": "Post-processed",
+        "postProcessedValue": "{{count}} ({{percent}}%)",
+        "timeSavedHoursMinutes": "{{hours}}h {{minutes}}m",
+        "timeSavedMinutesOnly": "{{minutes}}m"
+      }
     },
     "debug": {
       "title": "偵錯",

--- a/src/i18n/locales/zh/translation.json
+++ b/src/i18n/locales/zh/translation.json
@@ -449,7 +449,24 @@
       "retranscribe": "重新转录",
       "retranscribeError": "重新转录失败。请重试。",
       "transcribing": "转录中...",
-      "transcriptionFailed": "转录失败。您可以使用重试图标重新转录。"
+      "transcriptionFailed": "转录失败。您可以使用重试图标重新转录。",
+      "stats": {
+        "title": "Usage",
+        "words": "Words dictated",
+        "timeSaved": "Time saved",
+        "avgSpeed": "Avg speed",
+        "unavailable": "—",
+        "wpm": "{{value}} WPM",
+        "total": "Total dictations",
+        "thisWeekMonth": "This week / this month",
+        "dailyAverage": "Daily average",
+        "streak": "Streak",
+        "streakValue": "{{current}}-day current, {{best}}-day best",
+        "postProcessed": "Post-processed",
+        "postProcessedValue": "{{count}} ({{percent}}%)",
+        "timeSavedHoursMinutes": "{{hours}}h {{minutes}}m",
+        "timeSavedMinutesOnly": "{{minutes}}m"
+      }
     },
     "debug": {
       "title": "调试",


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [x] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

Handy already stores every finished dictation locally, but History is only a list. I use Willow Voice and WisprFlow style numbers (words, time saved, speed, streak) and wanted the same view without sending audio off the machine. The earlier stats PR died on translation-key parity. This one keeps key parity (English placeholders in other locales) and uses real WAV durations for speed instead of a guessed speaking rate.

## Related Issues/Discussions

Related: #1086

The closed PR added a usage table and was closed the same day with no review comments. This is a new implementation: SQL aggregates, local-day streaks, Willow's published time-saved formula (`words × (1/40 − 1/150)` minutes), and average WPM from WAV headers. Apps-used and correction counts are omitted because Handy does not store them.

## Community Feedback

I did not open a new discussion. Interest already exists in #1086. I can start a discussion if that is required under the feature freeze.

## Testing

- `cargo test --lib managers::history` (9 stats tests, including whitespace word counts, empty post-processed text, local-noon streaks, and a 1-second WAV WPM fixture)
- `bun run lint`
- `bun run check:translations` (23 locales)
- `bun run build`
- Live check against a real `history.db`: 88 words, 7 dictations, 99 WPM from WAV headers, 7/4 this week/this month. Those numbers matched the independent sqlite/WAV oracle and the rendered History card.

## Screenshots/Videos (if applicable)

History now opens with a Usage card (words, time saved, avg speed) above the existing list.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: ZCode (GLM-5.3) for the first backend draft; Grok 4.6 to finish, review, and open this PR
- How extensively: AI wrote the Rust aggregator, History UI, and locale keys. I specified the Willow/WisprFlow metrics, local-only data, and the install/test bar.
