### PR TITLE
fix: clear stale macOS accessibility permissions during onboarding

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -194,3 +194,18 @@ pub fn initialize_shortcuts(app: AppHandle) -> Result<(), String> {
     log::info!("Shortcuts initialized successfully");
     Ok(())
 }
+
+// Reset macOS Accessibility permissions for Handy using tccutil.
+// Clears stale code signature requirements left by prior installs.
+#[specta::specta]
+#[tauri::command]
+pub fn reset_accessibility_permission() -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        use std::process::Command;
+        let _ = Command::new("tccutil")
+            .args(["reset", "Accessibility", "com.pais.handy"])
+            .output();
+    }
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -725,6 +725,7 @@ pub fn run(cli_args: CliArgs) {
             commands::check_apple_intelligence_available,
             commands::initialize_enigo,
             commands::initialize_shortcuts,
+            commands::reset_accessibility_permission,
             commands::models::get_available_models,
             commands::models::get_model_info,
             commands::models::download_model,

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -632,6 +632,14 @@ async initializeShortcuts() : Promise<Result<null, string>> {
     else return { status: "error", error: e  as any };
 }
 },
+async resetAccessibilityPermission() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("reset_accessibility_permission") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async getAvailableModels() : Promise<Result<ModelInfo[], string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_available_models") };

--- a/src/components/onboarding/AccessibilityOnboarding.tsx
+++ b/src/components/onboarding/AccessibilityOnboarding.tsx
@@ -263,6 +263,9 @@ const AccessibilityOnboarding: React.FC<AccessibilityOnboardingProps> = ({
     if (preview) return;
 
     try {
+      if (isMacOS) {
+        await commands.resetAccessibilityPermission();
+      }
       await requestAccessibilityPermission();
       setPermissions((prev) => ({ ...prev, accessibility: "waiting" }));
       startPolling();


### PR DESCRIPTION
## Before Submitting This PR
- [x] I have searched [existing issues](https://github.com/cjpais/Handy/issues) and [pull requests](https://github.com/cjpais/Handy/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/cjpais/Handy/blob/main/CONTRIBUTING.md)

## Human Written Description
Faced the same mentioned issue. What happens is that macOS stores permission grants in its TCC db using app's id  and hash. When a new build is installed, the hash changes. Because macOS sees an existing entry for the id with a mismatched hash, it rejects the permission  and suppresses the prompt, leaving the app stuck on **Waiting**.
So resetting that with `tccutils`(built in) before asking the permission fixes that .  

Under the hood, it runs ` tccutil reset Accessibility com.pais.handy` before asking for **Accessibility** permission.


## Related Issues/Discussions
Fixes #1234  & #1618  (same issue)

## Community Feedback
The issue is confirmed by others.


## Testing
**System:** Apple M4 (macOS Sequoia 15.7.7)

1. **Reproduction:** Reproduced the problem by first removing the official build. Then built and installed from the source.

2. **Verification:**
   - Tested onboarding with the fix in place. Clicking **"Grant Permission"** resets the Accessibility TCC entry using `tccutil reset Accessibility com.pais.handy` before requesting permission.
   - Verified that macOS displays the permission dialog and registers the active binary without getting stuck on **"Waiting…"**.
   - After granting permission in System Settings, Handy transitions to **"Granted"** and proceeds to the next step.

## Screenshots/Videos (if applicable)
Heres a video of the Issue.  
https://github.com/user-attachments/assets/e0de138f-f657-418c-a2a0-bebeae4a4807
Now it clears the permission entry first 
https://github.com/user-attachments/assets/98120b6a-5221-45d4-80b2-a01d25d1cab7


## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Antigravity
- How extensively: Finding the cause of the issue
