### PR TITLE
docs: restore the recording indicator on Omarchy with native Wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,44 @@ Exec=env HANDY_NO_GTK_LAYER_SHELL=1 handy
 
 If a workaround helps you, please [open an issue](https://github.com/cjpais/Handy/issues) describing your distro, desktop environment, and session type — that information helps us narrow down the underlying bug.
 
+### Recording overlay is an empty outlined window on Hyprland / Omarchy
+
+If the microphone records but the overlay is an empty outlined rectangle or
+extends below the screen, check whether Handy is running through XWayland:
+
+```bash
+hyprctl clients
+```
+
+Find the Handy window and check `xwayland`. When it is `1` (or `true` in
+`hyprctl clients -j`), Handy cannot use GTK layer shell. Its overlay falls back to
+a regular window, which can be resized, decorated, or focused by the compositor.
+On Omarchy with 150% display scaling, this fallback was observed to extend below
+the screen, leaving the microphone bars out of view.
+
+For a native Linux installation with the dependencies in [BUILD.md](BUILD.md#linux),
+fully quit Handy from its tray menu, then launch it with:
+
+```bash
+GDK_BACKEND=wayland handy
+```
+
+Ensure `HANDY_NO_GTK_LAYER_SHELL` is unset and choose **Minimal** or **Live** in the
+overlay settings. During recording, `hyprctl layers` should show a
+`gtk-layer-shell` surface belonging to Handy. The microphone indicator should now
+appear without a normal window border. Launching a second instance without first
+quitting the running one only reopens its window; it does not change its backend.
+
+If this resolves the problem, apply `GDK_BACKEND=wayland` to Handy's launcher
+rather than exporting it globally. Keep global recording shortcuts in Hyprland
+using the [CLI flags](#cli-parameters).
+
+**AppImage caveat:** the 0.9.6 AppImage's generated GTK launch hook forcibly sets
+`GDK_BACKEND=x11`, overriding a value supplied by the shell. Passing the command
+above to that AppImage is therefore insufficient. Use a native installation
+(see [Linux Install](BUILD.md#linux-install-from-source)) to test this workaround.
+This does not require disabling the recording overlay or changing its animation.
+
 ### Handy Starts or Stops Recording on Its Own (Linux)
 
 Handy 0.9.4 and earlier listened for `SIGUSR1` as a remote-control trigger. WebKitGTK — the webview engine embedded in Handy on Linux — uses that same signal internally to coordinate JavaScript garbage collection, so GC cycles were misread as hotkey presses: recordings started on their own, or real dictations were cut off mid-sentence (typically ~2 minutes in). See [#1660](https://github.com/cjpais/Handy/issues/1660).


### PR DESCRIPTION
## Before Submitting This PR

- [x] I have searched existing issues and pull requests (including closed ones) to ensure this isn't a duplicate.
- [x] I have read CONTRIBUTING.md.

**If this is a feature or change that was previously closed/rejected:**

Not applicable: this is a troubleshooting documentation update, not a new feature or a resubmission.

## Human Written Description

This is a fix to allow the microphone indicator that appears when you're talking to be compatible with Omarchy

## Related Issues/Discussions

Related context: #1700 (merged Wayland overlay fix), #1909 (Wayland overlay rendering and lifecycle). This does not claim to fix either issue.

The README adds a separate diagnostic for Handy running through XWayland on Hyprland/Omarchy. On the tested machine, the regular fallback window extended below the screen and displayed a blue outline instead of the microphone bars. Running the same Handy binary with GDK_BACKEND=wayland enabled its existing GTK layer-shell overlay and restored the visible indicator.

## Community Feedback

Reported and reproduced on the contributor's Omarchy machine. No broader community confirmation has been collected. This documents a verified local workaround rather than changing the application's backend selection for all Linux users.

## Testing

- Handy 0.9.6, Omarchy/Hyprland, 1920×1200 display at 150% scaling, system WebKitGTK 2.52.6.
- Compared the same local binary with GDK_BACKEND=x11 and GDK_BACKEND=wayland. The local installation uses the executable, speech libraries and resources from the AppImage, with system GTK/WebKit libraries.
- XWayland: normal Recording window measured 342×267 logical pixels at y=685 on an 800-logical-pixel-high display; screenshot showed its border and no visible microphone bars.
- Native Wayland: screenshot showed the compact pink microphone bars; hyprctl layers reported a 256×46 gtk-layer-shell surface at (512, 714).
- Three further recording/cancel cycles all displayed the layer surface successfully. Logs confirmed microphone samples and successful model loading. Test recordings were canceled rather than inserted into another application.
- Inspected the 0.9.6 AppImage's generated GTK hook: it unconditionally exports GDK_BACKEND=x11. The README explicitly warns that an external environment override alone does not fix that AppImage.
- npx --yes prettier@3.6.2 --check README.md: passed.
- git diff --check: passed before commit.
- bun run lint and bun run format:check could not run because Bun is not installed. No application code changed.
- Not tested on other compositors, X11 sessions, or other Linux packages.

## Screenshots/Videos (if applicable)

Before/after desktop captures were inspected locally. They are not attached because they contain unrelated private desktop content.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex.
- How extensively: Codex investigated the local window geometry and GTK backend, applied and tested the local launcher workaround, wrote the README guidance and technical PR sections, and committed the change. The Human Written Description above was supplied verbatim by the contributor. A human keyboard/microphone workflow test after this backend change remains welcome.
